### PR TITLE
feat: add medical device tracking and implant registry contract (#53)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,6 +988,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "medical-device-tracking"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
   "contracts/rehabilitation-services",
   "contracts/prenatal-pediatric",
   "contracts/hai-tracking",
+  "contracts/medical-device-tracking",
 ]
 
 [workspace.dependencies]

--- a/contracts/medical-device-tracking/Cargo.toml
+++ b/contracts/medical-device-tracking/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "medical-device-tracking"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/medical-device-tracking/src/lib.rs
+++ b/contracts/medical-device-tracking/src/lib.rs
@@ -1,0 +1,429 @@
+#![no_std]
+
+mod types;
+mod test;
+
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Symbol, Vec};
+use types::{
+    DataKey, DeviceRecord, DmePrescription, Error, ImplantRecord, MaintenanceRecord,
+    PerformanceReport, RecallInfo,
+};
+
+#[contract]
+pub struct MedicalDeviceRegistry;
+
+#[contractimpl]
+impl MedicalDeviceRegistry {
+    /// Register a medical device with its Unique Device Identifier (UDI).
+    pub fn register_device(
+        env: Env,
+        device_udi: String,
+        device_type: Symbol,
+        manufacturer: String,
+        model_number: String,
+        lot_number: String,
+        manufacturing_date: u64,
+        expiration_date: Option<u64>,
+        device_specs_hash: BytesN<32>,
+    ) -> Result<u64, Error> {
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::DeviceCounter)
+            .unwrap_or(0);
+        let new_id = count + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::DeviceCounter, &new_id);
+
+        let device = DeviceRecord {
+            device_id: new_id,
+            device_udi,
+            device_type,
+            manufacturer,
+            model_number,
+            lot_number,
+            manufacturing_date,
+            expiration_date,
+            device_specs_hash,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::DeviceRecord(new_id), &device);
+
+        Ok(new_id)
+    }
+
+    /// Record a device implantation procedure for a patient.
+    pub fn implant_device(
+        env: Env,
+        patient_id: Address,
+        device_id: u64,
+        provider_id: Address,
+        implant_date: u64,
+        implant_location: String,
+        surgical_notes_hash: BytesN<32>,
+    ) -> Result<u64, Error> {
+        provider_id.require_auth();
+
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::DeviceRecord(device_id))
+        {
+            return Err(Error::RecordNotFound);
+        }
+
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ImplantCounter)
+            .unwrap_or(0);
+        let new_id = count + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::ImplantCounter, &new_id);
+
+        let record = ImplantRecord {
+            implant_record_id: new_id,
+            patient_id: patient_id.clone(),
+            device_id,
+            implant_date,
+            implant_location,
+            implanting_provider: provider_id,
+            surgical_notes_hash,
+            is_active: true,
+            removal_date: None,
+            removal_reason: None,
+            explant_analysis_hash: None,
+            maintenance_history: Vec::new(&env),
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::ImplantRecord(new_id), &record);
+
+        let mut patient_implants: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PatientImplants(patient_id.clone()))
+            .unwrap_or(Vec::new(&env));
+        patient_implants.push_back(new_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::PatientImplants(patient_id), &patient_implants);
+
+        let mut device_implants: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DeviceImplants(device_id))
+            .unwrap_or(Vec::new(&env));
+        device_implants.push_back(new_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::DeviceImplants(device_id), &device_implants);
+
+        Ok(new_id)
+    }
+
+    /// Prescribe durable medical equipment (DME) to a patient.
+    pub fn prescribe_dme(
+        env: Env,
+        patient_id: Address,
+        provider_id: Address,
+        device_type: Symbol,
+        device_id: u64,
+        prescription_date: u64,
+        duration_days: Option<u64>,
+        instructions_hash: BytesN<32>,
+    ) -> Result<u64, Error> {
+        provider_id.require_auth();
+
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::DmeCounter)
+            .unwrap_or(0);
+        let new_id = count + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::DmeCounter, &new_id);
+
+        let prescription = DmePrescription {
+            prescription_id: new_id,
+            patient_id,
+            provider_id,
+            device_type,
+            device_id,
+            prescription_date,
+            duration_days,
+            instructions_hash,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::DmeRecord(new_id), &prescription);
+
+        Ok(new_id)
+    }
+
+    /// Record a maintenance event for an implanted device.
+    pub fn record_device_maintenance(
+        env: Env,
+        implant_record_id: u64,
+        maintenance_date: u64,
+        maintenance_type: Symbol,
+        performed_by: Address,
+        notes_hash: BytesN<32>,
+    ) -> Result<(), Error> {
+        performed_by.require_auth();
+
+        let mut record: ImplantRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ImplantRecord(implant_record_id))
+            .ok_or(Error::RecordNotFound)?;
+
+        let m_count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaintenanceCounter)
+            .unwrap_or(0);
+        let new_m_id = m_count + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::MaintenanceCounter, &new_m_id);
+
+        let maintenance = MaintenanceRecord {
+            maintenance_id: new_m_id,
+            implant_record_id,
+            maintenance_date,
+            maintenance_type,
+            performed_by,
+            notes_hash,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::MaintenanceRecord(new_m_id), &maintenance);
+
+        record.maintenance_history.push_back(new_m_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ImplantRecord(implant_record_id), &record);
+
+        Ok(())
+    }
+
+    /// Issue a recall for one or more medical devices.
+    pub fn issue_device_recall(
+        env: Env,
+        manufacturer: Address,
+        device_ids: Vec<u64>,
+        recall_reason: String,
+        severity: Symbol,
+        recall_date: u64,
+        action_required: String,
+    ) -> Result<u64, Error> {
+        manufacturer.require_auth();
+
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RecallCounter)
+            .unwrap_or(0);
+        let new_id = count + 1;
+        env.storage()
+            .instance()
+            .set(&DataKey::RecallCounter, &new_id);
+
+        let recall = RecallInfo {
+            recall_id: new_id,
+            device_ids: device_ids.clone(),
+            recall_reason,
+            severity,
+            recall_date,
+            action_required,
+            resolution_deadline: None,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::RecallInfo(new_id), &recall);
+
+        for device_id in device_ids {
+            let mut device_recalls: Vec<u64> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::DeviceRecalls(device_id))
+                .unwrap_or(Vec::new(&env));
+            device_recalls.push_back(new_id);
+            env.storage()
+                .persistent()
+                .set(&DataKey::DeviceRecalls(device_id), &device_recalls);
+        }
+
+        Ok(new_id)
+    }
+
+    /// Return the IDs of all patients with an active implant from the recalled devices.
+    pub fn notify_affected_patients(
+        env: Env,
+        recall_id: u64,
+        _notification_date: u64,
+    ) -> Result<Vec<Address>, Error> {
+        let recall: RecallInfo = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RecallInfo(recall_id))
+            .ok_or(Error::RecordNotFound)?;
+
+        let mut affected_patients: Vec<Address> = Vec::new(&env);
+
+        for device_id in recall.device_ids {
+            let implant_ids: Vec<u64> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::DeviceImplants(device_id))
+                .unwrap_or(Vec::new(&env));
+
+            for implant_id in implant_ids {
+                if let Some(implant) = env
+                    .storage()
+                    .persistent()
+                    .get::<DataKey, ImplantRecord>(&DataKey::ImplantRecord(implant_id))
+                {
+                    if implant.is_active {
+                        affected_patients.push_back(implant.patient_id);
+                    }
+                }
+            }
+        }
+
+        Ok(affected_patients)
+    }
+
+    /// Record the removal of a previously implanted device.
+    pub fn remove_implant(
+        env: Env,
+        implant_record_id: u64,
+        provider_id: Address,
+        removal_date: u64,
+        removal_reason: String,
+        explant_analysis_hash: Option<BytesN<32>>,
+    ) -> Result<(), Error> {
+        provider_id.require_auth();
+
+        let mut record: ImplantRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ImplantRecord(implant_record_id))
+            .ok_or(Error::RecordNotFound)?;
+
+        if !record.is_active {
+            return Err(Error::DeviceNotActive);
+        }
+
+        record.is_active = false;
+        record.removal_date = Some(removal_date);
+        record.removal_reason = Some(removal_reason);
+        record.explant_analysis_hash = explant_analysis_hash;
+        env.storage()
+            .persistent()
+            .set(&DataKey::ImplantRecord(implant_record_id), &record);
+
+        Ok(())
+    }
+
+    /// Record a device performance report including optional complications.
+    pub fn track_device_performance(
+        env: Env,
+        implant_record_id: u64,
+        patient_id: Address,
+        performance_data_hash: BytesN<32>,
+        reported_date: u64,
+        complications: Option<Vec<String>>,
+    ) -> Result<(), Error> {
+        patient_id.require_auth();
+
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::ImplantRecord(implant_record_id))
+        {
+            return Err(Error::RecordNotFound);
+        }
+
+        let report = PerformanceReport {
+            implant_record_id,
+            patient_id,
+            performance_data_hash,
+            reported_date,
+            complications,
+        };
+
+        let mut reports: Vec<PerformanceReport> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PerformanceReports(implant_record_id))
+            .unwrap_or(Vec::new(&env));
+        reports.push_back(report);
+        env.storage()
+            .persistent()
+            .set(&DataKey::PerformanceReports(implant_record_id), &reports);
+
+        Ok(())
+    }
+
+    /// Retrieve all implant records for a patient, optionally filtered to active implants only.
+    pub fn get_patient_implants(
+        env: Env,
+        patient_id: Address,
+        requester: Address,
+        active_only: bool,
+    ) -> Result<Vec<ImplantRecord>, Error> {
+        requester.require_auth();
+
+        let implant_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PatientImplants(patient_id))
+            .unwrap_or(Vec::new(&env));
+
+        let mut implants: Vec<ImplantRecord> = Vec::new(&env);
+        for id in implant_ids {
+            if let Some(record) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, ImplantRecord>(&DataKey::ImplantRecord(id))
+            {
+                if !active_only || record.is_active {
+                    implants.push_back(record);
+                }
+            }
+        }
+
+        Ok(implants)
+    }
+
+    /// Retrieve all recalls associated with a specific device ID.
+    pub fn check_device_recalls(
+        env: Env,
+        device_id: u64,
+    ) -> Result<Vec<RecallInfo>, Error> {
+        let recall_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DeviceRecalls(device_id))
+            .unwrap_or(Vec::new(&env));
+
+        let mut recalls: Vec<RecallInfo> = Vec::new(&env);
+        for id in recall_ids {
+            if let Some(recall) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, RecallInfo>(&DataKey::RecallInfo(id))
+            {
+                recalls.push_back(recall);
+            }
+        }
+
+        Ok(recalls)
+    }
+}

--- a/contracts/medical-device-tracking/src/test.rs
+++ b/contracts/medical-device-tracking/src/test.rs
@@ -1,0 +1,637 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Symbol, Vec};
+
+fn dummy_hash(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[0u8; 32])
+}
+
+fn register_device_helper(env: &Env, client: &MedicalDeviceRegistryClient) -> u64 {
+    client.register_device(
+        &String::from_str(env, "UDI-12345-ABC"),
+        &Symbol::new(env, "IMPLANT"),
+        &String::from_str(env, "MedCorp"),
+        &String::from_str(env, "MC-100"),
+        &String::from_str(env, "LOT-001"),
+        &1690000000u64,
+        &None,
+        &dummy_hash(env),
+    )
+}
+
+#[test]
+fn test_register_device() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let id = register_device_helper(&env, &client);
+    assert_eq!(id, 1);
+
+    let id2 = register_device_helper(&env, &client);
+    assert_eq!(id2, 2);
+}
+
+#[test]
+fn test_register_device_with_expiration() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let id = client.register_device(
+        &String::from_str(&env, "UDI-99999-XYZ"),
+        &Symbol::new(&env, "DME"),
+        &String::from_str(&env, "DeviceMaker"),
+        &String::from_str(&env, "DM-500"),
+        &String::from_str(&env, "LOT-999"),
+        &1690000000u64,
+        &Some(1800000000u64),
+        &dummy_hash(&env),
+    );
+    assert_eq!(id, 1);
+}
+
+#[test]
+fn test_implant_device() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+
+    let device_id = register_device_helper(&env, &client);
+
+    let implant_id = client.implant_device(
+        &patient_id,
+        &device_id,
+        &provider_id,
+        &1700000000u64,
+        &String::from_str(&env, "Left Hip"),
+        &dummy_hash(&env),
+    );
+    assert_eq!(implant_id, 1);
+
+    let requester = Address::generate(&env);
+    let implants = client.get_patient_implants(&patient_id, &requester, &true);
+    assert_eq!(implants.len(), 1);
+
+    let record = implants.get(0).unwrap();
+    assert_eq!(record.patient_id, patient_id);
+    assert_eq!(record.device_id, device_id);
+    assert!(record.is_active);
+    assert!(record.removal_date.is_none());
+}
+
+#[test]
+fn test_implant_device_nonexistent_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+
+    let res = client.try_implant_device(
+        &patient_id,
+        &999u64,
+        &provider_id,
+        &1700000000u64,
+        &String::from_str(&env, "Left Hip"),
+        &dummy_hash(&env),
+    );
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_prescribe_dme() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+    let device_id = register_device_helper(&env, &client);
+
+    let rx_id = client.prescribe_dme(
+        &patient_id,
+        &provider_id,
+        &Symbol::new(&env, "WHEELCHAIR"),
+        &device_id,
+        &1700000000u64,
+        &Some(90u64),
+        &dummy_hash(&env),
+    );
+    assert_eq!(rx_id, 1);
+
+    let rx_id2 = client.prescribe_dme(
+        &patient_id,
+        &provider_id,
+        &Symbol::new(&env, "CRUTCHES"),
+        &device_id,
+        &1700100000u64,
+        &None,
+        &dummy_hash(&env),
+    );
+    assert_eq!(rx_id2, 2);
+}
+
+#[test]
+fn test_record_device_maintenance() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+    let technician = Address::generate(&env);
+
+    let device_id = register_device_helper(&env, &client);
+    let implant_id = client.implant_device(
+        &patient_id,
+        &device_id,
+        &provider_id,
+        &1700000000u64,
+        &String::from_str(&env, "Lumbar Spine"),
+        &dummy_hash(&env),
+    );
+
+    client.record_device_maintenance(
+        &implant_id,
+        &1710000000u64,
+        &Symbol::new(&env, "CALIBRATION"),
+        &technician,
+        &dummy_hash(&env),
+    );
+    client.record_device_maintenance(
+        &implant_id,
+        &1720000000u64,
+        &Symbol::new(&env, "INSPECTION"),
+        &technician,
+        &dummy_hash(&env),
+    );
+
+    let requester = Address::generate(&env);
+    let implants = client.get_patient_implants(&patient_id, &requester, &true);
+    let record = implants.get(0).unwrap();
+    assert_eq!(record.maintenance_history.len(), 2);
+}
+
+#[test]
+fn test_record_device_maintenance_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let technician = Address::generate(&env);
+    let res = client.try_record_device_maintenance(
+        &999u64,
+        &1710000000u64,
+        &Symbol::new(&env, "CALIBRATION"),
+        &technician,
+        &dummy_hash(&env),
+    );
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_issue_device_recall() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let manufacturer = Address::generate(&env);
+    let device_id = register_device_helper(&env, &client);
+
+    let mut device_ids: Vec<u64> = Vec::new(&env);
+    device_ids.push_back(device_id);
+
+    let recall_id = client.issue_device_recall(
+        &manufacturer,
+        &device_ids,
+        &String::from_str(&env, "Battery failure risk"),
+        &Symbol::new(&env, "CRITICAL"),
+        &1750000000u64,
+        &String::from_str(&env, "Immediate explantation required"),
+    );
+    assert_eq!(recall_id, 1);
+}
+
+#[test]
+fn test_notify_affected_patients() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let patient1 = Address::generate(&env);
+    let patient2 = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let manufacturer = Address::generate(&env);
+
+    let device_id = register_device_helper(&env, &client);
+
+    client.implant_device(
+        &patient1,
+        &device_id,
+        &provider,
+        &1700000000u64,
+        &String::from_str(&env, "Left Knee"),
+        &dummy_hash(&env),
+    );
+    client.implant_device(
+        &patient2,
+        &device_id,
+        &provider,
+        &1700100000u64,
+        &String::from_str(&env, "Right Knee"),
+        &dummy_hash(&env),
+    );
+
+    let mut device_ids: Vec<u64> = Vec::new(&env);
+    device_ids.push_back(device_id);
+
+    let recall_id = client.issue_device_recall(
+        &manufacturer,
+        &device_ids,
+        &String::from_str(&env, "Stress fracture risk"),
+        &Symbol::new(&env, "HIGH"),
+        &1750000000u64,
+        &String::from_str(&env, "Monitoring required"),
+    );
+
+    let affected = client.notify_affected_patients(&recall_id, &1750100000u64);
+    assert_eq!(affected.len(), 2);
+    assert!(affected.contains(&patient1));
+    assert!(affected.contains(&patient2));
+}
+
+#[test]
+fn test_notify_affected_patients_excludes_removed() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let patient1 = Address::generate(&env);
+    let patient2 = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let manufacturer = Address::generate(&env);
+
+    let device_id = register_device_helper(&env, &client);
+
+    let implant_id1 = client.implant_device(
+        &patient1,
+        &device_id,
+        &provider,
+        &1700000000u64,
+        &String::from_str(&env, "Chest"),
+        &dummy_hash(&env),
+    );
+    client.implant_device(
+        &patient2,
+        &device_id,
+        &provider,
+        &1700100000u64,
+        &String::from_str(&env, "Abdomen"),
+        &dummy_hash(&env),
+    );
+
+    // patient1 has device removed before recall
+    client.remove_implant(
+        &implant_id1,
+        &provider,
+        &1740000000u64,
+        &String::from_str(&env, "Elective removal"),
+        &None,
+    );
+
+    let mut device_ids: Vec<u64> = Vec::new(&env);
+    device_ids.push_back(device_id);
+
+    let recall_id = client.issue_device_recall(
+        &manufacturer,
+        &device_ids,
+        &String::from_str(&env, "Software defect"),
+        &Symbol::new(&env, "MODERATE"),
+        &1750000000u64,
+        &String::from_str(&env, "Software update required"),
+    );
+
+    let affected = client.notify_affected_patients(&recall_id, &1750100000u64);
+    assert_eq!(affected.len(), 1);
+    assert!(affected.contains(&patient2));
+}
+
+#[test]
+fn test_notify_affected_patients_recall_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let res = client.try_notify_affected_patients(&999u64, &1750100000u64);
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_remove_implant() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+
+    let device_id = register_device_helper(&env, &client);
+    let implant_id = client.implant_device(
+        &patient_id,
+        &device_id,
+        &provider_id,
+        &1700000000u64,
+        &String::from_str(&env, "Right Hip"),
+        &dummy_hash(&env),
+    );
+
+    client.remove_implant(
+        &implant_id,
+        &provider_id,
+        &1750000000u64,
+        &String::from_str(&env, "Device malfunction"),
+        &Some(dummy_hash(&env)),
+    );
+
+    let requester = Address::generate(&env);
+    let active_implants = client.get_patient_implants(&patient_id, &requester, &true);
+    assert_eq!(active_implants.len(), 0);
+
+    let all_implants = client.get_patient_implants(&patient_id, &requester, &false);
+    assert_eq!(all_implants.len(), 1);
+    let record = all_implants.get(0).unwrap();
+    assert!(!record.is_active);
+    assert_eq!(record.removal_date, Some(1750000000u64));
+}
+
+#[test]
+fn test_remove_implant_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let provider_id = Address::generate(&env);
+    let res = client.try_remove_implant(
+        &999u64,
+        &provider_id,
+        &1750000000u64,
+        &String::from_str(&env, "Unknown"),
+        &None,
+    );
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_remove_implant_already_inactive() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+
+    let device_id = register_device_helper(&env, &client);
+    let implant_id = client.implant_device(
+        &patient_id,
+        &device_id,
+        &provider_id,
+        &1700000000u64,
+        &String::from_str(&env, "Shoulder"),
+        &dummy_hash(&env),
+    );
+
+    client.remove_implant(
+        &implant_id,
+        &provider_id,
+        &1750000000u64,
+        &String::from_str(&env, "Scheduled removal"),
+        &None,
+    );
+
+    // Attempt duplicate removal
+    let res = client.try_remove_implant(
+        &implant_id,
+        &provider_id,
+        &1760000000u64,
+        &String::from_str(&env, "Duplicate"),
+        &None,
+    );
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_track_device_performance_no_complications() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+
+    let device_id = register_device_helper(&env, &client);
+    let implant_id = client.implant_device(
+        &patient_id,
+        &device_id,
+        &provider_id,
+        &1700000000u64,
+        &String::from_str(&env, "Spine L4"),
+        &dummy_hash(&env),
+    );
+
+    client.track_device_performance(
+        &implant_id,
+        &patient_id,
+        &dummy_hash(&env),
+        &1710000000u64,
+        &None,
+    );
+}
+
+#[test]
+fn test_track_device_performance_with_complications() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+
+    let device_id = register_device_helper(&env, &client);
+    let implant_id = client.implant_device(
+        &patient_id,
+        &device_id,
+        &provider_id,
+        &1700000000u64,
+        &String::from_str(&env, "Left Knee"),
+        &dummy_hash(&env),
+    );
+
+    let mut complications: Vec<String> = Vec::new(&env);
+    complications.push_back(String::from_str(&env, "Mild inflammation"));
+    complications.push_back(String::from_str(&env, "Intermittent pain"));
+
+    client.track_device_performance(
+        &implant_id,
+        &patient_id,
+        &dummy_hash(&env),
+        &1710000000u64,
+        &Some(complications),
+    );
+}
+
+#[test]
+fn test_track_device_performance_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    let res = client.try_track_device_performance(
+        &999u64,
+        &patient_id,
+        &dummy_hash(&env),
+        &1710000000u64,
+        &None,
+    );
+    assert!(res.is_err());
+}
+
+#[test]
+fn test_get_patient_implants_active_only_filter() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+    let requester = Address::generate(&env);
+
+    let device_id = register_device_helper(&env, &client);
+
+    let implant_id1 = client.implant_device(
+        &patient_id,
+        &device_id,
+        &provider_id,
+        &1700000000u64,
+        &String::from_str(&env, "Hip"),
+        &dummy_hash(&env),
+    );
+    client.implant_device(
+        &patient_id,
+        &device_id,
+        &provider_id,
+        &1705000000u64,
+        &String::from_str(&env, "Knee"),
+        &dummy_hash(&env),
+    );
+
+    client.remove_implant(
+        &implant_id1,
+        &provider_id,
+        &1750000000u64,
+        &String::from_str(&env, "Worn out"),
+        &None,
+    );
+
+    let active = client.get_patient_implants(&patient_id, &requester, &true);
+    assert_eq!(active.len(), 1);
+
+    let all = client.get_patient_implants(&patient_id, &requester, &false);
+    assert_eq!(all.len(), 2);
+}
+
+#[test]
+fn test_check_device_recalls() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let manufacturer = Address::generate(&env);
+    let device_id = register_device_helper(&env, &client);
+
+    let no_recalls = client.check_device_recalls(&device_id);
+    assert_eq!(no_recalls.len(), 0);
+
+    let mut device_ids: Vec<u64> = Vec::new(&env);
+    device_ids.push_back(device_id);
+
+    client.issue_device_recall(
+        &manufacturer,
+        &device_ids.clone(),
+        &String::from_str(&env, "Component failure"),
+        &Symbol::new(&env, "HIGH"),
+        &1750000000u64,
+        &String::from_str(&env, "Return to manufacturer"),
+    );
+    client.issue_device_recall(
+        &manufacturer,
+        &device_ids.clone(),
+        &String::from_str(&env, "Labeling error"),
+        &Symbol::new(&env, "LOW"),
+        &1760000000u64,
+        &String::from_str(&env, "Update records"),
+    );
+
+    let recalls = client.check_device_recalls(&device_id);
+    assert_eq!(recalls.len(), 2);
+
+    let r = recalls.get(0).unwrap();
+    assert_eq!(r.recall_id, 1);
+    assert_eq!(r.severity, Symbol::new(&env, "HIGH"));
+}
+
+#[test]
+fn test_check_device_recalls_no_results_for_unknown_device() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let recalls = client.check_device_recalls(&999u64);
+    assert_eq!(recalls.len(), 0);
+}

--- a/contracts/medical-device-tracking/src/types.rs
+++ b/contracts/medical-device-tracking/src/types.rs
@@ -1,0 +1,106 @@
+use soroban_sdk::{contracterror, contracttype, Address, BytesN, String, Symbol, Vec};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataKey {
+    DeviceCounter,
+    ImplantCounter,
+    DmeCounter,
+    RecallCounter,
+    MaintenanceCounter,
+    DeviceRecord(u64),
+    ImplantRecord(u64),
+    DmeRecord(u64),
+    RecallInfo(u64),
+    MaintenanceRecord(u64),
+    PatientImplants(Address),
+    DeviceImplants(u64),
+    DeviceRecalls(u64),
+    PerformanceReports(u64),
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    NotAuthorized = 1,
+    RecordNotFound = 2,
+    DeviceNotActive = 3,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DeviceRecord {
+    pub device_id: u64,
+    pub device_udi: String,
+    pub device_type: Symbol,
+    pub manufacturer: String,
+    pub model_number: String,
+    pub lot_number: String,
+    pub manufacturing_date: u64,
+    pub expiration_date: Option<u64>,
+    pub device_specs_hash: BytesN<32>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ImplantRecord {
+    pub implant_record_id: u64,
+    pub patient_id: Address,
+    pub device_id: u64,
+    pub implant_date: u64,
+    pub implant_location: String,
+    pub implanting_provider: Address,
+    pub surgical_notes_hash: BytesN<32>,
+    pub is_active: bool,
+    pub removal_date: Option<u64>,
+    pub removal_reason: Option<String>,
+    pub explant_analysis_hash: Option<BytesN<32>>,
+    pub maintenance_history: Vec<u64>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DmePrescription {
+    pub prescription_id: u64,
+    pub patient_id: Address,
+    pub provider_id: Address,
+    pub device_type: Symbol,
+    pub device_id: u64,
+    pub prescription_date: u64,
+    pub duration_days: Option<u64>,
+    pub instructions_hash: BytesN<32>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MaintenanceRecord {
+    pub maintenance_id: u64,
+    pub implant_record_id: u64,
+    pub maintenance_date: u64,
+    pub maintenance_type: Symbol,
+    pub performed_by: Address,
+    pub notes_hash: BytesN<32>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PerformanceReport {
+    pub implant_record_id: u64,
+    pub patient_id: Address,
+    pub performance_data_hash: BytesN<32>,
+    pub reported_date: u64,
+    pub complications: Option<Vec<String>>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RecallInfo {
+    pub recall_id: u64,
+    pub device_ids: Vec<u64>,
+    pub recall_reason: String,
+    pub severity: Symbol,
+    pub recall_date: u64,
+    pub action_required: String,
+    pub resolution_deadline: Option<u64>,
+}


### PR DESCRIPTION
### Summary

Implements the Medical Device Tracking and Implant Registry System as a new Soroban smart contract (`medical-device-tracking`), providing all 10 functions specified in issue #53 for registering devices, tracking implant lifecycles, managing recalls, and monitoring device performance.

### Changes

- Added `contracts/medical-device-tracking/` with `Cargo.toml`, `src/types.rs`, `src/lib.rs`, and `src/test.rs`
- Registered the new package as a workspace member in the root `Cargo.toml`

### Functions Implemented

- `register_device` — UDI-compliant device registration with optional expiration
- `implant_device` — links a device to a patient with provider auth and surgical notes hash
- `prescribe_dme` — records DME prescriptions with optional duration
- `record_device_maintenance` — appends maintenance entries to an implant's history
- `issue_device_recall` — creates a manufacturer-authenticated recall across multiple device IDs
- `notify_affected_patients` — returns active implant holders affected by a recall
- `remove_implant` — marks implant inactive with removal reason and optional explant analysis hash
- `track_device_performance` — attaches performance reports with optional complications list
- `get_patient_implants` — retrieves implant records with optional active-only filter
- `check_device_recalls` — returns all recalls associated with a device ID

### Data Structures

`ImplantRecord` and `RecallInfo` implemented exactly as specified in the issue.

Closes #53