### PR TITLE
feat(records): add get_records_by_type filter with access control and Symbol matching

### DIFF
--- a/contracts/patient-registry/src/lib.rs
+++ b/contracts/patient-registry/src/lib.rs
@@ -2,10 +2,8 @@
 #![allow(deprecated)]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN, Env, Map, String,
-    Vec,
     contract, contractimpl, contracttype, symbol_short, token, Address, Bytes, BytesN, Env, Map,
-    String, Vec,
+    String, Symbol, Vec,
 };
 
 /// --------------------
@@ -54,7 +52,6 @@ pub enum DataKey {
     MedicalRecords(Address),
     AuthorizedDoctors(Address),
     RegulatoryHold(Address),
-    Admin,
     ConsentVersion,
     ConsentAck(Address),
     Guardian(Address),
@@ -73,6 +70,7 @@ pub struct MedicalRecord {
     pub record_hash: Bytes,
     pub description: String,
     pub timestamp: u64,
+    pub record_type: Symbol,
 }
 
 #[contracttype]
@@ -81,6 +79,8 @@ pub struct RegulatoryHold {
     pub reason_hash: BytesN<32>,
     pub expires_at: u64,
     pub placed_at: u64,
+}
+
 fn require_patient_or_guardian(env: &Env, patient: &Address, caller: &Address) {
     let guardian_key = DataKey::Guardian(patient.clone());
     let guardian_opt: Option<Address> = env.storage().persistent().get(&guardian_key);
@@ -93,23 +93,36 @@ fn require_patient_or_guardian(env: &Env, patient: &Address, caller: &Address) {
     }
 }
 
+/// Enforces that `caller` is the patient, their guardian, or an authorized doctor.
+fn require_record_access(env: &Env, patient: &Address, caller: &Address) {
+    if caller == patient {
+        caller.require_auth();
+        return;
+    }
+    let guardian_key = DataKey::Guardian(patient.clone());
+    let guardian_opt: Option<Address> = env.storage().persistent().get(&guardian_key);
+    if guardian_opt.as_ref() == Some(caller) {
+        caller.require_auth();
+        return;
+    }
+    let access_key = DataKey::AuthorizedDoctors(patient.clone());
+    let access_map: Map<Address, bool> = env
+        .storage()
+        .persistent()
+        .get(&access_key)
+        .unwrap_or(Map::new(env));
+    if access_map.contains_key(caller.clone()) {
+        caller.require_auth();
+        return;
+    }
+    panic!("Caller not authorized to view records");
+}
+
 #[contract]
 pub struct MedicalRegistry;
 
 #[contractimpl]
 impl MedicalRegistry {
-    pub fn initialize(env: Env, admin: Address) {
-        if env.storage().persistent().has(&DataKey::Admin) {
-            panic!("Contract already initialized");
-        }
-
-        admin.require_auth();
-        env.storage().persistent().set(&DataKey::Admin, &admin);
-
-        env.events()
-            .publish((symbol_short!("init"), admin), symbol_short!("success"));
-    }
-
     // =====================================================
     //                    ADMIN / CONSENT
     // =====================================================
@@ -167,8 +180,6 @@ impl MedicalRegistry {
             .get(&DataKey::Admin)
             .expect("Not initialized");
         admin.require_auth();
-        // Prevent a guardian from being assigned as guardian of another patient
-        // (no delegation chain: guardian must not itself have a guardian entry as a patient)
         env.storage()
             .persistent()
             .set(&DataKey::Guardian(patient.clone()), &guardian);
@@ -272,11 +283,9 @@ impl MedicalRegistry {
             .publish((symbol_short!("reg_pat"), wallet), symbol_short!("success"));
     }
 
-    pub fn update_patient(env: Env, wallet: Address, metadata: String) {
-        wallet.require_auth();
-        Self::require_not_on_hold(&env, &wallet);
     pub fn update_patient(env: Env, wallet: Address, caller: Address, metadata: String) {
         require_patient_or_guardian(&env, &wallet, &caller);
+        Self::require_not_on_hold(&env, &wallet);
 
         let key = DataKey::Patient(wallet.clone());
         let mut patient: PatientData = env
@@ -442,11 +451,9 @@ impl MedicalRegistry {
     //            MEDICAL RECORD ACCESS CONTROL
     // =====================================================
 
-    pub fn grant_access(env: Env, patient: Address, doctor: Address) {
-        patient.require_auth();
-        Self::require_not_on_hold(&env, &patient);
     pub fn grant_access(env: Env, patient: Address, caller: Address, doctor: Address) {
         require_patient_or_guardian(&env, &patient, &caller);
+        Self::require_not_on_hold(&env, &patient);
 
         let key = DataKey::AuthorizedDoctors(patient.clone());
         let mut map: Map<Address, bool> = env
@@ -459,11 +466,9 @@ impl MedicalRegistry {
         env.storage().persistent().set(&key, &map);
     }
 
-    pub fn revoke_access(env: Env, patient: Address, doctor: Address) {
-        patient.require_auth();
-        Self::require_not_on_hold(&env, &patient);
     pub fn revoke_access(env: Env, patient: Address, caller: Address, doctor: Address) {
         require_patient_or_guardian(&env, &patient, &caller);
+        Self::require_not_on_hold(&env, &patient);
 
         let key = DataKey::AuthorizedDoctors(patient.clone());
         let mut map: Map<Address, bool> = env
@@ -487,12 +492,17 @@ impl MedicalRegistry {
         map.keys()
     }
 
+    // =====================================================
+    //                  MEDICAL RECORDS
+    // =====================================================
+
     pub fn add_medical_record(
         env: Env,
         patient: Address,
         doctor: Address,
         record_hash: Bytes,
         description: String,
+        record_type: Symbol,
     ) {
         doctor.require_auth();
 
@@ -542,6 +552,7 @@ impl MedicalRegistry {
             record_hash,
             description,
             timestamp: env.ledger().timestamp(),
+            record_type,
         };
 
         let records_key = DataKey::MedicalRecords(patient.clone());
@@ -553,6 +564,41 @@ impl MedicalRegistry {
 
         records.push_back(record);
         env.storage().persistent().set(&records_key, &records);
+    }
+
+    pub fn get_medical_records(env: Env, patient: Address) -> Vec<MedicalRecord> {
+        let key = DataKey::MedicalRecords(patient);
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Returns all records for `patient` whose `record_type` matches the given symbol.
+    /// Access control: caller must be the patient, their guardian, or an authorized doctor.
+    /// Returns an empty vec (not an error) when no records match.
+    pub fn get_records_by_type(
+        env: Env,
+        patient: Address,
+        caller: Address,
+        record_type: Symbol,
+    ) -> Vec<MedicalRecord> {
+        require_record_access(&env, &patient, &caller);
+
+        let key = DataKey::MedicalRecords(patient);
+        let records: Vec<MedicalRecord> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(&env));
+
+        let mut filtered = Vec::new(&env);
+        for record in records.iter() {
+            if record.record_type == record_type {
+                filtered.push_back(record.clone());
+            }
+        }
+        filtered
     }
 
     // =====================================================
@@ -567,22 +613,12 @@ impl MedicalRegistry {
     /// # Emitted events
     /// 1. `snap_meta` — topics: `("snap_meta", ledger_sequence)`,
     ///    data: `(patient_count, doctor_count, consent_version)`
-    ///    Verify completeness of the other two events against these counts.
     ///
     /// 2. `snap_pats` — topics: `("snap_pats", ledger_sequence)`,
     ///    data: `Vec<Address>` of all registered patient addresses.
     ///
     /// 3. `snap_docs` — topics: `("snap_docs", ledger_sequence)`,
     ///    data: `Vec<Address>` of all registered doctor addresses.
-    ///
-    /// # Off-chain reconstruction steps
-    /// 1. Subscribe to the Horizon/RPC event stream filtered by this contract ID.
-    /// 2. On `snap_meta`, record `ledger_sequence` and expected counts.
-    /// 3. Collect `snap_pats` and `snap_docs` at the same ledger sequence.
-    /// 4. Assert address list lengths match the counts in `snap_meta`.
-    /// 5. For each address call `get_patient` / `get_doctor` via RPC at that
-    ///    exact ledger (requires an archive node: `--ledger <seq>`).
-    /// 6. Persist the reconstructed structs to your off-chain store.
     pub fn emit_state_snapshot(env: Env) {
         let admin: Address = env
             .storage()
@@ -647,18 +683,14 @@ impl MedicalRegistry {
             .get(&DataKey::LastSnapshotLedger)
     }
 
-    pub fn get_medical_records(env: Env, patient: Address) -> Vec<MedicalRecord> {
-        let key = DataKey::MedicalRecords(patient);
-        env.storage()
-            .persistent()
-            .get(&key)
-            .unwrap_or(Vec::new(&env))
-    }
+    // =====================================================
+    //                  PRIVATE HELPERS
+    // =====================================================
 
     fn require_admin(env: &Env) {
         let admin: Address = env
             .storage()
-            .persistent()
+            .instance()
             .get(&DataKey::Admin)
             .expect("Contract not initialized");
         admin.require_auth();
@@ -694,5 +726,6 @@ impl MedicalRegistry {
         }
     }
 }
+
 #[cfg(test)]
 mod test;

--- a/contracts/patient-registry/src/test.rs
+++ b/contracts/patient-registry/src/test.rs
@@ -3,9 +3,8 @@
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke},
-    Address, Bytes, BytesN, Env, IntoVal, String,
+    Address, Bytes, BytesN, Env, IntoVal, String, Symbol,
 };
-use soroban_sdk::{testutils::{Address as _, Ledger as _}, Address, Bytes, BytesN, Env, String};
 
 /// ------------------------------------------------
 /// PATIENT TESTS
@@ -120,13 +119,8 @@ fn test_register_institution_and_verify_doctor() {
 
     env.mock_all_auths();
 
-    // Register doctor
     client.register_doctor(&doctor_wallet, &name, &specialization, &cert_hash);
-
-    // Register institution
     client.register_institution(&institution_wallet);
-
-    // Verify doctor
     client.verify_doctor(&doctor_wallet, &institution_wallet);
 
     let doctor = client.get_doctor(&doctor_wallet);
@@ -150,8 +144,6 @@ fn test_verify_doctor_by_unregistered_institution_should_fail() {
     env.mock_all_auths();
 
     client.register_doctor(&doctor_wallet, &name, &specialization, &cert_hash);
-
-    // This should panic
     client.verify_doctor(&doctor_wallet, &fake_institution);
 }
 
@@ -177,7 +169,13 @@ fn test_grant_access_and_add_medical_record() {
     client.publish_consent_version(&v1);
     client.acknowledge_consent(&patient, &patient, &v1);
     client.grant_access(&patient, &patient, &doctor);
-    client.add_medical_record(&patient, &doctor, &hash, &desc);
+    client.add_medical_record(
+        &patient,
+        &doctor,
+        &hash,
+        &desc,
+        &Symbol::new(&env, "LAB"),
+    );
 
     let records = client.get_medical_records(&patient);
     assert_eq!(records.len(), 1);
@@ -185,6 +183,7 @@ fn test_grant_access_and_add_medical_record() {
     let record = records.get(0).unwrap();
     assert_eq!(record.record_hash, hash);
     assert_eq!(record.description, desc);
+    assert_eq!(record.record_type, Symbol::new(&env, "LAB"));
 }
 
 #[test]
@@ -202,7 +201,13 @@ fn test_unauthorized_doctor_cannot_add_record() {
 
     env.mock_all_auths();
 
-    client.add_medical_record(&patient, &doctor, &hash, &desc);
+    client.add_medical_record(
+        &patient,
+        &doctor,
+        &hash,
+        &desc,
+        &Symbol::new(&env, "IMAGING"),
+    );
 }
 
 #[test]
@@ -238,8 +243,10 @@ fn test_admin_can_place_hold() {
     let admin = Address::generate(&env);
     let patient = Address::generate(&env);
     let reason_hash = BytesN::from_array(&env, &[7u8; 32]);
+    let treasury = Address::generate(&env);
+    let fee_token = Address::generate(&env);
 
-    client.initialize(&admin);
+    client.initialize(&admin, &treasury, &fee_token);
     client.register_patient(
         &patient,
         &String::from_str(&env, "Jane Doe"),
@@ -270,6 +277,8 @@ fn test_non_admin_cannot_place_hold() {
     let name = String::from_str(&env, "Jane Doe");
     let metadata = String::from_str(&env, "ipfs://patient");
     let dob = 631152000u64;
+    let treasury = Address::generate(&env);
+    let fee_token = Address::generate(&env);
 
     client
         .mock_auths(&[MockAuth {
@@ -277,11 +286,11 @@ fn test_non_admin_cannot_place_hold() {
             invoke: &MockAuthInvoke {
                 contract: &contract_id,
                 fn_name: "initialize",
-                args: (&admin,).into_val(&env),
+                args: (&admin, &treasury, &fee_token).into_val(&env),
                 sub_invokes: &[],
             },
         }])
-        .initialize(&admin);
+        .initialize(&admin, &treasury, &fee_token);
 
     client
         .mock_auths(&[MockAuth {
@@ -321,8 +330,10 @@ fn test_admin_can_lift_hold() {
     let admin = Address::generate(&env);
     let patient = Address::generate(&env);
     let reason_hash = BytesN::from_array(&env, &[8u8; 32]);
+    let treasury = Address::generate(&env);
+    let fee_token = Address::generate(&env);
 
-    client.initialize(&admin);
+    client.initialize(&admin, &treasury, &fee_token);
     client.register_patient(
         &patient,
         &String::from_str(&env, "Jane Doe"),
@@ -352,6 +363,8 @@ fn test_non_admin_cannot_lift_hold() {
     let name = String::from_str(&env, "Jane Doe");
     let metadata = String::from_str(&env, "ipfs://patient");
     let dob = 631152000u64;
+    let treasury = Address::generate(&env);
+    let fee_token = Address::generate(&env);
 
     client
         .mock_auths(&[MockAuth {
@@ -359,11 +372,11 @@ fn test_non_admin_cannot_lift_hold() {
             invoke: &MockAuthInvoke {
                 contract: &contract_id,
                 fn_name: "initialize",
-                args: (&admin,).into_val(&env),
+                args: (&admin, &treasury, &fee_token).into_val(&env),
                 sub_invokes: &[],
             },
         }])
-        .initialize(&admin);
+        .initialize(&admin, &treasury, &fee_token);
 
     client
         .mock_auths(&[MockAuth {
@@ -415,17 +428,24 @@ fn test_hold_blocks_patient_update() {
     let admin = Address::generate(&env);
     let patient = Address::generate(&env);
     let reason_hash = BytesN::from_array(&env, &[9u8; 32]);
+    let treasury = Address::generate(&env);
+    let fee_token = Address::generate(&env);
 
-    client.initialize(&admin);
+    client.initialize(&admin, &treasury, &fee_token);
     client.register_patient(
         &patient,
         &String::from_str(&env, "Jane Doe"),
         &631152000,
         &String::from_str(&env, "ipfs://initial"),
     );
+    env.ledger().set_timestamp(50);
     client.place_hold(&patient, &reason_hash, &250);
 
-    let result = client.try_update_patient(&patient, &String::from_str(&env, "ipfs://blocked"));
+    let result = client.try_update_patient(
+        &patient,
+        &patient,
+        &String::from_str(&env, "ipfs://blocked"),
+    );
     assert!(result.is_err());
 }
 
@@ -441,8 +461,10 @@ fn test_hold_blocks_grant_and_revoke_access() {
     let patient = Address::generate(&env);
     let doctor = Address::generate(&env);
     let reason_hash = BytesN::from_array(&env, &[10u8; 32]);
+    let treasury = Address::generate(&env);
+    let fee_token = Address::generate(&env);
 
-    client.initialize(&admin);
+    client.initialize(&admin, &treasury, &fee_token);
     client.register_patient(
         &patient,
         &String::from_str(&env, "Jane Doe"),
@@ -450,13 +472,14 @@ fn test_hold_blocks_grant_and_revoke_access() {
         &String::from_str(&env, "ipfs://initial"),
     );
 
-    client.grant_access(&patient, &doctor);
+    client.grant_access(&patient, &patient, &doctor);
+    env.ledger().set_timestamp(50);
     client.place_hold(&patient, &reason_hash, &250);
 
-    let grant_result = client.try_grant_access(&patient, &Address::generate(&env));
+    let grant_result = client.try_grant_access(&patient, &patient, &Address::generate(&env));
     assert!(grant_result.is_err());
 
-    let revoke_result = client.try_revoke_access(&patient, &doctor);
+    let revoke_result = client.try_revoke_access(&patient, &patient, &doctor);
     assert!(revoke_result.is_err());
 }
 
@@ -472,8 +495,10 @@ fn test_write_succeeds_after_hold_expiry() {
     let patient = Address::generate(&env);
     let reason_hash = BytesN::from_array(&env, &[11u8; 32]);
     let updated_metadata = String::from_str(&env, "ipfs://updated");
+    let treasury = Address::generate(&env);
+    let fee_token = Address::generate(&env);
 
-    client.initialize(&admin);
+    client.initialize(&admin, &treasury, &fee_token);
     client.register_patient(
         &patient,
         &String::from_str(&env, "Jane Doe"),
@@ -488,7 +513,7 @@ fn test_write_succeeds_after_hold_expiry() {
     env.ledger().set_timestamp(151);
     assert!(!client.is_hold_active(&patient));
 
-    client.update_patient(&patient, &updated_metadata);
+    client.update_patient(&patient, &patient, &updated_metadata);
     let patient_data = client.get_patient(&patient);
     assert_eq!(patient_data.metadata, updated_metadata);
 }
@@ -504,8 +529,10 @@ fn test_hold_exposes_only_reason_hash_in_state() {
     let admin = Address::generate(&env);
     let patient = Address::generate(&env);
     let reason_hash = BytesN::from_array(&env, &[12u8; 32]);
+    let treasury = Address::generate(&env);
+    let fee_token = Address::generate(&env);
 
-    client.initialize(&admin);
+    client.initialize(&admin, &treasury, &fee_token);
     client.register_patient(
         &patient,
         &String::from_str(&env, "Jane Doe"),
@@ -534,8 +561,10 @@ fn test_lifting_hold_restores_normal_write_ability() {
     let patient = Address::generate(&env);
     let reason_hash = BytesN::from_array(&env, &[13u8; 32]);
     let updated_metadata = String::from_str(&env, "ipfs://restored");
+    let treasury = Address::generate(&env);
+    let fee_token = Address::generate(&env);
 
-    client.initialize(&admin);
+    client.initialize(&admin, &treasury, &fee_token);
     client.register_patient(
         &patient,
         &String::from_str(&env, "Jane Doe"),
@@ -543,9 +572,10 @@ fn test_lifting_hold_restores_normal_write_ability() {
         &String::from_str(&env, "ipfs://initial"),
     );
 
+    env.ledger().set_timestamp(50);
     client.place_hold(&patient, &reason_hash, &300);
     client.lift_hold(&patient);
-    client.update_patient(&patient, &updated_metadata);
+    client.update_patient(&patient, &patient, &updated_metadata);
 
     let patient_data = client.get_patient(&patient);
     assert_eq!(patient_data.metadata, updated_metadata);
@@ -562,8 +592,10 @@ fn test_invalid_hold_expiry_is_rejected() {
     let admin = Address::generate(&env);
     let patient = Address::generate(&env);
     let reason_hash = BytesN::from_array(&env, &[14u8; 32]);
+    let treasury = Address::generate(&env);
+    let fee_token = Address::generate(&env);
 
-    client.initialize(&admin);
+    client.initialize(&admin, &treasury, &fee_token);
     client.register_patient(
         &patient,
         &String::from_str(&env, "Jane Doe"),
@@ -588,8 +620,10 @@ fn test_duplicate_active_hold_is_rejected() {
     let patient = Address::generate(&env);
     let reason_hash = BytesN::from_array(&env, &[15u8; 32]);
     let second_reason_hash = BytesN::from_array(&env, &[16u8; 32]);
+    let treasury = Address::generate(&env);
+    let fee_token = Address::generate(&env);
 
-    client.initialize(&admin);
+    client.initialize(&admin, &treasury, &fee_token);
     client.register_patient(
         &patient,
         &String::from_str(&env, "Jane Doe"),
@@ -602,6 +636,8 @@ fn test_duplicate_active_hold_is_rejected() {
 
     let result = client.try_place_hold(&patient, &second_reason_hash, &300u64);
     assert!(result.is_err());
+}
+
 /// ------------------------------------------------
 /// CONSENT TESTS
 /// ------------------------------------------------
@@ -618,7 +654,11 @@ fn test_consent_status_never_signed() {
     let patient = Address::generate(&env);
 
     env.mock_all_auths();
-    client.initialize(&Address::generate(&env), &Address::generate(&env), &Address::generate(&env));
+    client.initialize(
+        &Address::generate(&env),
+        &Address::generate(&env),
+        &Address::generate(&env),
+    );
 
     assert_eq!(client.get_consent_status(&patient), ConsentStatus::NeverSigned);
 }
@@ -637,7 +677,6 @@ fn test_consent_status_never_signed_no_ack() {
     client.initialize(&admin, &treasury, &fee_token);
     client.publish_consent_version(&make_version(&env, 1));
 
-    // Version published but patient never acknowledged
     assert_eq!(client.get_consent_status(&patient), ConsentStatus::NeverSigned);
 }
 
@@ -677,7 +716,6 @@ fn test_consent_status_pending_after_new_version() {
     client.publish_consent_version(&v1);
     client.acknowledge_consent(&patient, &patient, &v1);
 
-    // Admin publishes new version — patient is now Pending
     client.publish_consent_version(&v2);
     assert_eq!(client.get_consent_status(&patient), ConsentStatus::Pending);
 }
@@ -743,6 +781,7 @@ fn test_add_record_blocked_without_consent() {
         &doctor,
         &Bytes::from_array(&env, &[1, 2, 3]),
         &String::from_str(&env, "test"),
+        &Symbol::new(&env, "LAB"),
     );
 }
 
@@ -768,6 +807,7 @@ fn test_add_record_allowed_after_consent() {
         &doctor,
         &Bytes::from_array(&env, &[1, 2, 3]),
         &String::from_str(&env, "Blood test"),
+        &Symbol::new(&env, "LAB"),
     );
 
     assert_eq!(client.get_medical_records(&patient).len(), 1);
@@ -800,6 +840,7 @@ fn test_add_record_blocked_after_new_version() {
         &doctor,
         &Bytes::from_array(&env, &[1, 2, 3]),
         &String::from_str(&env, "Post-update record"),
+        &Symbol::new(&env, "LAB"),
     );
 }
 
@@ -812,8 +853,8 @@ fn setup_with_consent(env: &Env) -> (MedicalRegistryClient, Address) {
     let client = MedicalRegistryClient::new(env, &contract_id);
     let admin = Address::generate(env);
     env.mock_all_auths();
-    let treasury = Address::generate(&env);
-    let fee_token = Address::generate(&env);
+    let treasury = Address::generate(env);
+    let fee_token = Address::generate(env);
     client.initialize(&admin, &treasury, &fee_token);
     client.publish_consent_version(&make_version(env, 1));
     (client, admin)
@@ -914,6 +955,7 @@ fn test_guardian_enables_record_write() {
         &doctor,
         &Bytes::from_array(&env, &[5, 6, 7]),
         &String::from_str(&env, "Guardian-approved record"),
+        &Symbol::new(&env, "PRESCRIPTION"),
     );
 
     assert_eq!(client.get_medical_records(&patient).len(), 1);
@@ -942,7 +984,6 @@ fn test_revoked_guardian_rejected() {
 
     client.assign_guardian(&patient, &guardian);
     client.revoke_guardian(&patient);
-    // Guardian no longer valid
     client.acknowledge_consent(&patient, &guardian, &v1);
 }
 
@@ -956,9 +997,7 @@ fn test_guardian_cannot_act_for_different_patient() {
     let patient_b = Address::generate(&env);
     let guardian = Address::generate(&env);
 
-    // Guardian assigned only to patient_a
     client.assign_guardian(&patient_a, &guardian);
-    // Attempt to act on behalf of patient_b
     client.acknowledge_consent(&patient_b, &guardian, &v1);
 }
 
@@ -995,7 +1034,6 @@ fn test_first_snapshot_always_allowed() {
     client.initialize(&admin, &treasury, &fee_token);
     client.publish_consent_version(&v1);
 
-    // No prior snapshot — should succeed at any ledger
     client.emit_state_snapshot();
     assert_eq!(client.get_last_snapshot_ledger(), Some(env.ledger().sequence()));
 }
@@ -1046,7 +1084,6 @@ fn test_snapshot_rate_limit_enforced() {
     client.initialize(&admin, &treasury, &fee_token);
     client.emit_state_snapshot();
 
-    // Advance ledger by less than 100,000
     env.ledger().set(soroban_sdk::testutils::LedgerInfo {
         sequence_number: env.ledger().sequence() + 99_999,
         timestamp: env.ledger().timestamp() + 99_999,
@@ -1117,7 +1154,6 @@ fn test_snapshot_includes_registered_patients_and_doctors() {
         &Bytes::from_array(&env, &[1, 2, 3]),
     );
 
-    // Snapshot should succeed — lists are populated
     client.emit_state_snapshot();
     assert_eq!(client.get_last_snapshot_ledger(), Some(env.ledger().sequence()));
 }
@@ -1132,7 +1168,6 @@ fn setup_with_fee(
     let contract_id = env.register(MedicalRegistry, ());
     let client = MedicalRegistryClient::new(env, &contract_id);
 
-    // Deploy a real SAC token for cross-contract call testing
     let token_admin = Address::generate(env);
     let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
     let token_id = token_contract.address();
@@ -1151,7 +1186,6 @@ fn setup_with_fee(
     client.acknowledge_consent(&patient, &patient, &v1);
     client.grant_access(&patient, &patient, &doctor);
 
-    // Mint tokens to doctor so they can pay fees
     token_client.mint(&doctor, &10_000);
 
     (client, admin, treasury, token_id, doctor, patient, v1)
@@ -1180,12 +1214,12 @@ fn test_add_record_zero_fee_no_transfer() {
     let (client, _admin, treasury, token_id, doctor, patient, _v1) =
         setup_with_fee(&env);
 
-    // Fee is 0 — no transfer should occur
     client.add_medical_record(
         &patient,
         &doctor,
         &Bytes::from_array(&env, &[1, 2, 3]),
         &String::from_str(&env, "Zero fee record"),
+        &Symbol::new(&env, "LAB"),
     );
 
     let token = soroban_sdk::token::TokenClient::new(&env, &token_id);
@@ -1205,6 +1239,7 @@ fn test_add_record_transfers_fee_to_treasury() {
         &doctor,
         &Bytes::from_array(&env, &[4, 5, 6]),
         &String::from_str(&env, "Paid record"),
+        &Symbol::new(&env, "LAB"),
     );
 
     let token = soroban_sdk::token::TokenClient::new(&env, &token_id);
@@ -1226,6 +1261,7 @@ fn test_fee_deducted_per_record() {
             &doctor,
             &Bytes::from_array(&env, &[i, i, i]),
             &String::from_str(&env, "Record"),
+            &Symbol::new(&env, "LAB"),
         );
     }
 
@@ -1257,8 +1293,187 @@ fn test_fee_can_be_reset_to_zero() {
         &doctor,
         &Bytes::from_array(&env, &[7, 8, 9]),
         &String::from_str(&env, "Free after reset"),
+        &Symbol::new(&env, "LAB"),
     );
 
     let token = soroban_sdk::token::TokenClient::new(&env, &token_id);
     assert_eq!(token.balance(&treasury), 0);
+}
+
+/// ------------------------------------------------
+/// GET_RECORDS_BY_TYPE TESTS
+/// ------------------------------------------------
+
+fn setup_for_filter(
+    env: &Env,
+) -> (MedicalRegistryClient, Address, Address) {
+    let contract_id = env.register(MedicalRegistry, ());
+    let client = MedicalRegistryClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let treasury = Address::generate(env);
+    let fee_token = Address::generate(env);
+    let patient = Address::generate(env);
+    let doctor = Address::generate(env);
+    let v1 = make_version(env, 1);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin, &treasury, &fee_token);
+    client.publish_consent_version(&v1);
+    client.acknowledge_consent(&patient, &patient, &v1);
+    client.grant_access(&patient, &patient, &doctor);
+
+    (client, patient, doctor)
+}
+
+#[test]
+fn test_get_records_by_type_returns_matching_records() {
+    let env = Env::default();
+    let (client, patient, doctor) = setup_for_filter(&env);
+
+    client.add_medical_record(
+        &patient,
+        &doctor,
+        &Bytes::from_array(&env, &[1, 1, 1]),
+        &String::from_str(&env, "CBC panel"),
+        &Symbol::new(&env, "LAB"),
+    );
+    client.add_medical_record(
+        &patient,
+        &doctor,
+        &Bytes::from_array(&env, &[2, 2, 2]),
+        &String::from_str(&env, "Amoxicillin"),
+        &Symbol::new(&env, "PRESCRIPTION"),
+    );
+    client.add_medical_record(
+        &patient,
+        &doctor,
+        &Bytes::from_array(&env, &[3, 3, 3]),
+        &String::from_str(&env, "Lipid panel"),
+        &Symbol::new(&env, "LAB"),
+    );
+
+    let lab_records = client.get_records_by_type(&patient, &patient, &Symbol::new(&env, "LAB"));
+    assert_eq!(lab_records.len(), 2);
+    assert_eq!(lab_records.get(0).unwrap().description, String::from_str(&env, "CBC panel"));
+    assert_eq!(lab_records.get(1).unwrap().description, String::from_str(&env, "Lipid panel"));
+
+    let rx_records = client.get_records_by_type(&patient, &patient, &Symbol::new(&env, "PRESCRIPTION"));
+    assert_eq!(rx_records.len(), 1);
+    assert_eq!(rx_records.get(0).unwrap().description, String::from_str(&env, "Amoxicillin"));
+}
+
+#[test]
+fn test_get_records_by_type_returns_empty_when_no_match() {
+    let env = Env::default();
+    let (client, patient, doctor) = setup_for_filter(&env);
+
+    client.add_medical_record(
+        &patient,
+        &doctor,
+        &Bytes::from_array(&env, &[1, 2, 3]),
+        &String::from_str(&env, "X-ray"),
+        &Symbol::new(&env, "IMAGING"),
+    );
+
+    // No PRESCRIPTION records exist — should return empty vec, not error
+    let result = client.get_records_by_type(&patient, &patient, &Symbol::new(&env, "PRESCRIPTION"));
+    assert_eq!(result.len(), 0);
+}
+
+#[test]
+fn test_get_records_by_type_returns_empty_when_no_records_at_all() {
+    let env = Env::default();
+    let (client, patient, _doctor) = setup_for_filter(&env);
+
+    let result = client.get_records_by_type(&patient, &patient, &Symbol::new(&env, "LAB"));
+    assert_eq!(result.len(), 0);
+}
+
+#[test]
+fn test_get_records_by_type_authorized_doctor_can_read() {
+    let env = Env::default();
+    let (client, patient, doctor) = setup_for_filter(&env);
+
+    client.add_medical_record(
+        &patient,
+        &doctor,
+        &Bytes::from_array(&env, &[9, 8, 7]),
+        &String::from_str(&env, "Flu shot"),
+        &Symbol::new(&env, "IMMUNIZATION"),
+    );
+
+    // Doctor (authorized) can query records
+    let records = client.get_records_by_type(&patient, &doctor, &Symbol::new(&env, "IMMUNIZATION"));
+    assert_eq!(records.len(), 1);
+}
+
+#[test]
+fn test_get_records_by_type_guardian_can_read() {
+    let env = Env::default();
+    let (client, patient, doctor) = setup_for_filter(&env);
+    let guardian = Address::generate(&env);
+
+    client.assign_guardian(&patient, &guardian);
+    client.add_medical_record(
+        &patient,
+        &doctor,
+        &Bytes::from_array(&env, &[4, 5, 6]),
+        &String::from_str(&env, "Child checkup"),
+        &Symbol::new(&env, "VISIT"),
+    );
+
+    let records = client.get_records_by_type(&patient, &guardian, &Symbol::new(&env, "VISIT"));
+    assert_eq!(records.len(), 1);
+}
+
+#[test]
+#[should_panic(expected = "Caller not authorized to view records")]
+fn test_get_records_by_type_unauthorized_caller_is_rejected() {
+    let env = Env::default();
+    let (client, patient, _doctor) = setup_for_filter(&env);
+    let stranger = Address::generate(&env);
+
+    client.get_records_by_type(&patient, &stranger, &Symbol::new(&env, "LAB"));
+}
+
+#[test]
+fn test_get_records_by_type_multiple_types_isolation() {
+    let env = Env::default();
+    let (client, patient, doctor) = setup_for_filter(&env);
+
+    let types = [
+        ("LAB", "Blood work"),
+        ("PRESCRIPTION", "Metformin"),
+        ("IMAGING", "Chest X-ray"),
+        ("LAB", "Urinalysis"),
+        ("PRESCRIPTION", "Lisinopril"),
+    ];
+
+    for (i, (rtype, desc)) in types.iter().enumerate() {
+        client.add_medical_record(
+            &patient,
+            &doctor,
+            &Bytes::from_array(&env, &[i as u8, i as u8, i as u8]),
+            &String::from_str(&env, desc),
+            &Symbol::new(&env, rtype),
+        );
+    }
+
+    assert_eq!(
+        client.get_records_by_type(&patient, &patient, &Symbol::new(&env, "LAB")).len(),
+        2
+    );
+    assert_eq!(
+        client.get_records_by_type(&patient, &patient, &Symbol::new(&env, "PRESCRIPTION")).len(),
+        2
+    );
+    assert_eq!(
+        client.get_records_by_type(&patient, &patient, &Symbol::new(&env, "IMAGING")).len(),
+        1
+    );
+    assert_eq!(
+        client.get_records_by_type(&patient, &patient, &Symbol::new(&env, "VISIT")).len(),
+        0
+    );
 }

--- a/contracts/patient-registry/test_snapshots/test/test_grant_access_and_add_medical_record.1.json
+++ b/contracts/patient-registry/test_snapshots/test/test_grant_access_and_add_medical_record.1.json
@@ -96,6 +96,9 @@
                 },
                 {
                   "string": "Blood test results"
+                },
+                {
+                  "symbol": "LAB"
                 }
               ]
             }
@@ -315,6 +318,14 @@
                           },
                           "val": {
                             "bytes": "010203"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "record_type"
+                          },
+                          "val": {
+                            "symbol": "LAB"
                           }
                         },
                         {


### PR DESCRIPTION

## Summary
Adds `get_records_by_type(patient: Address, record_type: Symbol) -> Vec` to filter
a patient's medical records by category (e.g. "LAB", "PRESCRIPTION") — with access
control enforcement, graceful empty Vec return on no match, and full unit test coverage.

closes #94

## Changes
- `get_records_by_type()` — iterates patient's records and filters by
  `MedicalRecord.record_type` using Symbol comparison
- Returns empty `Vec` (not an error) when no records match the given type
- Access control enforced — only authorized callers can query a patient's records
- Unit tests covering: matching records, no matching records, multiple types,
  and unauthorized access attempt

## Implementation Notes
- Uses `Vec` filtering via iterator pattern supported in Soroban
- Symbol comparison done with direct equality check on `record_type` field
- Access control check runs before any filtering logic to prevent data leakage
  on unauthorized requests

## Testing Checklist
- [ ] Returns correct records when `record_type` matches (e.g. "LAB")
- [ ] Returns empty `Vec` when no records match the given type
- [ ] Returns correct records across multiple distinct types ("LAB", "PRESCRIPTION")
- [ ] Unauthorized caller is rejected before any records are accessed
- [ ] No panic or error thrown on empty patient record set