### PR TITLE
rate limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "multisig-governance"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,6 +1176,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "provider-registry"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
 ]
 
 [[package]]

--- a/contracts/provider-registry/src/lib.rs
+++ b/contracts/provider-registry/src/lib.rs
@@ -1,14 +1,39 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String,
+};
 
 mod test;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    RateLimitExceeded = 1,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RateLimitConfig {
+    pub max_records: u32,
+    pub window_seconds: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderRateWindow {
+    pub count: u32,
+    pub window_start: u64,
+}
 
 #[contracttype]
 pub enum DataKey {
     Admin,
     Provider(Address),
     Record(String),
+    RateLimitConfig,
+    ProviderRate(Address),
 }
 
 #[contract]
@@ -23,6 +48,19 @@ impl ProviderRegistry {
         }
         admin.require_auth();
         env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    /// Configure rolling per-provider rate limit for `add_record`. Admin only.
+    /// Use `max_records = 0` or `window_seconds = 0` to disable limiting.
+    pub fn set_rate_limit(env: Env, admin: Address, max_records: u32, window_seconds: u64) {
+        Self::assert_admin(&env, &admin);
+        env.storage().instance().set(
+            &DataKey::RateLimitConfig,
+            &RateLimitConfig {
+                max_records,
+                window_seconds,
+            },
+        );
     }
 
     /// Whitelist a provider address. Admin only.
@@ -54,16 +92,23 @@ impl ProviderRegistry {
     }
 
     /// Add a medical record. Caller must be a whitelisted provider.
-    pub fn add_record(env: Env, provider: Address, record_id: String, data: String) {
+    pub fn add_record(
+        env: Env,
+        provider: Address,
+        record_id: String,
+        data: String,
+    ) -> Result<(), ContractError> {
         provider.require_auth();
         if !Self::is_provider(env.clone(), provider.clone()) {
             panic!("Unauthorized: not a whitelisted provider");
         }
+        Self::consume_provider_rate_slot(&env, &provider)?;
         env.storage()
             .persistent()
             .set(&DataKey::Record(record_id.clone()), &data);
         env.events()
             .publish((symbol_short!("add_rec"), provider, record_id), symbol_short!("ok"));
+        Ok(())
     }
 
     /// Retrieve a medical record by ID.
@@ -86,5 +131,39 @@ impl ProviderRegistry {
         if *caller != admin {
             panic!("Unauthorized: admin only");
         }
+    }
+
+    /// Per-provider counter with window start; resets when ledger time passes the window.
+    fn consume_provider_rate_slot(env: &Env, provider: &Address) -> Result<(), ContractError> {
+        let config_opt: Option<RateLimitConfig> = env.storage().instance().get(&DataKey::RateLimitConfig);
+        let Some(config) = config_opt else {
+            return Ok(());
+        };
+        if config.max_records == 0 || config.window_seconds == 0 {
+            return Ok(());
+        }
+
+        let now = env.ledger().timestamp();
+        let key = DataKey::ProviderRate(provider.clone());
+        let mut state: ProviderRateWindow = env.storage().persistent().get(&key).unwrap_or(
+            ProviderRateWindow {
+                count: 0,
+                window_start: 0,
+            },
+        );
+
+        let window_end = state.window_start.saturating_add(config.window_seconds);
+        if state.window_start == 0 || now >= window_end {
+            state.count = 0;
+            state.window_start = now;
+        }
+
+        if state.count >= config.max_records {
+            return Err(ContractError::RateLimitExceeded);
+        }
+
+        state.count += 1;
+        env.storage().persistent().set(&key, &state);
+        Ok(())
     }
 }

--- a/contracts/provider-registry/src/test.rs
+++ b/contracts/provider-registry/src/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::Address as _, Address, Env, String};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, Env, String};
 
 fn setup() -> (Env, Address, ProviderRegistryClient<'static>) {
     let env = Env::default();
@@ -106,6 +106,149 @@ fn test_revoke_provider_non_admin_rejected() {
 #[test]
 #[should_panic(expected = "Already initialized")]
 fn test_double_initialize() {
-    let (env, admin, client) = setup();
+    let (_env, admin, client) = setup();
     client.initialize(&admin);
+}
+
+// --- Rate limit: within limit (max 50/hour, add 3) ---
+#[test]
+fn test_rate_limit_within_limit() {
+    let (env, admin, client) = setup();
+    let provider = Address::generate(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000_000);
+
+    client.register_provider(&admin, &provider);
+    client.set_rate_limit(&admin, &50, &3600);
+
+    for id in ["REC-W-0", "REC-W-1", "REC-W-2"] {
+        client.add_record(
+            &provider,
+            &String::from_str(&env, id),
+            &String::from_str(&env, "data"),
+        );
+    }
+}
+
+// --- At limit: exactly max_records succeed, next fails ---
+#[test]
+fn test_rate_limit_at_limit() {
+    let (env, admin, client) = setup();
+    let provider = Address::generate(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 2_000_000);
+
+    client.register_provider(&admin, &provider);
+    const MAX: u32 = 5;
+    client.set_rate_limit(&admin, &MAX, &3600);
+
+    let ids = ["REC-A-0", "REC-A-1", "REC-A-2", "REC-A-3", "REC-A-4"];
+    for id in ids {
+        client.add_record(
+            &provider,
+            &String::from_str(&env, id),
+            &String::from_str(&env, "data"),
+        );
+    }
+
+    let over = client.try_add_record(
+        &provider,
+        &String::from_str(&env, "REC-A-OVER"),
+        &String::from_str(&env, "data"),
+    );
+    assert!(matches!(over, Err(Ok(ContractError::RateLimitExceeded))));
+}
+
+// --- Over limit (same as at-limit verification) ---
+#[test]
+fn test_rate_limit_over_limit_rejected() {
+    let (env, admin, client) = setup();
+    let provider = Address::generate(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 3_000_000);
+
+    client.register_provider(&admin, &provider);
+    client.set_rate_limit(&admin, &2, &100);
+
+    client.add_record(
+        &provider,
+        &String::from_str(&env, "R1"),
+        &String::from_str(&env, "d"),
+    );
+    client.add_record(
+        &provider,
+        &String::from_str(&env, "R2"),
+        &String::from_str(&env, "d"),
+    );
+
+    let third = client.try_add_record(
+        &provider,
+        &String::from_str(&env, "R3"),
+        &String::from_str(&env, "d"),
+    );
+    assert!(matches!(third, Err(Ok(ContractError::RateLimitExceeded))));
+}
+
+// --- Window resets after window_seconds; can record again ---
+#[test]
+fn test_rate_limit_window_reset_allows_again() {
+    let (env, admin, client) = setup();
+    let provider = Address::generate(&env);
+
+    let t0 = 10_000u64;
+    env.ledger().with_mut(|li| li.timestamp = t0);
+
+    client.register_provider(&admin, &provider);
+    client.set_rate_limit(&admin, &3, &3600);
+
+    for id in ["REC-R-0", "REC-R-1", "REC-R-2"] {
+        client.add_record(
+            &provider,
+            &String::from_str(&env, id),
+            &String::from_str(&env, "data"),
+        );
+    }
+
+    let blocked = client.try_add_record(
+        &provider,
+        &String::from_str(&env, "REC-BLOCKED"),
+        &String::from_str(&env, "data"),
+    );
+    assert!(matches!(blocked, Err(Ok(ContractError::RateLimitExceeded))));
+
+    // Past window end: new window starts
+    env.ledger().with_mut(|li| li.timestamp = t0 + 3600);
+
+    client.add_record(
+        &provider,
+        &String::from_str(&env, "REC-AFTER-RESET"),
+        &String::from_str(&env, "data"),
+    );
+    assert_eq!(
+        client.get_record(&String::from_str(&env, "REC-AFTER-RESET")),
+        String::from_str(&env, "data")
+    );
+}
+
+#[test]
+fn test_rate_limit_disabled_with_zero_max() {
+    let (env, admin, client) = setup();
+    let provider = Address::generate(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 4_000_000);
+
+    client.register_provider(&admin, &provider);
+    client.set_rate_limit(&admin, &0, &3600);
+
+    let ids = [
+        "REC-D-0", "REC-D-1", "REC-D-2", "REC-D-3", "REC-D-4", "REC-D-5", "REC-D-6", "REC-D-7",
+        "REC-D-8", "REC-D-9",
+    ];
+    for id in ids {
+        client.add_record(
+            &provider,
+            &String::from_str(&env, id),
+            &String::from_str(&env, "data"),
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Add admin-only `set_rate_limit(max_records, window_seconds)` storing policy in **instance** storage (`RateLimitConfig`).
- Track per-provider usage in persistent storage (`ProviderRateWindow`: count + window start).
- Reset the counter when `env.ledger().timestamp() >= window_start + window_seconds` (new window).
- `add_record` returns `Result<(), ContractError>` and rejects with **`ContractError::RateLimitExceeded`** when the provider is over the limit for the current window.
- `max_records == 0` or `window_seconds == 0` disables rate limiting (backward compatible when unset / disabled).
closes #123 
## Why
Limit abuse/spam: cap how many records a single provider can create in a rolling time window (e.g. 50/hour).

## Tests
- Within limit, at limit (+ next call fails), over limit, window reset allows adds again, zero max disables limit.
- `cargo test -p provider-registry` — all passing.

## Integration note
- Successful paths can keep using `add_record`; expected rate-limit failures should use `try_add_record` and assert on `ContractError::RateLimitExceeded`.