### PR TITLE
feat(access-control): add DID registration and audit trail

### DIFF
--- a/contracts/access-control/DID_INTEGRATION.md
+++ b/contracts/access-control/DID_INTEGRATION.md
@@ -1,0 +1,46 @@
+# DID Integration Guide
+
+This contract now includes an integration layer that links Soroban `Address` values to W3C Decentralized Identifiers (DIDs).
+
+## Purpose
+
+- Anchor identity bindings on-chain for both patients and providers.
+- Enable future cross-chain identity checks by storing a canonical DID per address.
+- Emit an auditable DID-change event without exposing the old/new DID values directly.
+
+## API
+
+### `register_did(address: Address, did: Bytes) -> Result<(), ContractError>`
+
+- Self-registration only: `address` must authorize the call (`address.require_auth()`).
+- Validates DID format: must begin with ASCII prefix `did:`.
+- Stores/updates DID under persistent storage key `Did(address)`.
+- Emits audit event:
+  - Topic: `("did_aud", address)`
+  - Data: `(old_did_hash: Option<BytesN<32>>, new_did_hash: BytesN<32>)`
+
+### `get_did(address: Address) -> Option<Bytes>`
+
+- Returns DID bytes if registered; otherwise `None`.
+
+## Validation Rules
+
+- Accepted: `did:example:123`, `did:stellar:provider:abc`, `did:key:z6M...`
+- Rejected: values not starting with `did:`
+
+## Integration Pattern for DID Resolution
+
+1. Read on-chain DID:
+   - Call `get_did(address)`.
+2. Resolve DID off-chain:
+   - Send DID to your DID resolver (method-specific, e.g. `did:key`, `did:web`).
+3. Verify controller binding:
+   - Compare resolved DID document controller/public key against expected signer.
+4. Optional audit check:
+   - Track `did_aud` events to detect DID rotations and require re-verification.
+
+## Security Notes
+
+- One address can only self-assert or rotate its DID (no third-party writes).
+- Audit events emit hashes, not plain DID history, reducing metadata leakage.
+- Downstream services should re-verify proofs whenever a DID hash changes.

--- a/contracts/access-control/src/lib.rs
+++ b/contracts/access-control/src/lib.rs
@@ -1,9 +1,19 @@
 #![no_std]
 #![allow(deprecated)]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN,
+    Env, String, Vec,
+};
 
 mod test;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    InvalidDidFormat = 1,
+}
 
 /// --------------------
 /// Entity Types
@@ -51,6 +61,7 @@ pub enum DataKey {
     Entity(Address),
     AccessList(Address),    // Entity -> Vec<AccessPermission>
     ResourceAccess(String), // Resource -> Vec<Address> (authorized parties)
+    Did(Address),
 }
 
 #[contract]
@@ -395,5 +406,43 @@ impl AccessControl {
 
         env.events()
             .publish((symbol_short!("deact"), wallet), symbol_short!("success"));
+    }
+
+    /// Register or update a W3C DID for the provided address.
+    /// Self-registration only: `address` must authorize this call.
+    ///
+    /// DID format must start with `did:`.
+    pub fn register_did(env: Env, address: Address, did: Bytes) -> Result<(), ContractError> {
+        address.require_auth();
+        Self::validate_did(&did)?;
+
+        let key = DataKey::Did(address.clone());
+        let old_did: Option<Bytes> = env.storage().persistent().get(&key);
+        let old_hash: Option<BytesN<32>> = old_did.map(|d| env.crypto().sha256(&d).into());
+        let new_hash: BytesN<32> = env.crypto().sha256(&did).into();
+
+        env.storage().persistent().set(&key, &did);
+        env.events()
+            .publish((symbol_short!("did_aud"), address), (old_hash, new_hash));
+        Ok(())
+    }
+
+    /// Returns the DID registered for an address, if present.
+    pub fn get_did(env: Env, address: Address) -> Option<Bytes> {
+        env.storage().persistent().get(&DataKey::Did(address))
+    }
+
+    fn validate_did(did: &Bytes) -> Result<(), ContractError> {
+        if did.len() < 4 {
+            return Err(ContractError::InvalidDidFormat);
+        }
+        let d = did.get(0).unwrap_or_default();
+        let i = did.get(1).unwrap_or_default();
+        let d2 = did.get(2).unwrap_or_default();
+        let colon = did.get(3).unwrap_or_default();
+        if d != b'd' || i != b'i' || d2 != b'd' || colon != b':' {
+            return Err(ContractError::InvalidDidFormat);
+        }
+        Ok(())
     }
 }

--- a/contracts/access-control/src/test.rs
+++ b/contracts/access-control/src/test.rs
@@ -1,7 +1,10 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::Address as _, Address, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Bytes, Env, IntoVal, String,
+};
 
 #[test]
 fn test_initialize() {
@@ -320,4 +323,96 @@ fn test_update_entity() {
 
     let entity = client.get_entity(&hospital);
     assert_eq!(entity.metadata, new_metadata);
+}
+
+#[test]
+fn test_register_and_get_did() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AccessControl, ());
+    let client = AccessControlClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let patient = Address::generate(&env);
+    client.initialize(&admin);
+
+    let did = Bytes::from_slice(&env, b"did:stellar:patient:abc123");
+    client.register_did(&patient, &did);
+
+    let stored = client.get_did(&patient).unwrap();
+    assert_eq!(stored, did);
+}
+
+#[test]
+fn test_register_did_invalid_format_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AccessControl, ());
+    let client = AccessControlClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let provider = Address::generate(&env);
+    client.initialize(&admin);
+
+    let invalid = Bytes::from_slice(&env, b"stellar:provider:abc123");
+    let result = client.try_register_did(&provider, &invalid);
+    assert!(matches!(result, Err(Ok(ContractError::InvalidDidFormat))));
+}
+
+#[test]
+fn test_register_did_self_registration_only() {
+    let env = Env::default();
+    let contract_id = env.register(AccessControl, ());
+    let client = AccessControlClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let patient = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "initialize",
+                args: (&admin,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .initialize(&admin);
+
+    let did = Bytes::from_slice(&env, b"did:stellar:patient:secure1");
+    let unauthorized = client
+        .mock_auths(&[MockAuth {
+            address: &attacker,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "register_did",
+                args: (&patient, &did).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .try_register_did(&patient, &did);
+
+    assert!(unauthorized.is_err());
+}
+
+#[test]
+fn test_register_did_update_replaces_value() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(AccessControl, ());
+    let client = AccessControlClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let provider = Address::generate(&env);
+    client.initialize(&admin);
+
+    let did_v1 = Bytes::from_slice(&env, b"did:stellar:provider:old");
+    let did_v2 = Bytes::from_slice(&env, b"did:stellar:provider:new");
+    client.register_did(&provider, &did_v1);
+    client.register_did(&provider, &did_v2);
+
+    let stored = client.get_did(&provider).unwrap();
+    assert_eq!(stored, did_v2);
 }


### PR DESCRIPTION
## PR Title
feat(access-control): add DID registration and audit trail
closes #109
## Summary
- Add DID integration layer in `access-control` for linking on-chain addresses to W3C DIDs.
- Implement `register_did(address, did)` with self-registration only (`address.require_auth()`).
- Implement `get_did(address) -> Option<Bytes>`.
- Validate DID format (`did:` prefix required), returning `ContractError::InvalidDidFormat` on invalid input.
- Emit DID audit events on create/update with hashed history:
  - topic: `("did_aud", address)`
  - data: `(old_did_hash, new_did_hash)`

## Why
This provides a secure, on-chain identity binding primitive for patients and providers that can be used later for cross-chain DID verification workflows, while keeping DID change history auditable and privacy-conscious via hashes.

## Acceptance Criteria Mapping
- [x] `register_did(address: Address, did: Bytes)` implemented
- [x] Self-registration enforced (caller must be the same `address`)
- [x] `get_did(address) -> Option` implemented
- [x] DID format validation enforced (`did:` prefix)
- [x] DID changes emit audit event with old/new DID hash
- [x] Integration documentation added (`contracts/access-control/DID_INTEGRATION.md`)

## Test Plan
- [x] `cargo test -q -p access-control`
- [x] Test DID registration + retrieval
- [x] Test invalid DID format rejection
- [x] Test self-registration-only authorization
- [x] Test DID update/rotation replaces stored value correctly

## Integration Notes
- Consumers should fetch DID via `get_did`, resolve off-chain with a method-specific resolver, and verify controller/signing keys against expected wallet ownership.
- Consumers can monitor `did_aud` events to detect DID rotation and trigger re-verification.