### PR TITLE
feat(patient-registry): fuzz + proptest validators; fix build for CI

### DIFF
--- a/.github/workflows/fuzz-validation.yml
+++ b/.github/workflows/fuzz-validation.yml
@@ -1,4 +1,5 @@
 # Fuzz patient-registry input validators (CID, DID, score) for 60s per target on each PR.
+# Labels: intermediate testing security
 name: Fuzz validation
 
 on:
@@ -16,7 +17,8 @@ jobs:
     timeout-minutes: 30
     defaults:
       run:
-        working-directory: contracts/patient-registry
+        # cargo-fuzz expects the fuzz crate manifest under this directory.
+        working-directory: contracts/patient-registry/fuzz
 
     steps:
       - uses: actions/checkout@v4
@@ -27,10 +29,10 @@ jobs:
         run: cargo install cargo-fuzz --locked
 
       - name: Fuzz validate_cid (60s)
-        run: cargo fuzz run validate_cid fuzz/corpus/validate_cid -- -max_total_time=60 -print_final_stats=1
+        run: cargo fuzz run validate_cid corpus/validate_cid -- -max_total_time=60 -print_final_stats=1
 
       - name: Fuzz validate_did (60s)
-        run: cargo fuzz run validate_did fuzz/corpus/validate_did -- -max_total_time=60 -print_final_stats=1
+        run: cargo fuzz run validate_did corpus/validate_did -- -max_total_time=60 -print_final_stats=1
 
       - name: Fuzz validate_score (60s)
-        run: cargo fuzz run validate_score fuzz/corpus/validate_score -- -max_total_time=60 -print_final_stats=1
+        run: cargo fuzz run validate_score corpus/validate_score -- -max_total_time=60 -print_final_stats=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,7 +181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -201,6 +207,27 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -327,7 +354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -587,7 +614,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -612,7 +639,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -632,6 +659,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "escape-bytes"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,12 +681,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -679,6 +722,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,13 +752,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -742,6 +816,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -841,6 +924,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -952,6 +1041,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +1057,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -1101,6 +1202,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 name = "patient-registry"
 version = "0.0.0"
 dependencies = [
+ "proptest",
  "soroban-sdk",
 ]
 
@@ -1179,11 +1281,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "provider-registry"
 version = "0.0.0"
 dependencies = [
  "soroban-sdk",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -1195,14 +1322,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1212,7 +1361,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1221,7 +1380,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1252,6 +1429,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rehabilitation-services"
 version = "0.1.0"
 dependencies = [
@@ -1278,10 +1461,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "schemars"
@@ -1446,7 +1654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1483,7 +1691,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1511,7 +1719,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.17",
  "hex-literal",
  "hmac",
  "k256",
@@ -1519,8 +1727,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
@@ -1529,7 +1737,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey 0.0.13",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1573,7 +1781,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.5",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1614,7 +1822,7 @@ dependencies = [
  "base64",
  "stellar-xdr",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1756,6 +1964,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,10 +2034,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "upgrade-governance"
@@ -1843,10 +2076,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1894,6 +2154,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
 name = "wasmi_arena"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1917,6 +2199,18 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
+ "indexmap 2.13.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
 ]
@@ -1987,6 +2281,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]

--- a/contracts/patient-registry/Cargo.toml
+++ b/contracts/patient-registry/Cargo.toml
@@ -12,4 +12,5 @@ doctest = false
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]
+proptest = "1.4"
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/patient-registry/fuzz/fuzz_targets/validate_cid.rs
+++ b/contracts/patient-registry/fuzz/fuzz_targets/validate_cid.rs
@@ -1,9 +1,10 @@
 #![no_main]
 
+use core::hint::black_box;
 use libfuzzer_sys::fuzz_target;
 use patient_registry::validation::validate_cid_bytes;
 
 // Must never panic: only Ok / Err.
 fuzz_target!(|data: &[u8]| {
-    let _ = validate_cid_bytes(data);
+    let _ = black_box(validate_cid_bytes(data));
 });

--- a/contracts/patient-registry/fuzz/fuzz_targets/validate_did.rs
+++ b/contracts/patient-registry/fuzz/fuzz_targets/validate_did.rs
@@ -1,9 +1,10 @@
 #![no_main]
 
+use core::hint::black_box;
 use libfuzzer_sys::fuzz_target;
 use patient_registry::validation::validate_did_bytes;
 
 // Must never panic: only Ok / Err.
 fuzz_target!(|data: &[u8]| {
-    let _ = validate_did_bytes(data);
+    let _ = black_box(validate_did_bytes(data));
 });

--- a/contracts/patient-registry/fuzz/fuzz_targets/validate_score.rs
+++ b/contracts/patient-registry/fuzz/fuzz_targets/validate_score.rs
@@ -1,9 +1,10 @@
 #![no_main]
 
+use core::hint::black_box;
 use libfuzzer_sys::fuzz_target;
 use patient_registry::validation::validate_score_i32;
 
-// Must never panic: only Ok / Err.
+// Must never panic: only Ok / Err. Any input bytes map to an i32 via the first 4 octets.
 fuzz_target!(|data: &[u8]| {
     let mut buf = [0u8; 4];
     let n = data.len().min(4);
@@ -11,5 +12,5 @@ fuzz_target!(|data: &[u8]| {
         buf[..n].copy_from_slice(&data[..n]);
     }
     let score = i32::from_le_bytes(buf);
-    let _ = validate_score_i32(score);
+    let _ = black_box(validate_score_i32(score));
 });

--- a/contracts/patient-registry/src/lib.rs
+++ b/contracts/patient-registry/src/lib.rs
@@ -108,6 +108,8 @@ pub enum DataKey {
     GlobalTypeIndex(Symbol),
     /// Soft-delete tombstone for a record (value: timestamp of deletion).
     DeletedRecord(u64),
+    /// Merkle root over the patient's ordered record IDs (see `merkle` module).
+    MerkleRoot(Address),
 }
 
 /// --------------------
@@ -177,10 +179,11 @@ pub enum ContractError {
     InvalidCID = 1,
     InvalidToken = 2,
     NotAuthorized = 3,
-    InvalidDID = 2,
-    InvalidScore = 3,
-    ContractFrozen = 2,
-    NoRecordsFound = 4,
+    InvalidDID = 4,
+    InvalidScore = 5,
+    ContractFrozen = 6,
+    NoRecordsFound = 7,
+    NotFound = 8,
 }
 
 pub fn validate_cid(cid: &Bytes) -> Result<(), ContractError> {
@@ -799,7 +802,7 @@ impl MedicalRegistry {
             .storage()
             .persistent()
             .get(&key)
-            .unwrapOr(Map::new(&env));
+            .unwrap_or(Map::new(&env));
 
         if !map.contains_key(doctor.clone()) {
             let total_access_grants: u64 = env
@@ -931,7 +934,7 @@ impl MedicalRegistry {
         let record_data = RecordData {
             patient: patient.clone(),
             record_type: record_type.clone(),
-            description,
+            description: description.clone(),
             current_ipfs: record_hash.clone(),
             history: {
                 let mut h = Vec::new(&env);
@@ -940,17 +943,6 @@ impl MedicalRegistry {
             },
             latest_version: 1u64,
         };
-
-        let counter_key = DataKey::RecordCounter(patient.clone());
-        let record_id: u64 = env
-            .storage()
-            .persistent()
-            .get(&counter_key)
-            .unwrap_or(0u64)
-            + 1;
-        env.storage().persistent().set(&counter_key, &record_id);
-
-        let timestamp = env.ledger().timestamp();
 
         let record = MedicalRecord {
             record_id,
@@ -996,6 +988,7 @@ impl MedicalRegistry {
             .unwrap_or(Vec::new(&env));
         ids.push_back(record_id);
         env.storage().persistent().set(&ids_key, &ids);
+        Self::update_merkle_root(&env, &patient, &ids);
 
         // ── Secondary index update ────────────────────────────────────────────
         // Atomically append (patient, record_id) to the global type index.
@@ -1139,6 +1132,38 @@ impl MedicalRegistry {
         Ok(latest)
     }
 
+    /// Merkle root over the patient's ordered record IDs (see `merkle` module).
+    /// If no root was persisted yet, recomputes from `PatientRecordIds` (or empty sentinel).
+    pub fn get_merkle_root(env: Env, patient: Address) -> BytesN<32> {
+        let key = DataKey::MerkleRoot(patient.clone());
+        if let Some(root) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, BytesN<32>>(&key)
+        {
+            root
+        } else {
+            let ids_key = DataKey::PatientRecordIds(patient);
+            let ids: Vec<u64> = env
+                .storage()
+                .persistent()
+                .get(&ids_key)
+                .unwrap_or(Vec::new(&env));
+            merkle::compute_merkle_root(&env, &ids)
+        }
+    }
+
+    /// Returns true iff `proof` is a valid Merkle membership proof for `record_id` under this patient's root.
+    pub fn verify_record_membership(
+        env: Env,
+        patient: Address,
+        record_id: u64,
+        proof: Vec<BytesN<32>>,
+    ) -> bool {
+        let root = Self::get_merkle_root(env.clone(), patient);
+        merkle::verify_membership(&env, record_id, &proof, &root)
+    }
+
     /// Returns all records for `patient` whose `record_type` matches the given symbol.
     /// Access control: caller must be the patient, their guardian, or an authorized doctor.
     /// Returns an empty vec (not an error) when no records match.
@@ -1146,7 +1171,6 @@ impl MedicalRegistry {
         env: Env,
         caller: Address,
         record_id: u64,
-        caller: Address,
         new_ipfs_hash: Bytes,
     ) -> Result<(), ContractError> {
         Self::require_not_frozen(&env);
@@ -1544,7 +1568,7 @@ impl MedicalRegistry {
         // ── Secondary index update ────────────────────────────────────────────
         // Remove this entry from the global type index atomically.
         let idx_key = DataKey::GlobalTypeIndex(record_data.record_type.clone());
-        let mut type_index: Vec<TypeIndexEntry> = env
+        let type_index: Vec<TypeIndexEntry> = env
             .storage()
             .persistent()
             .get(&idx_key)

--- a/contracts/patient-registry/src/test.rs
+++ b/contracts/patient-registry/src/test.rs
@@ -136,22 +136,90 @@ fn test_analytics_counters_admin_only() {
     let fee_token = Address::generate(&env);
     let patient = Address::generate(&env);
     let v1 = make_version(&env, 1);
-
-    env.mock_all_auths();
-    client.initialize(&admin, &treasury, &fee_token);
-    client.publish_consent_version(&v1);
-    client.register_patient(&patient, &String::from_str(&env, "P1"), &631152000, &String::from_str(&env, "ipfs://p1"));
-
-    // non-admin access should fail
     let attacker = Address::generate(&env);
-    let result = client.try_get_total_records_created(&attacker);
-    assert!(result.is_err());
 
-    let result = client.try_get_total_providers(&attacker);
-    assert!(result.is_err());
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "initialize",
+                args: (&admin, &treasury, &fee_token).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .initialize(&admin, &treasury, &fee_token);
 
-    let result = client.try_get_total_access_grants(&attacker);
-    assert!(result.is_err());
+    client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "publish_consent_version",
+                args: (&v1,).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .publish_consent_version(&v1);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &patient,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "register_patient",
+                args: (
+                    &patient,
+                    &String::from_str(&env, "P1"),
+                    &631152000u64,
+                    &String::from_str(&env, "ipfs://p1"),
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .register_patient(
+            &patient,
+            &String::from_str(&env, "P1"),
+            &631152000,
+            &String::from_str(&env, "ipfs://p1"),
+        );
+
+    let inv1 = MockAuthInvoke {
+        contract: &contract_id,
+        fn_name: "get_total_records_created",
+        args: ().into_val(&env),
+        sub_invokes: &[],
+    };
+    let a1 = MockAuth {
+        address: &attacker,
+        invoke: &inv1,
+    };
+    assert!(client.mock_auths(&[a1]).try_get_total_records_created().is_err());
+
+    let inv2 = MockAuthInvoke {
+        contract: &contract_id,
+        fn_name: "get_total_providers",
+        args: ().into_val(&env),
+        sub_invokes: &[],
+    };
+    let a2 = MockAuth {
+        address: &attacker,
+        invoke: &inv2,
+    };
+    assert!(client.mock_auths(&[a2]).try_get_total_providers().is_err());
+
+    let inv3 = MockAuthInvoke {
+        contract: &contract_id,
+        fn_name: "get_total_access_grants",
+        args: ().into_val(&env),
+        sub_invokes: &[],
+    };
+    let a3 = MockAuth {
+        address: &attacker,
+        invoke: &inv3,
+    };
+    assert!(client.mock_auths(&[a3]).try_get_total_access_grants().is_err());
 }
 
 #[test]
@@ -198,7 +266,8 @@ fn test_total_access_grants_increments_on_grant_and_decrements_on_revoke() {
     let (client, _admin, patient, doctor, _v1) = setup_for_ttl(&env);
     let other_doctor = Address::generate(&env);
 
-    assert_eq!(client.get_total_access_grants(), 0);
+    // `setup_for_ttl` already granted `doctor` once.
+    assert_eq!(client.get_total_access_grants(), 1);
 
     client.grant_access(&patient, &patient, &doctor);
     assert_eq!(client.get_total_access_grants(), 1);
@@ -1866,7 +1935,10 @@ fn test_get_latest_record_returns_most_recent() {
         &Symbol::new(&env, "LAB"),
     );
 
-    let latest = client.get_latest_record(&patient, &patient).unwrap();
+    let latest = client
+        .try_get_latest_record(&patient, &patient)
+        .unwrap()
+        .unwrap();
     assert_eq!(latest.description, String::from_str(&env, "Second record"));
     assert_eq!(latest.timestamp, 2000);
 }

--- a/contracts/patient-registry/src/validation.rs
+++ b/contracts/patient-registry/src/validation.rs
@@ -71,3 +71,27 @@ pub fn validate_score_i32(score: i32) -> Result<(), ()> {
         Err(())
     }
 }
+
+#[cfg(test)]
+mod proptest_validators {
+    //! Property-based checks: validators must never panic (only `Ok` / `Err`).
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn prop_validate_cid_bytes_no_panic(bytes in prop::collection::vec(any::<u8>(), 0..600)) {
+            let _ = validate_cid_bytes(&bytes);
+        }
+
+        #[test]
+        fn prop_validate_did_bytes_no_panic(bytes in prop::collection::vec(any::<u8>(), 0..300)) {
+            let _ = validate_did_bytes(&bytes);
+        }
+
+        #[test]
+        fn prop_validate_score_i32_no_panic(score in any::<i32>()) {
+            let _ = validate_score_i32(score);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Labels:** intermediate · testing · security  

Hardens **patient-registry** input validation with **cargo-fuzz** (CID, DID, score) and **proptest**, fixes **CI** so fuzz runs from the correct directory with committed corpus seeds, and repairs **contract/test build breaks** that blocked nightly fuzz builds.
closes #114 
## Fuzzing & property tests

- **3 libFuzzer targets** (`validate_cid`, `validate_did`, `validate_score`) call pure `validation::*` helpers only — **no panics**; results passed through `black_box` / ignored explicitly to avoid `unused_must_use` noise.
- **proptest** (`validation.rs`): `prop_validate_cid_bytes_no_panic`, `prop_validate_did_bytes_no_panic`, `prop_validate_score_i32_no_panic`.
- **Corpus:** `fuzz/corpus/validate_score/seed_mid` (4-byte LE `i32`); existing CID/DID seeds unchanged; generated corpus hashes remain gitignored.

## CI

- **`.github/workflows/fuzz-validation.yml`**: `working-directory` → `contracts/patient-registry/fuzz`; corpus paths → `corpus/validate_*` (matches `cargo-fuzz` layout).
- Still **60 seconds per target** on PR / push to `main` / `develop`.

## Contract fixes (build + tests)

- Unique **`ContractError`** discriminants + **`NotFound`**; `grant_access` **`unwrap_or`** for `Map`.
- **`DataKey::MerkleRoot`**, **`get_merkle_root`**, **`verify_record_membership`**; **`update_merkle_root`** after appending record IDs; removed broken duplicate counter logic in **`add_medical_record`**; fixed **`update_record`** arity.
- Test updates: admin-only analytics mocks, `try_get_latest_record`, access-grant counter vs **`setup_for_ttl`**.

## How to verify

```bash
cd contracts/patient-registry/fuzz
cargo +nightly fuzz run validate_cid corpus/validate_cid -- -runs=100
cargo test -p patient-registry prop_validate
cargo test -p patient-registry