### PR TITLE
Feat/security registry claims hardening

### DIFF
--- a/contracts/hospital-registry/src/lib.rs
+++ b/contracts/hospital-registry/src/lib.rs
@@ -2,7 +2,8 @@
 #![allow(deprecated)]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String, Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
+    String, Vec,
 };
 
 #[contracterror]
@@ -12,22 +13,30 @@ pub enum ContractError {
     HospitalAlreadyRegistered = 1,
     HospitalNotFound = 2,
     HospitalConfigNotFound = 3,
+    CredentialExpired = 4,
+    CredentialRevoked = 5,
 }
 
-/// --------------------
-/// Hospital Structures
-/// --------------------
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CredentialAnchor {
+    pub credential_hash: BytesN<32>,
+    pub issuer: Address,
+    pub attestation_hash: BytesN<32>,
+    pub expires_at: u64,
+    pub revocation_reference: BytesN<32>,
+    pub revoked_at: Option<u64>,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct HospitalData {
     pub name: String,
     pub location: String,
-    pub metadata: String, // Services, departments, accreditation info
+    pub metadata: String,
+    pub credential: CredentialAnchor,
 }
 
-/// --------------------
-/// Hospital Configuration Structures
-/// --------------------
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Department {
@@ -109,9 +118,6 @@ pub struct HospitalConfig {
     pub emergency_protocols: Vec<EmergencyProtocol>,
 }
 
-/// --------------------
-/// Storage Keys
-/// --------------------
 #[contracttype]
 pub enum DataKey {
     Hospital(Address),
@@ -123,10 +129,25 @@ pub struct HospitalRegistry;
 
 #[contractimpl]
 impl HospitalRegistry {
-    fn assert_hospital_exists(env: &Env, wallet: &Address) -> Result<(), ContractError> {
-        let key = DataKey::Hospital(wallet.clone());
-        if !env.storage().persistent().has(&key) {
-            return Err(ContractError::HospitalNotFound);
+    fn load_hospital(env: &Env, wallet: &Address) -> Result<HospitalData, ContractError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Hospital(wallet.clone()))
+            .ok_or(ContractError::HospitalNotFound)
+    }
+
+    fn assert_active_hospital(env: &Env, wallet: &Address) -> Result<HospitalData, ContractError> {
+        let hospital = Self::load_hospital(env, wallet)?;
+        Self::assert_active_credential(env, &hospital.credential)?;
+        Ok(hospital)
+    }
+
+    fn assert_active_credential(env: &Env, credential: &CredentialAnchor) -> Result<(), ContractError> {
+        if credential.revoked_at.is_some() {
+            return Err(ContractError::CredentialRevoked);
+        }
+        if credential.expires_at <= env.ledger().timestamp() {
+            return Err(ContractError::CredentialExpired);
         }
         Ok(())
     }
@@ -148,38 +169,48 @@ impl HospitalRegistry {
         }
     }
 
-    /// Register a new hospital with basic information
-    ///
-    /// # Arguments
-    /// * `wallet` - The wallet address of the hospital
-    /// * `name` - The name of the hospital
-    /// * `location` - The physical location/address of the hospital
-    /// * `metadata` - Additional information (services, departments, etc.)
     pub fn register_hospital(
         env: Env,
         wallet: Address,
         name: String,
         location: String,
         metadata: String,
+        issuer: Address,
+        credential_hash: BytesN<32>,
+        attestation_hash: BytesN<32>,
+        expires_at: u64,
+        revocation_reference: BytesN<32>,
     ) -> Result<(), ContractError> {
         wallet.require_auth();
+        issuer.require_auth();
 
         let key = DataKey::Hospital(wallet.clone());
         if env.storage().persistent().has(&key) {
             return Err(ContractError::HospitalAlreadyRegistered);
+        }
+        if expires_at <= env.ledger().timestamp() {
+            return Err(ContractError::CredentialExpired);
         }
 
         let hospital = HospitalData {
             name,
             location,
             metadata,
+            credential: CredentialAnchor {
+                credential_hash,
+                issuer,
+                attestation_hash,
+                expires_at,
+                revocation_reference,
+                revoked_at: None,
+            },
         };
 
         env.storage().persistent().set(&key, &hospital);
-
-        let config_key = DataKey::HospitalConfig(wallet.clone());
-        let config = Self::default_config(&env);
-        env.storage().persistent().set(&config_key, &config);
+        env.storage().persistent().set(
+            &DataKey::HospitalConfig(wallet.clone()),
+            &Self::default_config(&env),
+        );
 
         env.events().publish(
             (symbol_short!("reg_hosp"), wallet),
@@ -188,27 +219,14 @@ impl HospitalRegistry {
         Ok(())
     }
 
-    /// Update hospital metadata
-    ///
-    /// # Arguments
-    /// * `wallet` - The wallet address of the hospital
-    /// * `metadata` - Updated metadata information
     pub fn update_hospital(env: Env, wallet: Address, metadata: String) -> Result<(), ContractError> {
         wallet.require_auth();
 
-        let key = DataKey::Hospital(wallet.clone());
-        let mut hospital: HospitalData = env
-            .storage()
-            .persistent()
-            .get(&key)
-
-            .unwrap_or_else(|| panic!("Hospital not found"));
-
-            .ok_or(ContractError::HospitalNotFound)?;
-
-
+        let mut hospital = Self::assert_active_hospital(&env, &wallet)?;
         hospital.metadata = metadata;
-        env.storage().persistent().set(&key, &hospital);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Hospital(wallet.clone()), &hospital);
 
         env.events().publish(
             (symbol_short!("upd_hosp"), wallet),
@@ -217,32 +235,25 @@ impl HospitalRegistry {
         Ok(())
     }
 
-    /// Retrieve hospital data by wallet address
-    ///
-    /// # Arguments
-    /// * `wallet` - The wallet address of the hospital
-    ///
-    /// # Returns
-    /// The HospitalData for the given wallet address
     pub fn get_hospital(env: Env, wallet: Address) -> Result<HospitalData, ContractError> {
-        let key = DataKey::Hospital(wallet);
-        env.storage()
-            .persistent()
-            .get(&key)
-
-            .unwrap_or_else(|| panic!("Hospital not found"))
-
-            .ok_or(ContractError::HospitalNotFound)
-
+        Self::load_hospital(&env, &wallet)
     }
 
-    /// Set full hospital configuration in one call
-    pub fn set_hospital_config(env: Env, wallet: Address, config: HospitalConfig) -> Result<(), ContractError> {
-        wallet.require_auth();
-        Self::assert_hospital_exists(&env, &wallet)?;
+    pub fn is_hospital_active(env: Env, wallet: Address) -> bool {
+        Self::assert_active_hospital(&env, &wallet).is_ok()
+    }
 
-        let key = DataKey::HospitalConfig(wallet.clone());
-        env.storage().persistent().set(&key, &config);
+    pub fn set_hospital_config(
+        env: Env,
+        wallet: Address,
+        config: HospitalConfig,
+    ) -> Result<(), ContractError> {
+        wallet.require_auth();
+        Self::assert_active_hospital(&env, &wallet)?;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::HospitalConfig(wallet.clone()), &config);
 
         env.events()
             .publish((symbol_short!("cfg_set"), wallet), symbol_short!("success"));
@@ -250,133 +261,94 @@ impl HospitalRegistry {
     }
 
     pub fn get_hospital_config(env: Env, wallet: Address) -> Result<HospitalConfig, ContractError> {
-        let key = DataKey::HospitalConfig(wallet);
         env.storage()
             .persistent()
-            .get(&key)
-
-            .unwrap_or_else(|| panic!("Hospital config not found"))
-
+            .get(&DataKey::HospitalConfig(wallet))
             .ok_or(ContractError::HospitalConfigNotFound)
-
     }
 
-    pub fn update_departments(env: Env, wallet: Address, departments: Vec<Department>) -> Result<(), ContractError> {
+    pub fn update_departments(
+        env: Env,
+        wallet: Address,
+        departments: Vec<Department>,
+    ) -> Result<(), ContractError> {
         wallet.require_auth();
-        Self::assert_hospital_exists(&env, &wallet)?;
-
-        let key = DataKey::HospitalConfig(wallet.clone());
-        let mut config: HospitalConfig = env
-            .storage()
-            .persistent()
-            .get(&key)
-
-            .unwrap_or_else(|| panic!("Hospital config not found"));
-
-            .ok_or(ContractError::HospitalConfigNotFound)?;
-
-
+        Self::assert_active_hospital(&env, &wallet)?;
+        let mut config = Self::get_hospital_config(env.clone(), wallet.clone())?;
         config.departments = departments;
-        env.storage().persistent().set(&key, &config);
-
-        env.events().publish(
-            (symbol_short!("upd_dept"), wallet),
-            symbol_short!("success"),
-        );
+        env.storage()
+            .persistent()
+            .set(&DataKey::HospitalConfig(wallet.clone()), &config);
+        env.events()
+            .publish((symbol_short!("upd_dept"), wallet), symbol_short!("success"));
         Ok(())
     }
 
-    pub fn update_locations(env: Env, wallet: Address, locations: Vec<Location>) -> Result<(), ContractError> {
+    pub fn update_locations(
+        env: Env,
+        wallet: Address,
+        locations: Vec<Location>,
+    ) -> Result<(), ContractError> {
         wallet.require_auth();
-        Self::assert_hospital_exists(&env, &wallet)?;
-
-        let key = DataKey::HospitalConfig(wallet.clone());
-        let mut config: HospitalConfig = env
-            .storage()
-            .persistent()
-            .get(&key)
-
-            .unwrap_or_else(|| panic!("Hospital config not found"));
-
-            .ok_or(ContractError::HospitalConfigNotFound)?;
-
-
+        Self::assert_active_hospital(&env, &wallet)?;
+        let mut config = Self::get_hospital_config(env.clone(), wallet.clone())?;
         config.locations = locations;
-        env.storage().persistent().set(&key, &config);
-
+        env.storage()
+            .persistent()
+            .set(&DataKey::HospitalConfig(wallet.clone()), &config);
         env.events()
             .publish((symbol_short!("upd_loc"), wallet), symbol_short!("success"));
         Ok(())
     }
 
-    pub fn update_equipment(env: Env, wallet: Address, equipment: Vec<EquipmentResource>) -> Result<(), ContractError> {
+    pub fn update_equipment(
+        env: Env,
+        wallet: Address,
+        equipment: Vec<EquipmentResource>,
+    ) -> Result<(), ContractError> {
         wallet.require_auth();
-        Self::assert_hospital_exists(&env, &wallet)?;
-
-        let key = DataKey::HospitalConfig(wallet.clone());
-        let mut config: HospitalConfig = env
-            .storage()
-            .persistent()
-            .get(&key)
-
-            .unwrap_or_else(|| panic!("Hospital config not found"));
-
-            .ok_or(ContractError::HospitalConfigNotFound)?;
-
-
+        Self::assert_active_hospital(&env, &wallet)?;
+        let mut config = Self::get_hospital_config(env.clone(), wallet.clone())?;
         config.equipment = equipment;
-        env.storage().persistent().set(&key, &config);
-
+        env.storage()
+            .persistent()
+            .set(&DataKey::HospitalConfig(wallet.clone()), &config);
         env.events()
             .publish((symbol_short!("upd_eq"), wallet), symbol_short!("success"));
         Ok(())
     }
 
-    pub fn update_policies(env: Env, wallet: Address, policies: Vec<PolicyProcedure>) -> Result<(), ContractError> {
+    pub fn update_policies(
+        env: Env,
+        wallet: Address,
+        policies: Vec<PolicyProcedure>,
+    ) -> Result<(), ContractError> {
         wallet.require_auth();
-        Self::assert_hospital_exists(&env, &wallet)?;
-
-        let key = DataKey::HospitalConfig(wallet.clone());
-        let mut config: HospitalConfig = env
-            .storage()
-            .persistent()
-            .get(&key)
-
-            .unwrap_or_else(|| panic!("Hospital config not found"));
-
-            .ok_or(ContractError::HospitalConfigNotFound)?;
-
-
+        Self::assert_active_hospital(&env, &wallet)?;
+        let mut config = Self::get_hospital_config(env.clone(), wallet.clone())?;
         config.policies = policies;
-        env.storage().persistent().set(&key, &config);
-
+        env.storage()
+            .persistent()
+            .set(&DataKey::HospitalConfig(wallet.clone()), &config);
         env.events()
             .publish((symbol_short!("upd_pol"), wallet), symbol_short!("success"));
         Ok(())
     }
 
-    pub fn update_alerts(env: Env, wallet: Address, alerts: Vec<AlertSetting>) -> Result<(), ContractError> {
+    pub fn update_alerts(
+        env: Env,
+        wallet: Address,
+        alerts: Vec<AlertSetting>,
+    ) -> Result<(), ContractError> {
         wallet.require_auth();
-        Self::assert_hospital_exists(&env, &wallet)?;
-
-        let key = DataKey::HospitalConfig(wallet.clone());
-        let mut config: HospitalConfig = env
-            .storage()
-            .persistent()
-            .get(&key)
-
-            .unwrap_or_else(|| panic!("Hospital config not found"));
-
-            .ok_or(ContractError::HospitalConfigNotFound)?;
-
-
+        Self::assert_active_hospital(&env, &wallet)?;
+        let mut config = Self::get_hospital_config(env.clone(), wallet.clone())?;
         config.alerts = alerts;
-        env.storage().persistent().set(&key, &config);
-
-        env.events().publish(
-            (symbol_short!("upd_alrt"), wallet),
-            symbol_short!("success"),
-        );
+        env.storage()
+            .persistent()
+            .set(&DataKey::HospitalConfig(wallet.clone()), &config);
+        env.events()
+            .publish((symbol_short!("upd_alrt"), wallet), symbol_short!("success"));
         Ok(())
     }
 
@@ -386,49 +358,31 @@ impl HospitalRegistry {
         insurance_providers: Vec<InsuranceProviderConfig>,
     ) -> Result<(), ContractError> {
         wallet.require_auth();
-        Self::assert_hospital_exists(&env, &wallet)?;
-
-        let key = DataKey::HospitalConfig(wallet.clone());
-        let mut config: HospitalConfig = env
-            .storage()
-            .persistent()
-            .get(&key)
-
-            .unwrap_or_else(|| panic!("Hospital config not found"));
-
-            .ok_or(ContractError::HospitalConfigNotFound)?;
-
-
+        Self::assert_active_hospital(&env, &wallet)?;
+        let mut config = Self::get_hospital_config(env.clone(), wallet.clone())?;
         config.insurance_providers = insurance_providers;
-        env.storage().persistent().set(&key, &config);
-
+        env.storage()
+            .persistent()
+            .set(&DataKey::HospitalConfig(wallet.clone()), &config);
         env.events()
             .publish((symbol_short!("upd_ins"), wallet), symbol_short!("success"));
         Ok(())
     }
 
-    pub fn update_billing(env: Env, wallet: Address, billing: BillingConfig) -> Result<(), ContractError> {
+    pub fn update_billing(
+        env: Env,
+        wallet: Address,
+        billing: BillingConfig,
+    ) -> Result<(), ContractError> {
         wallet.require_auth();
-        Self::assert_hospital_exists(&env, &wallet)?;
-
-        let key = DataKey::HospitalConfig(wallet.clone());
-        let mut config: HospitalConfig = env
-            .storage()
-            .persistent()
-            .get(&key)
-
-            .unwrap_or_else(|| panic!("Hospital config not found"));
-
-            .ok_or(ContractError::HospitalConfigNotFound)?;
-
-
+        Self::assert_active_hospital(&env, &wallet)?;
+        let mut config = Self::get_hospital_config(env.clone(), wallet.clone())?;
         config.billing = billing;
-        env.storage().persistent().set(&key, &config);
-
-        env.events().publish(
-            (symbol_short!("upd_bill"), wallet),
-            symbol_short!("success"),
-        );
+        env.storage()
+            .persistent()
+            .set(&DataKey::HospitalConfig(wallet.clone()), &config);
+        env.events()
+            .publish((symbol_short!("upd_bill"), wallet), symbol_short!("success"));
         Ok(())
     }
 
@@ -438,22 +392,12 @@ impl HospitalRegistry {
         protocols: Vec<EmergencyProtocol>,
     ) -> Result<(), ContractError> {
         wallet.require_auth();
-        Self::assert_hospital_exists(&env, &wallet)?;
-
-        let key = DataKey::HospitalConfig(wallet.clone());
-        let mut config: HospitalConfig = env
-            .storage()
-            .persistent()
-            .get(&key)
-
-            .unwrap_or_else(|| panic!("Hospital config not found"));
-
-            .ok_or(ContractError::HospitalConfigNotFound)?;
-
-
+        Self::assert_active_hospital(&env, &wallet)?;
+        let mut config = Self::get_hospital_config(env.clone(), wallet.clone())?;
         config.emergency_protocols = protocols;
-        env.storage().persistent().set(&key, &config);
-
+        env.storage()
+            .persistent()
+            .set(&DataKey::HospitalConfig(wallet.clone()), &config);
         env.events()
             .publish((symbol_short!("upd_emg"), wallet), symbol_short!("success"));
         Ok(())

--- a/contracts/hospital-registry/src/test.rs
+++ b/contracts/hospital-registry/src/test.rs
@@ -1,6 +1,30 @@
 #![cfg(test)]
+
 use super::*;
-use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, BytesN, Env, String, Vec};
+
+fn dummy_hash(env: &Env, byte: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[byte; 32])
+}
+
+fn register_hospital_with_anchor(
+    env: &Env,
+    client: &HospitalRegistryClient<'_>,
+    hospital_wallet: &Address,
+) {
+    let issuer = Address::generate(env);
+    client.register_hospital(
+        hospital_wallet,
+        &String::from_str(env, "General Hospital"),
+        &String::from_str(env, "123 Main St, New York, NY"),
+        &String::from_str(env, "Services: ER, Surgery, Cardiology"),
+        &issuer,
+        &dummy_hash(env, 1),
+        &dummy_hash(env, 2),
+        &4_100_000_000_u64,
+        &dummy_hash(env, 3),
+    );
+}
 
 #[test]
 fn test_register_hospital() {
@@ -11,15 +35,9 @@ fn test_register_hospital() {
     let hospital_wallet = Address::generate(&env);
     env.mock_all_auths();
 
-    client.register_hospital(
-        &hospital_wallet,
-        &String::from_str(&env, "General Hospital"),
-        &String::from_str(&env, "123 Main St, New York, NY"),
-        &String::from_str(&env, "Services: ER, Surgery, Cardiology"),
-    );
+    register_hospital_with_anchor(&env, &client, &hospital_wallet);
 
     let hospital = client.get_hospital(&hospital_wallet);
-
     assert_eq!(hospital.name, String::from_str(&env, "General Hospital"));
     assert_eq!(
         hospital.location,
@@ -29,6 +47,7 @@ fn test_register_hospital() {
         hospital.metadata,
         String::from_str(&env, "Services: ER, Surgery, Cardiology")
     );
+    assert_eq!(hospital.credential.credential_hash, dummy_hash(&env, 1));
 }
 
 #[test]
@@ -40,12 +59,7 @@ fn test_update_hospital() {
     let hospital_wallet = Address::generate(&env);
     env.mock_all_auths();
 
-    client.register_hospital(
-        &hospital_wallet,
-        &String::from_str(&env, "City Hospital"),
-        &String::from_str(&env, "456 Oak Ave"),
-        &String::from_str(&env, "General Services"),
-    );
+    register_hospital_with_anchor(&env, &client, &hospital_wallet);
 
     client.update_hospital(
         &hospital_wallet,
@@ -53,12 +67,11 @@ fn test_update_hospital() {
     );
 
     let hospital = client.get_hospital(&hospital_wallet);
-
     assert_eq!(
         hospital.metadata,
         String::from_str(&env, "Services: ER, ICU, Pediatrics, Oncology")
     );
-    assert_eq!(hospital.name, String::from_str(&env, "City Hospital"));
+    assert_eq!(hospital.name, String::from_str(&env, "General Hospital"));
 }
 
 #[test]
@@ -70,18 +83,19 @@ fn test_duplicate_registration() {
     let hospital_wallet = Address::generate(&env);
     env.mock_all_auths();
 
-    client.register_hospital(
-        &hospital_wallet,
-        &String::from_str(&env, "Test Hospital"),
-        &String::from_str(&env, "Test Location"),
-        &String::from_str(&env, "Test Metadata"),
-    );
+    register_hospital_with_anchor(&env, &client, &hospital_wallet);
 
+    let issuer = Address::generate(&env);
     let result = client.try_register_hospital(
         &hospital_wallet,
         &String::from_str(&env, "Test Hospital"),
         &String::from_str(&env, "Test Location"),
         &String::from_str(&env, "Test Metadata"),
+        &issuer,
+        &dummy_hash(&env, 4),
+        &dummy_hash(&env, 5),
+        &4_100_000_000_u64,
+        &dummy_hash(&env, 6),
     );
 
     assert_eq!(result, Err(Ok(ContractError::HospitalAlreadyRegistered)));
@@ -116,6 +130,40 @@ fn test_update_nonexistent_hospital() {
 }
 
 #[test]
+fn test_expired_hospital_credential_disables_membership() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, HospitalRegistry);
+    let client = HospitalRegistryClient::new(&env, &contract_id);
+
+    let hospital_wallet = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 100);
+
+    client.register_hospital(
+        &hospital_wallet,
+        &String::from_str(&env, "City Hospital"),
+        &String::from_str(&env, "456 Oak Ave"),
+        &String::from_str(&env, "General Services"),
+        &issuer,
+        &dummy_hash(&env, 1),
+        &dummy_hash(&env, 2),
+        &150_u64,
+        &dummy_hash(&env, 3),
+    );
+    assert!(client.is_hospital_active(&hospital_wallet));
+
+    env.ledger().with_mut(|li| li.timestamp = 151);
+    assert!(!client.is_hospital_active(&hospital_wallet));
+
+    let result = client.try_update_hospital(
+        &hospital_wallet,
+        &String::from_str(&env, "Should fail"),
+    );
+    assert_eq!(result, Err(Ok(ContractError::CredentialExpired)));
+}
+
+#[test]
 fn test_hospital_config_flow() {
     let env = Env::default();
     let contract_id = env.register_contract(None, HospitalRegistry);
@@ -124,12 +172,7 @@ fn test_hospital_config_flow() {
     let hospital_wallet = Address::generate(&env);
     env.mock_all_auths();
 
-    client.register_hospital(
-        &hospital_wallet,
-        &String::from_str(&env, "Regional Medical Center"),
-        &String::from_str(&env, "789 Pine Rd"),
-        &String::from_str(&env, "Accredited, trauma level II"),
-    );
+    register_hospital_with_anchor(&env, &client, &hospital_wallet);
 
     let mut departments: Vec<Department> = Vec::new(&env);
     departments.push_back(Department {

--- a/contracts/hospital-registry/test_snapshots/test/test_duplicate_registration.1.json
+++ b/contracts/hospital-registry/test_snapshots/test/test_duplicate_registration.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 2,
+    "address": 4,
     "nonce": 0,
     "mux_id": 0
   },
@@ -19,13 +19,69 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "string": "Test Hospital"
+                  "string": "General Hospital"
                 },
                 {
-                  "string": "Test Location"
+                  "string": "123 Main St, New York, NY"
                 },
                 {
-                  "string": "Test Metadata"
+                  "string": "Services: ER, Surgery, Cardiology"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_hospital",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "General Hospital"
+                },
+                {
+                  "string": "123 Main St, New York, NY"
+                },
+                {
+                  "string": "Services: ER, Surgery, Cardiology"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
                 }
               ]
             }
@@ -85,10 +141,65 @@
                   "map": [
                     {
                       "key": {
+                        "symbol": "credential"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "attestation_hash"
+                            },
+                            "val": {
+                              "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "credential_hash"
+                            },
+                            "val": {
+                              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "expires_at"
+                            },
+                            "val": {
+                              "u64": "4100000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "issuer"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revocation_reference"
+                            },
+                            "val": {
+                              "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revoked_at"
+                            },
+                            "val": "void"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "location"
                       },
                       "val": {
-                        "string": "Test Location"
+                        "string": "123 Main St, New York, NY"
                       }
                     },
                     {
@@ -96,7 +207,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "string": "Test Metadata"
+                        "string": "Services: ER, Surgery, Cardiology"
                       }
                     },
                     {
@@ -104,7 +215,7 @@
                         "symbol": "name"
                       },
                       "val": {
-                        "string": "Test Hospital"
+                        "string": "General Hospital"
                       }
                     }
                   ]
@@ -305,6 +416,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
                   }
                 },
                 "durability": "temporary",

--- a/contracts/hospital-registry/test_snapshots/test/test_expired_hospital_credential_disables_membership.1.json
+++ b/contracts/hospital-registry/test_snapshots/test/test_expired_hospital_credential_disables_membership.1.json
@@ -19,13 +19,13 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "string": "General Hospital"
+                  "string": "City Hospital"
                 },
                 {
-                  "string": "123 Main St, New York, NY"
+                  "string": "456 Oak Ave"
                 },
                 {
-                  "string": "Services: ER, Surgery, Cardiology"
+                  "string": "General Services"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
@@ -37,7 +37,7 @@
                   "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
                 },
                 {
-                  "u64": "4100000000"
+                  "u64": "150"
                 },
                 {
                   "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
@@ -60,13 +60,13 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "string": "General Hospital"
+                  "string": "City Hospital"
                 },
                 {
-                  "string": "123 Main St, New York, NY"
+                  "string": "456 Oak Ave"
                 },
                 {
-                  "string": "Services: ER, Surgery, Cardiology"
+                  "string": "General Services"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
@@ -78,7 +78,7 @@
                   "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
                 },
                 {
-                  "u64": "4100000000"
+                  "u64": "150"
                 },
                 {
                   "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
@@ -90,12 +90,14 @@
         }
       ]
     ],
+    [],
+    [],
     []
   ],
   "ledger": {
     "protocol_version": 23,
     "sequence_number": 0,
-    "timestamp": 0,
+    "timestamp": 151,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
     "min_persistent_entry_ttl": 4096,
@@ -166,7 +168,7 @@
                               "symbol": "expires_at"
                             },
                             "val": {
-                              "u64": "4100000000"
+                              "u64": "150"
                             }
                           },
                           {
@@ -199,7 +201,7 @@
                         "symbol": "location"
                       },
                       "val": {
-                        "string": "123 Main St, New York, NY"
+                        "string": "456 Oak Ave"
                       }
                     },
                     {
@@ -207,7 +209,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "string": "Services: ER, Surgery, Cardiology"
+                        "string": "General Services"
                       }
                     },
                     {
@@ -215,7 +217,7 @@
                         "symbol": "name"
                       },
                       "val": {
-                        "string": "General Hospital"
+                        "string": "City Hospital"
                       }
                     }
                   ]

--- a/contracts/hospital-registry/test_snapshots/test/test_hospital_config_flow.1.json
+++ b/contracts/hospital-registry/test_snapshots/test/test_hospital_config_flow.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 2,
+    "address": 3,
     "nonce": 0,
     "mux_id": 0
   },
@@ -19,13 +19,69 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "string": "Regional Medical Center"
+                  "string": "General Hospital"
                 },
                 {
-                  "string": "789 Pine Rd"
+                  "string": "123 Main St, New York, NY"
                 },
                 {
-                  "string": "Accredited, trauma level II"
+                  "string": "Services: ER, Surgery, Cardiology"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_hospital",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "General Hospital"
+                },
+                {
+                  "string": "123 Main St, New York, NY"
+                },
+                {
+                  "string": "Services: ER, Surgery, Cardiology"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
                 }
               ]
             }
@@ -498,10 +554,65 @@
                   "map": [
                     {
                       "key": {
+                        "symbol": "credential"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "attestation_hash"
+                            },
+                            "val": {
+                              "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "credential_hash"
+                            },
+                            "val": {
+                              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "expires_at"
+                            },
+                            "val": {
+                              "u64": "4100000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "issuer"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revocation_reference"
+                            },
+                            "val": {
+                              "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revoked_at"
+                            },
+                            "val": "void"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "location"
                       },
                       "val": {
-                        "string": "789 Pine Rd"
+                        "string": "123 Main St, New York, NY"
                       }
                     },
                     {
@@ -509,7 +620,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "string": "Accredited, trauma level II"
+                        "string": "Services: ER, Surgery, Cardiology"
                       }
                     },
                     {
@@ -517,7 +628,7 @@
                         "symbol": "name"
                       },
                       "val": {
-                        "string": "Regional Medical Center"
+                        "string": "General Hospital"
                       }
                     }
                   ]
@@ -1017,7 +1128,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "5541220902715666415"
+                "nonce": "4837995959683129791"
               }
             },
             "durability": "temporary"
@@ -1030,6 +1141,39 @@
               "contract_data": {
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "4837995959683129791"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "5541220902715666415"

--- a/contracts/hospital-registry/test_snapshots/test/test_update_hospital.1.json
+++ b/contracts/hospital-registry/test_snapshots/test/test_update_hospital.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 2,
+    "address": 3,
     "nonce": 0,
     "mux_id": 0
   },
@@ -19,13 +19,69 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "string": "City Hospital"
+                  "string": "General Hospital"
                 },
                 {
-                  "string": "456 Oak Ave"
+                  "string": "123 Main St, New York, NY"
                 },
                 {
-                  "string": "General Services"
+                  "string": "Services: ER, Surgery, Cardiology"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_hospital",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "General Hospital"
+                },
+                {
+                  "string": "123 Main St, New York, NY"
+                },
+                {
+                  "string": "Services: ER, Surgery, Cardiology"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
                 }
               ]
             }
@@ -107,10 +163,65 @@
                   "map": [
                     {
                       "key": {
+                        "symbol": "credential"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "attestation_hash"
+                            },
+                            "val": {
+                              "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "credential_hash"
+                            },
+                            "val": {
+                              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "expires_at"
+                            },
+                            "val": {
+                              "u64": "4100000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "issuer"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revocation_reference"
+                            },
+                            "val": {
+                              "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revoked_at"
+                            },
+                            "val": "void"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "location"
                       },
                       "val": {
-                        "string": "456 Oak Ave"
+                        "string": "123 Main St, New York, NY"
                       }
                     },
                     {
@@ -126,7 +237,7 @@
                         "symbol": "name"
                       },
                       "val": {
-                        "string": "City Hospital"
+                        "string": "General Hospital"
                       }
                     }
                   ]
@@ -344,7 +455,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "5541220902715666415"
+                "nonce": "1033654523790656264"
               }
             },
             "durability": "temporary"
@@ -357,6 +468,39 @@
               "contract_data": {
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "5541220902715666415"

--- a/contracts/insurer-registry/src/lib.rs
+++ b/contracts/insurer-registry/src/lib.rs
@@ -1,7 +1,10 @@
 #![no_std]
 #![allow(deprecated)]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
+    String, Vec,
+};
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -13,12 +16,21 @@ pub enum ContractError {
     ReviewerNotFound = 4,
     InsurerNotFound = 5,
     NoReviewersFound = 6,
+    CredentialExpired = 7,
+    CredentialRevoked = 8,
 }
 
-/// --------------------
-/// Insurer Structures
-/// --------------------
-/// Represents insurance company information stored on-chain
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CredentialAnchor {
+    pub credential_hash: BytesN<32>,
+    pub issuer: Address,
+    pub attestation_hash: BytesN<32>,
+    pub expires_at: u64,
+    pub revocation_reference: BytesN<32>,
+    pub revoked_at: Option<u64>,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InsurerData {
@@ -27,15 +39,13 @@ pub struct InsurerData {
     pub contact_details: String,
     pub coverage_policies: String,
     pub metadata: String,
+    pub credential: CredentialAnchor,
 }
 
-/// --------------------
-/// Storage Keys
-/// --------------------
 #[contracttype]
 pub enum DataKey {
     Insurer(Address),
-    ClaimsReviewers(Address), // Maps insurer wallet to list of approved reviewers
+    ClaimsReviewers(Address),
 }
 
 #[contract]
@@ -43,28 +53,45 @@ pub struct InsurerRegistry;
 
 #[contractimpl]
 impl InsurerRegistry {
-    /// Register a new insurance company with comprehensive information
-    ///
-    /// # Arguments
-    /// * `wallet` - The wallet address of the insurance company
-    /// * `name` - The name of the insurance company
-    /// * `license_id` - Government-issued insurance license identifier
-    /// * `metadata` - Additional information (contact details, coverage policies, etc.)
-    ///
-    /// # Panics
-    /// Panics if the insurer is already registered
+    fn load_insurer(env: &Env, wallet: &Address) -> Result<InsurerData, ContractError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Insurer(wallet.clone()))
+            .ok_or(ContractError::InsurerNotFound)
+    }
+
+    fn assert_active_insurer(env: &Env, wallet: &Address) -> Result<InsurerData, ContractError> {
+        let insurer = Self::load_insurer(env, wallet)?;
+        if insurer.credential.revoked_at.is_some() {
+            return Err(ContractError::CredentialRevoked);
+        }
+        if insurer.credential.expires_at <= env.ledger().timestamp() {
+            return Err(ContractError::CredentialExpired);
+        }
+        Ok(insurer)
+    }
+
     pub fn register_insurer(
         env: Env,
         wallet: Address,
         name: String,
         license_id: String,
         metadata: String,
+        issuer: Address,
+        credential_hash: BytesN<32>,
+        attestation_hash: BytesN<32>,
+        expires_at: u64,
+        revocation_reference: BytesN<32>,
     ) -> Result<(), ContractError> {
         wallet.require_auth();
+        issuer.require_auth();
 
         let key = DataKey::Insurer(wallet.clone());
         if env.storage().persistent().has(&key) {
             return Err(ContractError::AlreadyRegistered);
+        }
+        if expires_at <= env.ledger().timestamp() {
+            return Err(ContractError::CredentialExpired);
         }
 
         let insurer = InsurerData {
@@ -73,63 +100,52 @@ impl InsurerRegistry {
             contact_details: String::from_str(&env, ""),
             coverage_policies: String::from_str(&env, ""),
             metadata,
+            credential: CredentialAnchor {
+                credential_hash,
+                issuer,
+                attestation_hash,
+                expires_at,
+                revocation_reference,
+                revoked_at: None,
+            },
         };
 
         env.storage().persistent().set(&key, &insurer);
-
-        // Initialize empty claims reviewers list
-        let reviewers_key = DataKey::ClaimsReviewers(wallet.clone());
-        let reviewers: Vec<Address> = Vec::new(&env);
-        env.storage().persistent().set(&reviewers_key, &reviewers);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ClaimsReviewers(wallet.clone()), &Vec::<Address>::new(&env));
 
         env.events()
             .publish((symbol_short!("reg_ins"), wallet), symbol_short!("success"));
         Ok(())
     }
 
-    /// Update insurance company metadata and operational information
-    ///
-    /// # Arguments
-    /// * `wallet` - The wallet address of the insurance company
-    /// * `metadata` - Updated metadata information
-    ///
-    /// # Panics
-    /// Panics if the insurer is not found
     pub fn update_insurer(env: Env, wallet: Address, metadata: String) -> Result<(), ContractError> {
         wallet.require_auth();
 
-        let key = DataKey::Insurer(wallet.clone());
-        let mut insurer: InsurerData = env
-            .storage()
-            .persistent()
-            .get(&key)
-            .ok_or(ContractError::InsurerNotFound)?;
-
+        let mut insurer = Self::assert_active_insurer(&env, &wallet)?;
         insurer.metadata = metadata;
-        env.storage().persistent().set(&key, &insurer);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Insurer(wallet.clone()), &insurer);
 
         env.events()
             .publish((symbol_short!("upd_ins"), wallet), symbol_short!("success"));
         Ok(())
     }
 
-    /// Update insurance company contact details
-    ///
-    /// # Arguments
-    /// * `wallet` - The wallet address of the insurance company
-    /// * `contact_details` - Updated contact information (phone, email, address)
-    pub fn update_contact_details(env: Env, wallet: Address, contact_details: String) -> Result<(), ContractError> {
+    pub fn update_contact_details(
+        env: Env,
+        wallet: Address,
+        contact_details: String,
+    ) -> Result<(), ContractError> {
         wallet.require_auth();
 
-        let key = DataKey::Insurer(wallet.clone());
-        let mut insurer: InsurerData = env
-            .storage()
-            .persistent()
-            .get(&key)
-            .ok_or(ContractError::InsurerNotFound)?;
-
+        let mut insurer = Self::assert_active_insurer(&env, &wallet)?;
         insurer.contact_details = contact_details;
-        env.storage().persistent().set(&key, &insurer);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Insurer(wallet.clone()), &insurer);
 
         env.events().publish(
             (symbol_short!("upd_cntct"), wallet),
@@ -138,67 +154,39 @@ impl InsurerRegistry {
         Ok(())
     }
 
-    /// Update insurance company coverage policies
-    ///
-    /// # Arguments
-    /// * `wallet` - The wallet address of the insurance company
-    /// * `coverage_policies` - Updated coverage policy information
-    pub fn update_coverage_policies(env: Env, wallet: Address, coverage_policies: String) -> Result<(), ContractError> {
+    pub fn update_coverage_policies(
+        env: Env,
+        wallet: Address,
+        coverage_policies: String,
+    ) -> Result<(), ContractError> {
         wallet.require_auth();
 
-        let key = DataKey::Insurer(wallet.clone());
-        let mut insurer: InsurerData = env
-            .storage()
-            .persistent()
-            .get(&key)
-            .ok_or(ContractError::InsurerNotFound)?;
-
+        let mut insurer = Self::assert_active_insurer(&env, &wallet)?;
         insurer.coverage_policies = coverage_policies;
-        env.storage().persistent().set(&key, &insurer);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Insurer(wallet.clone()), &insurer);
 
         env.events()
             .publish((symbol_short!("upd_cov"), wallet), symbol_short!("success"));
         Ok(())
     }
 
-    /// Retrieve insurance company data by wallet address
-    ///
-    /// # Arguments
-    /// * `wallet` - The wallet address of the insurance company
-    ///
-    /// # Returns
-    /// The InsurerData for the given wallet address
-    ///
-    /// # Panics
-    /// Panics if the insurer is not found
     pub fn get_insurer(env: Env, wallet: Address) -> Result<InsurerData, ContractError> {
-        let key = DataKey::Insurer(wallet);
-        env.storage()
-            .persistent()
-            .get(&key)
-            .ok_or(ContractError::InsurerNotFound)
+        Self::load_insurer(&env, &wallet)
     }
 
-    // =====================================================
-    //            CLAIMS REVIEWERS MANAGEMENT
-    // =====================================================
+    pub fn is_insurer_active(env: Env, wallet: Address) -> bool {
+        Self::assert_active_insurer(&env, &wallet).is_ok()
+    }
 
-    /// Add a claims reviewer to the insurance company's authorized list
-    ///
-    /// # Arguments
-    /// * `insurer_wallet` - The wallet address of the insurance company
-    /// * `reviewer_wallet` - The wallet address of the claims reviewer to add
-    ///
-    /// # Panics
-    /// Panics if the insurer is not registered or reviewer already exists
-    pub fn add_claims_reviewer(env: Env, insurer_wallet: Address, reviewer_wallet: Address) -> Result<(), ContractError> {
+    pub fn add_claims_reviewer(
+        env: Env,
+        insurer_wallet: Address,
+        reviewer_wallet: Address,
+    ) -> Result<(), ContractError> {
         insurer_wallet.require_auth();
-
-        // Verify insurer exists
-        let insurer_key = DataKey::Insurer(insurer_wallet.clone());
-        if !env.storage().persistent().has(&insurer_key) {
-            return Err(ContractError::NotRegistered);
-        }
+        Self::assert_active_insurer(&env, &insurer_wallet)?;
 
         let reviewers_key = DataKey::ClaimsReviewers(insurer_wallet.clone());
         let mut reviewers: Vec<Address> = env
@@ -207,7 +195,6 @@ impl InsurerRegistry {
             .get(&reviewers_key)
             .unwrap_or(Vec::new(&env));
 
-        // Check if reviewer already exists
         for i in 0..reviewers.len() {
             if reviewers.get(i).unwrap() == reviewer_wallet {
                 return Err(ContractError::ReviewerAlreadyAuthorized);
@@ -224,16 +211,13 @@ impl InsurerRegistry {
         Ok(())
     }
 
-    /// Remove a claims reviewer from the insurance company's authorized list
-    ///
-    /// # Arguments
-    /// * `insurer_wallet` - The wallet address of the insurance company
-    /// * `reviewer_wallet` - The wallet address of the claims reviewer to remove
-    ///
-    /// # Panics
-    /// Panics if the insurer is not registered or reviewer not found
-    pub fn remove_claims_reviewer(env: Env, insurer_wallet: Address, reviewer_wallet: Address) -> Result<(), ContractError> {
+    pub fn remove_claims_reviewer(
+        env: Env,
+        insurer_wallet: Address,
+        reviewer_wallet: Address,
+    ) -> Result<(), ContractError> {
         insurer_wallet.require_auth();
+        Self::assert_active_insurer(&env, &insurer_wallet)?;
 
         let reviewers_key = DataKey::ClaimsReviewers(insurer_wallet.clone());
         let reviewers: Vec<Address> = env
@@ -269,39 +253,26 @@ impl InsurerRegistry {
         Ok(())
     }
 
-    /// Get all authorized claims reviewers for an insurance company
-    ///
-    /// # Arguments
-    /// * `insurer_wallet` - The wallet address of the insurance company
-    ///
-    /// # Returns
-    /// Vector of authorized reviewer wallet addresses
     pub fn get_claims_reviewers(env: Env, insurer_wallet: Address) -> Vec<Address> {
-        let reviewers_key = DataKey::ClaimsReviewers(insurer_wallet);
         env.storage()
             .persistent()
-            .get(&reviewers_key)
+            .get(&DataKey::ClaimsReviewers(insurer_wallet))
             .unwrap_or(Vec::new(&env))
     }
 
-    /// Check if a specific address is an authorized claims reviewer
-    ///
-    /// # Arguments
-    /// * `insurer_wallet` - The wallet address of the insurance company
-    /// * `reviewer_wallet` - The wallet address to check
-    ///
-    /// # Returns
-    /// True if the address is an authorized reviewer, false otherwise
     pub fn is_authorized_reviewer(
         env: Env,
         insurer_wallet: Address,
         reviewer_wallet: Address,
     ) -> bool {
-        let reviewers_key = DataKey::ClaimsReviewers(insurer_wallet);
+        if !Self::is_insurer_active(env.clone(), insurer_wallet.clone()) {
+            return false;
+        }
+
         let reviewers: Vec<Address> = env
             .storage()
             .persistent()
-            .get(&reviewers_key)
+            .get(&DataKey::ClaimsReviewers(insurer_wallet))
             .unwrap_or(Vec::new(&env));
 
         for i in 0..reviewers.len() {

--- a/contracts/insurer-registry/src/test.rs
+++ b/contracts/insurer-registry/src/test.rs
@@ -1,7 +1,30 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::Address as _, Env, String};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, BytesN, Env, String};
+
+fn dummy_hash(env: &Env, byte: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[byte; 32])
+}
+
+fn register_insurer_with_anchor(
+    env: &Env,
+    client: &InsurerRegistryClient<'_>,
+    insurer_wallet: &Address,
+) {
+    let issuer = Address::generate(env);
+    client.register_insurer(
+        insurer_wallet,
+        &String::from_str(env, "HealthGuard Insurance"),
+        &String::from_str(env, "INS-2026-12345"),
+        &String::from_str(env, "Full medical coverage provider"),
+        &issuer,
+        &dummy_hash(env, 1),
+        &dummy_hash(env, 2),
+        &4_100_000_000_u64,
+        &dummy_hash(env, 3),
+    );
+}
 
 #[test]
 fn test_register_insurer() {
@@ -10,39 +33,40 @@ fn test_register_insurer() {
     let client = InsurerRegistryClient::new(&env, &contract_id);
 
     let insurer_wallet = Address::generate(&env);
-    let name = String::from_str(&env, "HealthGuard Insurance");
-    let license_id = String::from_str(&env, "INS-2026-12345");
-    let metadata = String::from_str(&env, "Full medical coverage provider");
-
-    // Mock authorization
     env.mock_all_auths();
 
-    client.register_insurer(&insurer_wallet, &name, &license_id, &metadata);
+    register_insurer_with_anchor(&env, &client, &insurer_wallet);
 
-    // Verify insurer was registered
     let insurer = client.get_insurer(&insurer_wallet);
-    assert_eq!(insurer.name, name);
-    assert_eq!(insurer.license_id, license_id);
-    assert_eq!(insurer.metadata, metadata);
+    assert_eq!(insurer.name, String::from_str(&env, "HealthGuard Insurance"));
+    assert_eq!(insurer.license_id, String::from_str(&env, "INS-2026-12345"));
+    assert_eq!(insurer.metadata, String::from_str(&env, "Full medical coverage provider"));
+    assert_eq!(insurer.credential.credential_hash, dummy_hash(&env, 1));
 }
 
 #[test]
-#[should_panic(expected = "Insurer already registered")]
 fn test_duplicate_registration() {
     let env = Env::default();
     let contract_id = env.register_contract(None, InsurerRegistry);
     let client = InsurerRegistryClient::new(&env, &contract_id);
 
     let insurer_wallet = Address::generate(&env);
-    let name = String::from_str(&env, "HealthGuard Insurance");
-    let license_id = String::from_str(&env, "INS-2026-12345");
-    let metadata = String::from_str(&env, "Full medical coverage");
-
+    let issuer = Address::generate(&env);
     env.mock_all_auths();
 
-    client.register_insurer(&insurer_wallet, &name, &license_id, &metadata);
-    // Attempt to register again - should panic
-    client.register_insurer(&insurer_wallet, &name, &license_id, &metadata);
+    register_insurer_with_anchor(&env, &client, &insurer_wallet);
+    let result = client.try_register_insurer(
+        &insurer_wallet,
+        &String::from_str(&env, "HealthGuard Insurance"),
+        &String::from_str(&env, "INS-2026-12345"),
+        &String::from_str(&env, "Full medical coverage"),
+        &issuer,
+        &dummy_hash(&env, 4),
+        &dummy_hash(&env, 5),
+        &4_100_000_000_u64,
+        &dummy_hash(&env, 6),
+    );
+    assert!(matches!(result, Err(Ok(ContractError::AlreadyRegistered))));
 }
 
 #[test]
@@ -52,25 +76,19 @@ fn test_update_insurer() {
     let client = InsurerRegistryClient::new(&env, &contract_id);
 
     let insurer_wallet = Address::generate(&env);
-    let name = String::from_str(&env, "HealthGuard Insurance");
-    let license_id = String::from_str(&env, "INS-2026-12345");
-    let metadata = String::from_str(&env, "Basic coverage");
-
     env.mock_all_auths();
 
-    client.register_insurer(&insurer_wallet, &name, &license_id, &metadata);
+    register_insurer_with_anchor(&env, &client, &insurer_wallet);
 
-    // Update metadata
     let new_metadata = String::from_str(&env, "Premium coverage with dental and vision");
     client.update_insurer(&insurer_wallet, &new_metadata);
 
     let insurer = client.get_insurer(&insurer_wallet);
     assert_eq!(insurer.metadata, new_metadata);
-    assert_eq!(insurer.name, name); // Name should remain unchanged
+    assert_eq!(insurer.name, String::from_str(&env, "HealthGuard Insurance"));
 }
 
 #[test]
-#[should_panic(expected = "Insurer not found")]
 fn test_update_nonexistent_insurer() {
     let env = Env::default();
     let contract_id = env.register_contract(None, InsurerRegistry);
@@ -78,24 +96,21 @@ fn test_update_nonexistent_insurer() {
 
     let insurer_wallet = Address::generate(&env);
     let metadata = String::from_str(&env, "Updated metadata");
-
     env.mock_all_auths();
 
-    // Attempt to update non-existent insurer
-    client.update_insurer(&insurer_wallet, &metadata);
+    let result = client.try_update_insurer(&insurer_wallet, &metadata);
+    assert!(matches!(result, Err(Ok(ContractError::InsurerNotFound))));
 }
 
 #[test]
-#[should_panic(expected = "Insurer not found")]
 fn test_get_nonexistent_insurer() {
     let env = Env::default();
     let contract_id = env.register_contract(None, InsurerRegistry);
     let client = InsurerRegistryClient::new(&env, &contract_id);
 
     let insurer_wallet = Address::generate(&env);
-
-    // Attempt to get non-existent insurer
-    client.get_insurer(&insurer_wallet);
+    let result = client.try_get_insurer(&insurer_wallet);
+    assert!(matches!(result, Err(Ok(ContractError::InsurerNotFound))));
 }
 
 #[test]
@@ -105,15 +120,10 @@ fn test_update_contact_details() {
     let client = InsurerRegistryClient::new(&env, &contract_id);
 
     let insurer_wallet = Address::generate(&env);
-    let name = String::from_str(&env, "HealthGuard Insurance");
-    let license_id = String::from_str(&env, "INS-2026-12345");
-    let metadata = String::from_str(&env, "Coverage info");
-
     env.mock_all_auths();
 
-    client.register_insurer(&insurer_wallet, &name, &license_id, &metadata);
+    register_insurer_with_anchor(&env, &client, &insurer_wallet);
 
-    // Update contact details
     let contact_details = String::from_str(&env, "phone: 555-0123, email: contact@healthguard.com");
     client.update_contact_details(&insurer_wallet, &contact_details);
 
@@ -128,25 +138,16 @@ fn test_update_coverage_policies() {
     let client = InsurerRegistryClient::new(&env, &contract_id);
 
     let insurer_wallet = Address::generate(&env);
-    let name = String::from_str(&env, "HealthGuard Insurance");
-    let license_id = String::from_str(&env, "INS-2026-12345");
-    let metadata = String::from_str(&env, "Coverage info");
-
     env.mock_all_auths();
 
-    client.register_insurer(&insurer_wallet, &name, &license_id, &metadata);
+    register_insurer_with_anchor(&env, &client, &insurer_wallet);
 
-    // Update coverage policies
     let coverage = String::from_str(&env, "Medical: 80%, Dental: 50%, Vision: 100%");
     client.update_coverage_policies(&insurer_wallet, &coverage);
 
     let insurer = client.get_insurer(&insurer_wallet);
     assert_eq!(insurer.coverage_policies, coverage);
 }
-
-// =====================================================
-//         CLAIMS REVIEWERS TESTS
-// =====================================================
 
 #[test]
 fn test_add_claims_reviewer() {
@@ -156,13 +157,9 @@ fn test_add_claims_reviewer() {
 
     let insurer_wallet = Address::generate(&env);
     let reviewer_wallet = Address::generate(&env);
-    let name = String::from_str(&env, "HealthGuard Insurance");
-    let license_id = String::from_str(&env, "INS-2026-12345");
-    let metadata = String::from_str(&env, "Coverage info");
-
     env.mock_all_auths();
 
-    client.register_insurer(&insurer_wallet, &name, &license_id, &metadata);
+    register_insurer_with_anchor(&env, &client, &insurer_wallet);
     client.add_claims_reviewer(&insurer_wallet, &reviewer_wallet);
 
     let reviewers = client.get_claims_reviewers(&insurer_wallet);
@@ -180,13 +177,9 @@ fn test_add_multiple_claims_reviewers() {
     let reviewer1 = Address::generate(&env);
     let reviewer2 = Address::generate(&env);
     let reviewer3 = Address::generate(&env);
-    let name = String::from_str(&env, "HealthGuard Insurance");
-    let license_id = String::from_str(&env, "INS-2026-12345");
-    let metadata = String::from_str(&env, "Coverage info");
-
     env.mock_all_auths();
 
-    client.register_insurer(&insurer_wallet, &name, &license_id, &metadata);
+    register_insurer_with_anchor(&env, &client, &insurer_wallet);
     client.add_claims_reviewer(&insurer_wallet, &reviewer1);
     client.add_claims_reviewer(&insurer_wallet, &reviewer2);
     client.add_claims_reviewer(&insurer_wallet, &reviewer3);
@@ -196,7 +189,6 @@ fn test_add_multiple_claims_reviewers() {
 }
 
 #[test]
-#[should_panic(expected = "Reviewer already authorized")]
 fn test_add_duplicate_reviewer() {
     let env = Env::default();
     let contract_id = env.register_contract(None, InsurerRegistry);
@@ -204,20 +196,15 @@ fn test_add_duplicate_reviewer() {
 
     let insurer_wallet = Address::generate(&env);
     let reviewer_wallet = Address::generate(&env);
-    let name = String::from_str(&env, "HealthGuard Insurance");
-    let license_id = String::from_str(&env, "INS-2026-12345");
-    let metadata = String::from_str(&env, "Coverage info");
-
     env.mock_all_auths();
 
-    client.register_insurer(&insurer_wallet, &name, &license_id, &metadata);
+    register_insurer_with_anchor(&env, &client, &insurer_wallet);
     client.add_claims_reviewer(&insurer_wallet, &reviewer_wallet);
-    // Attempt to add same reviewer again - should panic
-    client.add_claims_reviewer(&insurer_wallet, &reviewer_wallet);
+    let result = client.try_add_claims_reviewer(&insurer_wallet, &reviewer_wallet);
+    assert!(matches!(result, Err(Ok(ContractError::ReviewerAlreadyAuthorized))));
 }
 
 #[test]
-#[should_panic(expected = "Insurer not registered")]
 fn test_add_reviewer_to_nonexistent_insurer() {
     let env = Env::default();
     let contract_id = env.register_contract(None, InsurerRegistry);
@@ -225,11 +212,10 @@ fn test_add_reviewer_to_nonexistent_insurer() {
 
     let insurer_wallet = Address::generate(&env);
     let reviewer_wallet = Address::generate(&env);
-
     env.mock_all_auths();
 
-    // Attempt to add reviewer to non-existent insurer
-    client.add_claims_reviewer(&insurer_wallet, &reviewer_wallet);
+    let result = client.try_add_claims_reviewer(&insurer_wallet, &reviewer_wallet);
+    assert!(matches!(result, Err(Ok(ContractError::InsurerNotFound))));
 }
 
 #[test]
@@ -240,19 +226,10 @@ fn test_remove_claims_reviewer() {
 
     let insurer_wallet = Address::generate(&env);
     let reviewer_wallet = Address::generate(&env);
-    let name = String::from_str(&env, "HealthGuard Insurance");
-    let license_id = String::from_str(&env, "INS-2026-12345");
-    let metadata = String::from_str(&env, "Coverage info");
-
     env.mock_all_auths();
 
-    client.register_insurer(&insurer_wallet, &name, &license_id, &metadata);
+    register_insurer_with_anchor(&env, &client, &insurer_wallet);
     client.add_claims_reviewer(&insurer_wallet, &reviewer_wallet);
-
-    let reviewers = client.get_claims_reviewers(&insurer_wallet);
-    assert_eq!(reviewers.len(), 1);
-
-    // Remove the reviewer
     client.remove_claims_reviewer(&insurer_wallet, &reviewer_wallet);
 
     let reviewers = client.get_claims_reviewers(&insurer_wallet);
@@ -260,7 +237,6 @@ fn test_remove_claims_reviewer() {
 }
 
 #[test]
-#[should_panic(expected = "Reviewer not found")]
 fn test_remove_nonexistent_reviewer() {
     let env = Env::default();
     let contract_id = env.register_contract(None, InsurerRegistry);
@@ -268,16 +244,12 @@ fn test_remove_nonexistent_reviewer() {
 
     let insurer_wallet = Address::generate(&env);
     let reviewer_wallet = Address::generate(&env);
-    let name = String::from_str(&env, "HealthGuard Insurance");
-    let license_id = String::from_str(&env, "INS-2026-12345");
-    let metadata = String::from_str(&env, "Coverage info");
-
     env.mock_all_auths();
 
-    client.register_insurer(&insurer_wallet, &name, &license_id, &metadata);
+    register_insurer_with_anchor(&env, &client, &insurer_wallet);
 
-    // Attempt to remove a reviewer that was never added
-    client.remove_claims_reviewer(&insurer_wallet, &reviewer_wallet);
+    let result = client.try_remove_claims_reviewer(&insurer_wallet, &reviewer_wallet);
+    assert!(matches!(result, Err(Ok(ContractError::ReviewerNotFound))));
 }
 
 #[test]
@@ -289,19 +261,12 @@ fn test_is_authorized_reviewer() {
     let insurer_wallet = Address::generate(&env);
     let reviewer_wallet = Address::generate(&env);
     let unauthorized_wallet = Address::generate(&env);
-    let name = String::from_str(&env, "HealthGuard Insurance");
-    let license_id = String::from_str(&env, "INS-2026-12345");
-    let metadata = String::from_str(&env, "Coverage info");
-
     env.mock_all_auths();
 
-    client.register_insurer(&insurer_wallet, &name, &license_id, &metadata);
+    register_insurer_with_anchor(&env, &client, &insurer_wallet);
     client.add_claims_reviewer(&insurer_wallet, &reviewer_wallet);
 
-    // Check authorized reviewer
     assert!(client.is_authorized_reviewer(&insurer_wallet, &reviewer_wallet));
-
-    // Check unauthorized address
     assert!(!client.is_authorized_reviewer(&insurer_wallet, &unauthorized_wallet));
 }
 
@@ -312,16 +277,46 @@ fn test_get_claims_reviewers_empty() {
     let client = InsurerRegistryClient::new(&env, &contract_id);
 
     let insurer_wallet = Address::generate(&env);
-    let name = String::from_str(&env, "HealthGuard Insurance");
-    let license_id = String::from_str(&env, "INS-2026-12345");
-    let metadata = String::from_str(&env, "Coverage info");
-
     env.mock_all_auths();
 
-    client.register_insurer(&insurer_wallet, &name, &license_id, &metadata);
+    register_insurer_with_anchor(&env, &client, &insurer_wallet);
 
     let reviewers = client.get_claims_reviewers(&insurer_wallet);
     assert_eq!(reviewers.len(), 0);
+}
+
+#[test]
+fn test_expired_insurer_anchor_disables_membership() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, InsurerRegistry);
+    let client = InsurerRegistryClient::new(&env, &contract_id);
+
+    let insurer_wallet = Address::generate(&env);
+    let issuer = Address::generate(&env);
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 100);
+
+    client.register_insurer(
+        &insurer_wallet,
+        &String::from_str(&env, "HealthGuard Insurance"),
+        &String::from_str(&env, "INS-2026-12345"),
+        &String::from_str(&env, "Coverage info"),
+        &issuer,
+        &dummy_hash(&env, 1),
+        &dummy_hash(&env, 2),
+        &150_u64,
+        &dummy_hash(&env, 3),
+    );
+    assert!(client.is_insurer_active(&insurer_wallet));
+
+    env.ledger().with_mut(|li| li.timestamp = 151);
+    assert!(!client.is_insurer_active(&insurer_wallet));
+
+    let result = client.try_update_contact_details(
+        &insurer_wallet,
+        &String::from_str(&env, "phone: 555-0123"),
+    );
+    assert!(matches!(result, Err(Ok(ContractError::CredentialExpired))));
 }
 
 #[test]
@@ -333,38 +328,28 @@ fn test_full_workflow() {
     let insurer_wallet = Address::generate(&env);
     let reviewer1 = Address::generate(&env);
     let reviewer2 = Address::generate(&env);
-
     env.mock_all_auths();
 
-    // Register insurer
-    let name = String::from_str(&env, "HealthGuard Insurance");
-    let license_id = String::from_str(&env, "INS-2026-12345");
-    let metadata = String::from_str(&env, "Comprehensive health coverage");
-    client.register_insurer(&insurer_wallet, &name, &license_id, &metadata);
+    register_insurer_with_anchor(&env, &client, &insurer_wallet);
 
-    // Update contact details
     let contact = String::from_str(&env, "555-0123, contact@healthguard.com");
     client.update_contact_details(&insurer_wallet, &contact);
 
-    // Update coverage policies
     let coverage = String::from_str(&env, "Medical: 100%, Dental: 80%");
     client.update_coverage_policies(&insurer_wallet, &coverage);
 
-    // Add reviewers
     client.add_claims_reviewer(&insurer_wallet, &reviewer1);
     client.add_claims_reviewer(&insurer_wallet, &reviewer2);
 
-    // Verify all data
     let insurer = client.get_insurer(&insurer_wallet);
-    assert_eq!(insurer.name, name);
-    assert_eq!(insurer.license_id, license_id);
+    assert_eq!(insurer.name, String::from_str(&env, "HealthGuard Insurance"));
+    assert_eq!(insurer.license_id, String::from_str(&env, "INS-2026-12345"));
     assert_eq!(insurer.contact_details, contact);
     assert_eq!(insurer.coverage_policies, coverage);
 
     let reviewers = client.get_claims_reviewers(&insurer_wallet);
     assert_eq!(reviewers.len(), 2);
 
-    // Remove one reviewer
     client.remove_claims_reviewer(&insurer_wallet, &reviewer1);
     let reviewers = client.get_claims_reviewers(&insurer_wallet);
     assert_eq!(reviewers.len(), 1);

--- a/contracts/insurer-registry/test_snapshots/test/test_add_claims_reviewer.1.json
+++ b/contracts/insurer-registry/test_snapshots/test/test_add_claims_reviewer.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0,
     "mux_id": 0
   },
@@ -25,7 +25,63 @@
                   "string": "INS-2026-12345"
                 },
                 {
-                  "string": "Coverage info"
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_insurer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "HealthGuard Insurance"
+                },
+                {
+                  "string": "INS-2026-12345"
+                },
+                {
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
                 }
               ]
             }
@@ -172,6 +228,61 @@
                     },
                     {
                       "key": {
+                        "symbol": "credential"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "attestation_hash"
+                            },
+                            "val": {
+                              "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "credential_hash"
+                            },
+                            "val": {
+                              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "expires_at"
+                            },
+                            "val": {
+                              "u64": "4100000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "issuer"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revocation_reference"
+                            },
+                            "val": {
+                              "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revoked_at"
+                            },
+                            "val": "void"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "license_id"
                       },
                       "val": {
@@ -183,7 +294,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "string": "Coverage info"
+                        "string": "Full medical coverage provider"
                       }
                     },
                     {
@@ -274,7 +385,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "5541220902715666415"
+                "nonce": "1033654523790656264"
               }
             },
             "durability": "temporary"
@@ -287,6 +398,39 @@
               "contract_data": {
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "5541220902715666415"

--- a/contracts/insurer-registry/test_snapshots/test/test_add_duplicate_reviewer.1.json
+++ b/contracts/insurer-registry/test_snapshots/test/test_add_duplicate_reviewer.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0,
     "mux_id": 0
   },
@@ -25,7 +25,63 @@
                   "string": "INS-2026-12345"
                 },
                 {
-                  "string": "Coverage info"
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_insurer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "HealthGuard Insurance"
+                },
+                {
+                  "string": "INS-2026-12345"
+                },
+                {
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
                 }
               ]
             }
@@ -172,6 +228,61 @@
                     },
                     {
                       "key": {
+                        "symbol": "credential"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "attestation_hash"
+                            },
+                            "val": {
+                              "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "credential_hash"
+                            },
+                            "val": {
+                              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "expires_at"
+                            },
+                            "val": {
+                              "u64": "4100000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "issuer"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revocation_reference"
+                            },
+                            "val": {
+                              "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revoked_at"
+                            },
+                            "val": "void"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "license_id"
                       },
                       "val": {
@@ -183,7 +294,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "string": "Coverage info"
+                        "string": "Full medical coverage provider"
                       }
                     },
                     {
@@ -274,7 +385,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "5541220902715666415"
+                "nonce": "1033654523790656264"
               }
             },
             "durability": "temporary"
@@ -287,6 +398,39 @@
               "contract_data": {
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "5541220902715666415"

--- a/contracts/insurer-registry/test_snapshots/test/test_add_multiple_claims_reviewers.1.json
+++ b/contracts/insurer-registry/test_snapshots/test/test_add_multiple_claims_reviewers.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 5,
+    "address": 6,
     "nonce": 0,
     "mux_id": 0
   },
@@ -25,7 +25,63 @@
                   "string": "INS-2026-12345"
                 },
                 {
-                  "string": "Coverage info"
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_insurer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "HealthGuard Insurance"
+                },
+                {
+                  "string": "INS-2026-12345"
+                },
+                {
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
                 }
               ]
             }
@@ -222,6 +278,61 @@
                     },
                     {
                       "key": {
+                        "symbol": "credential"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "attestation_hash"
+                            },
+                            "val": {
+                              "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "credential_hash"
+                            },
+                            "val": {
+                              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "expires_at"
+                            },
+                            "val": {
+                              "u64": "4100000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "issuer"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revocation_reference"
+                            },
+                            "val": {
+                              "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revoked_at"
+                            },
+                            "val": "void"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "license_id"
                       },
                       "val": {
@@ -233,7 +344,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "string": "Coverage info"
+                        "string": "Full medical coverage provider"
                       }
                     },
                     {
@@ -357,6 +468,39 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
+                "nonce": "2032731177588607455"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "2032731177588607455"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
                 "nonce": "4837995959683129791"
               }
             },
@@ -387,7 +531,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
             "key": {
               "ledger_key_nonce": {
                 "nonce": "5541220902715666415"
@@ -402,7 +546,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "5541220902715666415"

--- a/contracts/insurer-registry/test_snapshots/test/test_duplicate_registration.1.json
+++ b/contracts/insurer-registry/test_snapshots/test/test_duplicate_registration.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 2,
+    "address": 4,
     "nonce": 0,
     "mux_id": 0
   },
@@ -25,7 +25,63 @@
                   "string": "INS-2026-12345"
                 },
                 {
-                  "string": "Full medical coverage"
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_insurer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "HealthGuard Insurance"
+                },
+                {
+                  "string": "INS-2026-12345"
+                },
+                {
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
                 }
               ]
             }
@@ -146,6 +202,61 @@
                     },
                     {
                       "key": {
+                        "symbol": "credential"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "attestation_hash"
+                            },
+                            "val": {
+                              "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "credential_hash"
+                            },
+                            "val": {
+                              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "expires_at"
+                            },
+                            "val": {
+                              "u64": "4100000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "issuer"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revocation_reference"
+                            },
+                            "val": {
+                              "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revoked_at"
+                            },
+                            "val": "void"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "license_id"
                       },
                       "val": {
@@ -157,7 +268,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "string": "Full medical coverage"
+                        "string": "Full medical coverage provider"
                       }
                     },
                     {
@@ -231,6 +342,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
                   }
                 },
                 "durability": "temporary",

--- a/contracts/insurer-registry/test_snapshots/test/test_expired_insurer_anchor_disables_membership.1.json
+++ b/contracts/insurer-registry/test_snapshots/test/test_expired_insurer_anchor_disables_membership.1.json
@@ -13,19 +13,19 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "register_hospital",
+              "function_name": "register_insurer",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "string": "General Hospital"
+                  "string": "HealthGuard Insurance"
                 },
                 {
-                  "string": "123 Main St, New York, NY"
+                  "string": "INS-2026-12345"
                 },
                 {
-                  "string": "Services: ER, Surgery, Cardiology"
+                  "string": "Coverage info"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
@@ -37,7 +37,7 @@
                   "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
                 },
                 {
-                  "u64": "4100000000"
+                  "u64": "150"
                 },
                 {
                   "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
@@ -54,19 +54,19 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "register_hospital",
+              "function_name": "register_insurer",
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
-                  "string": "General Hospital"
+                  "string": "HealthGuard Insurance"
                 },
                 {
-                  "string": "123 Main St, New York, NY"
+                  "string": "INS-2026-12345"
                 },
                 {
-                  "string": "Services: ER, Surgery, Cardiology"
+                  "string": "Coverage info"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
@@ -78,7 +78,7 @@
                   "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
                 },
                 {
-                  "u64": "4100000000"
+                  "u64": "150"
                 },
                 {
                   "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
@@ -90,12 +90,14 @@
         }
       ]
     ],
+    [],
+    [],
     []
   ],
   "ledger": {
     "protocol_version": 23,
     "sequence_number": 0,
-    "timestamp": 0,
+    "timestamp": 151,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
     "min_persistent_entry_ttl": 4096,
@@ -109,7 +111,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "Hospital"
+                  "symbol": "ClaimsReviewers"
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
@@ -129,7 +131,52 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "Hospital"
+                      "symbol": "ClaimsReviewers"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": []
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Insurer"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Insurer"
                     },
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
@@ -139,6 +186,22 @@
                 "durability": "persistent",
                 "val": {
                   "map": [
+                    {
+                      "key": {
+                        "symbol": "contact_details"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "coverage_policies"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
                     {
                       "key": {
                         "symbol": "credential"
@@ -166,7 +229,7 @@
                               "symbol": "expires_at"
                             },
                             "val": {
-                              "u64": "4100000000"
+                              "u64": "150"
                             }
                           },
                           {
@@ -196,10 +259,10 @@
                     },
                     {
                       "key": {
-                        "symbol": "location"
+                        "symbol": "license_id"
                       },
                       "val": {
-                        "string": "123 Main St, New York, NY"
+                        "string": "INS-2026-12345"
                       }
                     },
                     {
@@ -207,7 +270,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "string": "Services: ER, Surgery, Cardiology"
+                        "string": "Coverage info"
                       }
                     },
                     {
@@ -215,142 +278,7 @@
                         "symbol": "name"
                       },
                       "val": {
-                        "string": "General Hospital"
-                      }
-                    }
-                  ]
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "HospitalConfig"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "HospitalConfig"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "alerts"
-                      },
-                      "val": {
-                        "vec": []
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "billing"
-                      },
-                      "val": {
-                        "map": [
-                          {
-                            "key": {
-                              "symbol": "currency"
-                            },
-                            "val": {
-                              "string": ""
-                            }
-                          },
-                          {
-                            "key": {
-                              "symbol": "payment_terms"
-                            },
-                            "val": {
-                              "string": ""
-                            }
-                          },
-                          {
-                            "key": {
-                              "symbol": "tax_id"
-                            },
-                            "val": {
-                              "string": ""
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "departments"
-                      },
-                      "val": {
-                        "vec": []
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "emergency_protocols"
-                      },
-                      "val": {
-                        "vec": []
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "equipment"
-                      },
-                      "val": {
-                        "vec": []
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "insurance_providers"
-                      },
-                      "val": {
-                        "vec": []
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "locations"
-                      },
-                      "val": {
-                        "vec": []
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "policies"
-                      },
-                      "val": {
-                        "vec": []
+                        "string": "HealthGuard Insurance"
                       }
                     }
                   ]

--- a/contracts/insurer-registry/test_snapshots/test/test_full_workflow.1.json
+++ b/contracts/insurer-registry/test_snapshots/test/test_full_workflow.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 4,
+    "address": 5,
     "nonce": 0,
     "mux_id": 0
   },
@@ -25,7 +25,63 @@
                   "string": "INS-2026-12345"
                 },
                 {
-                  "string": "Comprehensive health coverage"
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_insurer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "HealthGuard Insurance"
+                },
+                {
+                  "string": "INS-2026-12345"
+                },
+                {
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
                 }
               ]
             }
@@ -262,6 +318,61 @@
                     },
                     {
                       "key": {
+                        "symbol": "credential"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "attestation_hash"
+                            },
+                            "val": {
+                              "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "credential_hash"
+                            },
+                            "val": {
+                              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "expires_at"
+                            },
+                            "val": {
+                              "u64": "4100000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "issuer"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revocation_reference"
+                            },
+                            "val": {
+                              "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revoked_at"
+                            },
+                            "val": "void"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "license_id"
                       },
                       "val": {
@@ -273,7 +384,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "string": "Comprehensive health coverage"
+                        "string": "Full medical coverage provider"
                       }
                     },
                     {
@@ -496,7 +607,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "5541220902715666415"
+                "nonce": "8370022561469687789"
               }
             },
             "durability": "temporary"
@@ -509,6 +620,39 @@
               "contract_data": {
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "8370022561469687789"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "5541220902715666415"

--- a/contracts/insurer-registry/test_snapshots/test/test_get_claims_reviewers_empty.1.json
+++ b/contracts/insurer-registry/test_snapshots/test/test_get_claims_reviewers_empty.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 2,
+    "address": 3,
     "nonce": 0,
     "mux_id": 0
   },
@@ -25,7 +25,63 @@
                   "string": "INS-2026-12345"
                 },
                 {
-                  "string": "Coverage info"
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_insurer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "HealthGuard Insurance"
+                },
+                {
+                  "string": "INS-2026-12345"
+                },
+                {
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
                 }
               ]
             }
@@ -146,6 +202,61 @@
                     },
                     {
                       "key": {
+                        "symbol": "credential"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "attestation_hash"
+                            },
+                            "val": {
+                              "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "credential_hash"
+                            },
+                            "val": {
+                              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "expires_at"
+                            },
+                            "val": {
+                              "u64": "4100000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "issuer"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revocation_reference"
+                            },
+                            "val": {
+                              "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revoked_at"
+                            },
+                            "val": "void"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "license_id"
                       },
                       "val": {
@@ -157,7 +268,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "string": "Coverage info"
+                        "string": "Full medical coverage provider"
                       }
                     },
                     {
@@ -231,6 +342,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
                   }
                 },
                 "durability": "temporary",

--- a/contracts/insurer-registry/test_snapshots/test/test_is_authorized_reviewer.1.json
+++ b/contracts/insurer-registry/test_snapshots/test/test_is_authorized_reviewer.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 4,
+    "address": 5,
     "nonce": 0,
     "mux_id": 0
   },
@@ -25,7 +25,63 @@
                   "string": "INS-2026-12345"
                 },
                 {
-                  "string": "Coverage info"
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_insurer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "HealthGuard Insurance"
+                },
+                {
+                  "string": "INS-2026-12345"
+                },
+                {
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
                 }
               ]
             }
@@ -173,6 +229,61 @@
                     },
                     {
                       "key": {
+                        "symbol": "credential"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "attestation_hash"
+                            },
+                            "val": {
+                              "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "credential_hash"
+                            },
+                            "val": {
+                              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "expires_at"
+                            },
+                            "val": {
+                              "u64": "4100000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "issuer"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revocation_reference"
+                            },
+                            "val": {
+                              "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revoked_at"
+                            },
+                            "val": "void"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "license_id"
                       },
                       "val": {
@@ -184,7 +295,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "string": "Coverage info"
+                        "string": "Full medical coverage provider"
                       }
                     },
                     {
@@ -275,7 +386,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "5541220902715666415"
+                "nonce": "1033654523790656264"
               }
             },
             "durability": "temporary"
@@ -288,6 +399,39 @@
               "contract_data": {
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "5541220902715666415"

--- a/contracts/insurer-registry/test_snapshots/test/test_register_insurer.1.json
+++ b/contracts/insurer-registry/test_snapshots/test/test_register_insurer.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 2,
+    "address": 3,
     "nonce": 0,
     "mux_id": 0
   },
@@ -26,6 +26,62 @@
                 },
                 {
                   "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_insurer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "HealthGuard Insurance"
+                },
+                {
+                  "string": "INS-2026-12345"
+                },
+                {
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
                 }
               ]
             }
@@ -146,6 +202,61 @@
                     },
                     {
                       "key": {
+                        "symbol": "credential"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "attestation_hash"
+                            },
+                            "val": {
+                              "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "credential_hash"
+                            },
+                            "val": {
+                              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "expires_at"
+                            },
+                            "val": {
+                              "u64": "4100000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "issuer"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revocation_reference"
+                            },
+                            "val": {
+                              "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revoked_at"
+                            },
+                            "val": "void"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "license_id"
                       },
                       "val": {
@@ -231,6 +342,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
                   }
                 },
                 "durability": "temporary",

--- a/contracts/insurer-registry/test_snapshots/test/test_remove_claims_reviewer.1.json
+++ b/contracts/insurer-registry/test_snapshots/test/test_remove_claims_reviewer.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0,
     "mux_id": 0
   },
@@ -25,7 +25,63 @@
                   "string": "INS-2026-12345"
                 },
                 {
-                  "string": "Coverage info"
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_insurer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "HealthGuard Insurance"
+                },
+                {
+                  "string": "INS-2026-12345"
+                },
+                {
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
                 }
               ]
             }
@@ -56,7 +112,6 @@
         }
       ]
     ],
-    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
@@ -191,6 +246,61 @@
                     },
                     {
                       "key": {
+                        "symbol": "credential"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "attestation_hash"
+                            },
+                            "val": {
+                              "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "credential_hash"
+                            },
+                            "val": {
+                              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "expires_at"
+                            },
+                            "val": {
+                              "u64": "4100000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "issuer"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revocation_reference"
+                            },
+                            "val": {
+                              "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revoked_at"
+                            },
+                            "val": "void"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "license_id"
                       },
                       "val": {
@@ -202,7 +312,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "string": "Coverage info"
+                        "string": "Full medical coverage provider"
                       }
                     },
                     {
@@ -326,7 +436,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "5541220902715666415"
+                "nonce": "4837995959683129791"
               }
             },
             "durability": "temporary"
@@ -339,6 +449,39 @@
               "contract_data": {
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "4837995959683129791"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "5541220902715666415"

--- a/contracts/insurer-registry/test_snapshots/test/test_remove_nonexistent_reviewer.1.json
+++ b/contracts/insurer-registry/test_snapshots/test/test_remove_nonexistent_reviewer.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0,
     "mux_id": 0
   },
@@ -25,7 +25,63 @@
                   "string": "INS-2026-12345"
                 },
                 {
-                  "string": "Coverage info"
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_insurer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "HealthGuard Insurance"
+                },
+                {
+                  "string": "INS-2026-12345"
+                },
+                {
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
                 }
               ]
             }
@@ -146,6 +202,61 @@
                     },
                     {
                       "key": {
+                        "symbol": "credential"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "attestation_hash"
+                            },
+                            "val": {
+                              "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "credential_hash"
+                            },
+                            "val": {
+                              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "expires_at"
+                            },
+                            "val": {
+                              "u64": "4100000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "issuer"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revocation_reference"
+                            },
+                            "val": {
+                              "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revoked_at"
+                            },
+                            "val": "void"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "license_id"
                       },
                       "val": {
@@ -157,7 +268,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "string": "Coverage info"
+                        "string": "Full medical coverage provider"
                       }
                     },
                     {
@@ -231,6 +342,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
                   }
                 },
                 "durability": "temporary",

--- a/contracts/insurer-registry/test_snapshots/test/test_update_contact_details.1.json
+++ b/contracts/insurer-registry/test_snapshots/test/test_update_contact_details.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 2,
+    "address": 3,
     "nonce": 0,
     "mux_id": 0
   },
@@ -25,7 +25,63 @@
                   "string": "INS-2026-12345"
                 },
                 {
-                  "string": "Coverage info"
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_insurer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "HealthGuard Insurance"
+                },
+                {
+                  "string": "INS-2026-12345"
+                },
+                {
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
                 }
               ]
             }
@@ -168,6 +224,61 @@
                     },
                     {
                       "key": {
+                        "symbol": "credential"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "attestation_hash"
+                            },
+                            "val": {
+                              "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "credential_hash"
+                            },
+                            "val": {
+                              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "expires_at"
+                            },
+                            "val": {
+                              "u64": "4100000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "issuer"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revocation_reference"
+                            },
+                            "val": {
+                              "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revoked_at"
+                            },
+                            "val": "void"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "license_id"
                       },
                       "val": {
@@ -179,7 +290,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "string": "Coverage info"
+                        "string": "Full medical coverage provider"
                       }
                     },
                     {
@@ -270,7 +381,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "5541220902715666415"
+                "nonce": "1033654523790656264"
               }
             },
             "durability": "temporary"
@@ -283,6 +394,39 @@
               "contract_data": {
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "5541220902715666415"

--- a/contracts/insurer-registry/test_snapshots/test/test_update_coverage_policies.1.json
+++ b/contracts/insurer-registry/test_snapshots/test/test_update_coverage_policies.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 2,
+    "address": 3,
     "nonce": 0,
     "mux_id": 0
   },
@@ -25,7 +25,63 @@
                   "string": "INS-2026-12345"
                 },
                 {
-                  "string": "Coverage info"
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_insurer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "HealthGuard Insurance"
+                },
+                {
+                  "string": "INS-2026-12345"
+                },
+                {
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
                 }
               ]
             }
@@ -168,6 +224,61 @@
                     },
                     {
                       "key": {
+                        "symbol": "credential"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "attestation_hash"
+                            },
+                            "val": {
+                              "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "credential_hash"
+                            },
+                            "val": {
+                              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "expires_at"
+                            },
+                            "val": {
+                              "u64": "4100000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "issuer"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revocation_reference"
+                            },
+                            "val": {
+                              "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revoked_at"
+                            },
+                            "val": "void"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "license_id"
                       },
                       "val": {
@@ -179,7 +290,7 @@
                         "symbol": "metadata"
                       },
                       "val": {
-                        "string": "Coverage info"
+                        "string": "Full medical coverage provider"
                       }
                     },
                     {
@@ -270,7 +381,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "5541220902715666415"
+                "nonce": "1033654523790656264"
               }
             },
             "durability": "temporary"
@@ -283,6 +394,39 @@
               "contract_data": {
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "5541220902715666415"

--- a/contracts/insurer-registry/test_snapshots/test/test_update_insurer.1.json
+++ b/contracts/insurer-registry/test_snapshots/test/test_update_insurer.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 2,
+    "address": 3,
     "nonce": 0,
     "mux_id": 0
   },
@@ -25,7 +25,63 @@
                   "string": "INS-2026-12345"
                 },
                 {
-                  "string": "Basic coverage"
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "register_insurer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "HealthGuard Insurance"
+                },
+                {
+                  "string": "INS-2026-12345"
+                },
+                {
+                  "string": "Full medical coverage provider"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                },
+                {
+                  "u64": "4100000000"
+                },
+                {
+                  "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
                 }
               ]
             }
@@ -168,6 +224,61 @@
                     },
                     {
                       "key": {
+                        "symbol": "credential"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "attestation_hash"
+                            },
+                            "val": {
+                              "bytes": "0202020202020202020202020202020202020202020202020202020202020202"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "credential_hash"
+                            },
+                            "val": {
+                              "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "expires_at"
+                            },
+                            "val": {
+                              "u64": "4100000000"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "issuer"
+                            },
+                            "val": {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revocation_reference"
+                            },
+                            "val": {
+                              "bytes": "0303030303030303030303030303030303030303030303030303030303030303"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "revoked_at"
+                            },
+                            "val": "void"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "license_id"
                       },
                       "val": {
@@ -270,7 +381,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
-                "nonce": "5541220902715666415"
+                "nonce": "1033654523790656264"
               }
             },
             "durability": "temporary"
@@ -283,6 +394,39 @@
               "contract_data": {
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "5541220902715666415"

--- a/contracts/medical-claims/src/lib.rs
+++ b/contracts/medical-claims/src/lib.rs
@@ -5,7 +5,10 @@ mod test;
 mod types;
 
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Vec};
-use types::{ClaimRecord, ClaimStatus, DataKey, DenialInfo, Error, ServiceLine};
+use types::{
+    ClaimRecord, ClaimStatus, DataKey, DenialInfo, Error, InsurerPaymentRecord,
+    PatientPaymentRecord, ReconciliationStatus, ServiceLine,
+};
 
 #[contract]
 pub struct MedicalClaimsSystem;
@@ -24,6 +27,7 @@ impl MedicalClaimsSystem {
         total_amount: i128,
     ) -> Result<u64, Error> {
         provider_id.require_auth();
+        Self::validate_claim_amounts(&service_codes, total_amount)?;
 
         let count: u64 = env
             .storage()
@@ -49,13 +53,15 @@ impl MedicalClaimsSystem {
             approved_amount: None,
             patient_responsibility: None,
             appeal_level: 0,
+            insurer_paid_amount: 0,
+            patient_paid_amount: 0,
+            reconciliation_status: ReconciliationStatus::Unreconciled,
         };
 
         env.storage()
             .persistent()
             .set(&DataKey::Claim(claim_id), &claim);
 
-        // Store mappings
         let mut p_claims: Vec<u64> = env
             .storage()
             .persistent()
@@ -90,19 +96,26 @@ impl MedicalClaimsSystem {
     ) -> Result<(), Error> {
         insurance_admin.require_auth();
 
-        let mut claim: ClaimRecord = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Claim(claim_id))
-            .ok_or(Error::ClaimNotFound)?;
-
+        let mut claim = Self::load_claim(&env, claim_id)?;
         if claim.status != ClaimStatus::Submitted && claim.status != ClaimStatus::Appealed {
             return Err(Error::InvalidStateTransition);
         }
+        Self::validate_adjudication_amounts(
+            claim.total_amount,
+            approved_amount,
+            patient_responsibility,
+        )?;
 
         claim.status = ClaimStatus::Adjudicated;
         claim.approved_amount = Some(approved_amount);
         claim.patient_responsibility = Some(patient_responsibility);
+        claim.insurer_paid_amount = 0;
+        claim.patient_paid_amount = 0;
+        claim.reconciliation_status = if approved_amount == 0 && patient_responsibility == 0 {
+            ReconciliationStatus::Reconciled
+        } else {
+            ReconciliationStatus::Unreconciled
+        };
 
         env.storage()
             .persistent()
@@ -113,6 +126,12 @@ impl MedicalClaimsSystem {
         env.storage()
             .persistent()
             .set(&DataKey::DenialInfos(claim_id), &denied_lines);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ClaimPayment(claim_id), &Vec::<InsurerPaymentRecord>::new(&env));
+        env.storage()
+            .persistent()
+            .set(&DataKey::PatientPayment(claim_id), &Vec::<PatientPaymentRecord>::new(&env));
 
         Ok(())
     }
@@ -126,27 +145,19 @@ impl MedicalClaimsSystem {
     ) -> Result<u64, Error> {
         provider_id.require_auth();
 
-        let mut claim: ClaimRecord = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Claim(claim_id))
-            .ok_or(Error::ClaimNotFound)?;
-
+        let mut claim = Self::load_claim(&env, claim_id)?;
         if claim.provider_id != provider_id {
             return Err(Error::NotAuthorized);
         }
-
         if claim.status != ClaimStatus::Adjudicated {
             return Err(Error::InvalidStateTransition);
         }
-
         if appeal_level <= claim.appeal_level || appeal_level > 3 {
             return Err(Error::InvalidAppealLevel);
         }
 
         claim.status = ClaimStatus::Appealed;
         claim.appeal_level = appeal_level;
-
         env.storage()
             .persistent()
             .set(&DataKey::Claim(claim_id), &claim);
@@ -158,31 +169,54 @@ impl MedicalClaimsSystem {
         env: Env,
         claim_id: u64,
         insurance_admin: Address,
-        _payment_amount: i128, // Currently ignored, just relying on record
+        payment_amount: i128,
         payment_date: u64,
         payment_reference: String,
     ) -> Result<(), Error> {
         insurance_admin.require_auth();
 
-        let mut claim: ClaimRecord = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Claim(claim_id))
-            .ok_or(Error::ClaimNotFound)?;
+        if payment_amount <= 0 || payment_reference.is_empty() {
+            return Err(Error::InvalidAmount);
+        }
 
-        if claim.status != ClaimStatus::Adjudicated {
+        let mut claim = Self::load_claim(&env, claim_id)?;
+        if claim.status != ClaimStatus::Adjudicated && claim.status != ClaimStatus::Paid {
             return Err(Error::InvalidStateTransition);
         }
 
-        claim.status = ClaimStatus::Paid;
+        let approved_amount = claim.approved_amount.ok_or(Error::InvalidStateTransition)?;
+        let insurer_outstanding = Self::checked_sub(approved_amount, claim.insurer_paid_amount)?;
+        if payment_amount > insurer_outstanding {
+            return Err(Error::InvalidAmount);
+        }
+
+        claim.insurer_paid_amount = Self::checked_add(claim.insurer_paid_amount, payment_amount)?;
+        let (insurer_due, patient_due) = Self::refresh_reconciliation_status(&mut claim)?;
+        if insurer_due == 0 {
+            claim.status = if patient_due == 0 {
+                ClaimStatus::Closed
+            } else {
+                ClaimStatus::Paid
+            };
+        }
+
+        let mut payments: Vec<InsurerPaymentRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ClaimPayment(claim_id))
+            .unwrap_or(Vec::new(&env));
+        payments.push_back(InsurerPaymentRecord {
+            payment_date,
+            payment_amount,
+            payment_reference,
+        });
+
         env.storage()
             .persistent()
             .set(&DataKey::Claim(claim_id), &claim);
-
-        env.storage().persistent().set(
-            &DataKey::ClaimPayment(claim_id),
-            &(payment_date, payment_reference),
-        );
+        env.storage()
+            .persistent()
+            .set(&DataKey::ClaimPayment(claim_id), &payments);
 
         Ok(())
     }
@@ -196,38 +230,139 @@ impl MedicalClaimsSystem {
     ) -> Result<(), Error> {
         patient_id.require_auth();
 
-        let mut claim: ClaimRecord = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Claim(claim_id))
-            .ok_or(Error::ClaimNotFound)?;
+        if payment_amount <= 0 {
+            return Err(Error::InvalidAmount);
+        }
 
+        let mut claim = Self::load_claim(&env, claim_id)?;
         if claim.patient_id != patient_id {
             return Err(Error::NotAuthorized);
         }
-
-        // Technically, patient can pay anytime after adjudication
-        if claim.status != ClaimStatus::Paid && claim.status != ClaimStatus::Adjudicated {
+        if claim.status != ClaimStatus::Adjudicated && claim.status != ClaimStatus::Paid {
             return Err(Error::InvalidStateTransition);
         }
 
-        // Apply payment - simplified reconciliation
-        let current_resp = claim.patient_responsibility.unwrap_or(0);
-        let new_resp = current_resp - payment_amount;
-        claim.patient_responsibility = Some(if new_resp < 0 { 0 } else { new_resp });
-
-        if claim.status == ClaimStatus::Paid && claim.patient_responsibility.unwrap_or(0) == 0 {
-            claim.status = ClaimStatus::Closed;
+        let patient_responsibility = claim.patient_responsibility.ok_or(Error::InvalidStateTransition)?;
+        let patient_outstanding = Self::checked_sub(patient_responsibility, claim.patient_paid_amount)?;
+        if payment_amount > patient_outstanding {
+            return Err(Error::InvalidAmount);
         }
+
+        claim.patient_paid_amount = Self::checked_add(claim.patient_paid_amount, payment_amount)?;
+        let (insurer_due, patient_due) = Self::refresh_reconciliation_status(&mut claim)?;
+        if insurer_due == 0 && patient_due == 0 {
+            claim.status = ClaimStatus::Closed;
+        } else if insurer_due == 0 {
+            claim.status = ClaimStatus::Paid;
+        }
+
+        let mut payments: Vec<PatientPaymentRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PatientPayment(claim_id))
+            .unwrap_or(Vec::new(&env));
+        payments.push_back(PatientPaymentRecord {
+            payment_date,
+            payment_amount,
+        });
 
         env.storage()
             .persistent()
             .set(&DataKey::Claim(claim_id), &claim);
-        env.storage().persistent().set(
-            &DataKey::PatientPayment(claim_id),
-            &(payment_date, payment_amount),
-        );
+        env.storage()
+            .persistent()
+            .set(&DataKey::PatientPayment(claim_id), &payments);
 
         Ok(())
+    }
+
+    pub fn get_claim(env: Env, claim_id: u64) -> Result<ClaimRecord, Error> {
+        Self::load_claim(&env, claim_id)
+    }
+
+    pub fn get_insurer_payments(env: Env, claim_id: u64) -> Vec<InsurerPaymentRecord> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ClaimPayment(claim_id))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    pub fn get_patient_payments(env: Env, claim_id: u64) -> Vec<PatientPaymentRecord> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PatientPayment(claim_id))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    fn load_claim(env: &Env, claim_id: u64) -> Result<ClaimRecord, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Claim(claim_id))
+            .ok_or(Error::ClaimNotFound)
+    }
+
+    fn validate_claim_amounts(service_codes: &Vec<ServiceLine>, total_amount: i128) -> Result<(), Error> {
+        if total_amount < 0 || service_codes.is_empty() {
+            return Err(Error::InvalidAmount);
+        }
+
+        let mut computed_total = 0_i128;
+        for line in service_codes.iter() {
+            if line.quantity == 0 || line.charge_amount < 0 {
+                return Err(Error::InvalidAmount);
+            }
+            computed_total = Self::checked_add(computed_total, line.charge_amount)?;
+        }
+
+        if computed_total != total_amount {
+            return Err(Error::InvalidAmount);
+        }
+        Ok(())
+    }
+
+    fn validate_adjudication_amounts(
+        total_amount: i128,
+        approved_amount: i128,
+        patient_responsibility: i128,
+    ) -> Result<(), Error> {
+        if total_amount < 0 || approved_amount < 0 || patient_responsibility < 0 {
+            return Err(Error::InvalidAmount);
+        }
+
+        let allocated = Self::checked_add(approved_amount, patient_responsibility)?;
+        if allocated > total_amount {
+            return Err(Error::InvalidAmount);
+        }
+        Ok(())
+    }
+
+    fn refresh_reconciliation_status(
+        claim: &mut ClaimRecord,
+    ) -> Result<(i128, i128), Error> {
+        let approved_amount = claim.approved_amount.unwrap_or(0);
+        let patient_responsibility = claim.patient_responsibility.unwrap_or(0);
+
+        let insurer_due = Self::checked_sub(approved_amount, claim.insurer_paid_amount)?;
+        let patient_due = Self::checked_sub(patient_responsibility, claim.patient_paid_amount)?;
+
+        claim.reconciliation_status = if insurer_due == 0 && patient_due == 0 {
+            ReconciliationStatus::Reconciled
+        } else if claim.insurer_paid_amount > 0 || claim.patient_paid_amount > 0 {
+            ReconciliationStatus::PartiallyReconciled
+        } else {
+            ReconciliationStatus::Unreconciled
+        };
+
+        Ok((insurer_due, patient_due))
+    }
+
+    fn checked_add(lhs: i128, rhs: i128) -> Result<i128, Error> {
+        lhs.checked_add(rhs).ok_or(Error::AmountOverflow)
+    }
+
+    fn checked_sub(lhs: i128, rhs: i128) -> Result<i128, Error> {
+        lhs.checked_sub(rhs)
+            .filter(|value| *value >= 0)
+            .ok_or(Error::InvalidAmount)
     }
 }

--- a/contracts/medical-claims/src/test.rs
+++ b/contracts/medical-claims/src/test.rs
@@ -2,80 +2,22 @@
 #![allow(deprecated)]
 
 use super::*;
-use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Vec};
+use soroban_sdk::{testutils::Address as _, BytesN, Env, String, Vec};
 
-#[test]
-fn test_full_claim_lifecycle() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let contract_id = env.register_contract(None, MedicalClaimsSystem);
-    let client = MedicalClaimsSystemClient::new(&env, &contract_id);
-
-    let provider_id = Address::generate(&env);
-    let patient_id = Address::generate(&env);
-    let insurance_admin = Address::generate(&env);
-
-    let mut services = Vec::new(&env);
+fn build_services(env: &Env, amount: i128) -> Vec<ServiceLine> {
+    let mut services = Vec::new(env);
     services.push_back(ServiceLine {
-        procedure_code: String::from_str(&env, "99213"),
+        procedure_code: String::from_str(env, "99213"),
         modifier: None,
         quantity: 1,
-        charge_amount: 15000, // $150.00
-        diagnosis_pointers: Vec::new(&env),
+        charge_amount: amount,
+        diagnosis_pointers: Vec::new(env),
     });
-
-    // 1. Submit Claim
-    let claim_id = client.submit_claim(
-        &provider_id,
-        &patient_id,
-        &12345,      // policy
-        &1690000000, // date
-        &services,
-        &Vec::new(&env),                     // diagnoses
-        &BytesN::from_array(&env, &[0; 32]), // hash
-        &15000,
-    );
-    assert_eq!(claim_id, 1);
-
-    // 2. Adjudicate Claim
-    let mut approved_lines = Vec::new(&env);
-    approved_lines.push_back(1);
-
-    client.adjudicate_claim(
-        &claim_id,
-        &insurance_admin,
-        &approved_lines,
-        &Vec::new(&env), // no denials
-        &10000,          // Approved $100.00
-        &2000,           // Patient owes $20.00
-    );
-
-    // 3. Process Insurance Payment
-    client.process_payment(
-        &claim_id,
-        &insurance_admin,
-        &8000, // Ins pays $80.00 (100 - 20)
-        &1690100000,
-        &String::from_str(&env, "REF_123"),
-    );
-
-    // 4. Apply Patient Payment
-    client.apply_patient_payment(&claim_id, &patient_id, &2000, &1690200000);
-
-    // State cannot be verified directly without getters, but operations shouldn't panic.
-    // If we try to appeal a Paid claim, it should fail
-    let res = client.try_appeal_denial(
-        &claim_id,
-        &provider_id,
-        &1,
-        &BytesN::from_array(&env, &[0; 32]),
-    );
-    assert!(res.is_err()); // InvalidStateTransition
+    services
 }
 
 #[test]
-fn test_appeal_workflow() {
+fn test_full_claim_lifecycle_reconciles_cleanly() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -85,28 +27,223 @@ fn test_appeal_workflow() {
     let provider_id = Address::generate(&env);
     let patient_id = Address::generate(&env);
     let insurance_admin = Address::generate(&env);
-
-    let mut services = Vec::new(&env);
-    services.push_back(ServiceLine {
-        procedure_code: String::from_str(&env, "99214"),
-        modifier: None,
-        quantity: 1,
-        charge_amount: 25000,
-        diagnosis_pointers: Vec::new(&env),
-    });
 
     let claim_id = client.submit_claim(
         &provider_id,
         &patient_id,
         &12345,
         &1690000000,
-        &services,
+        &build_services(&env, 15000),
+        &Vec::new(&env),
+        &BytesN::from_array(&env, &[0; 32]),
+        &15000,
+    );
+
+    let mut approved_lines = Vec::new(&env);
+    approved_lines.push_back(1);
+    client.adjudicate_claim(
+        &claim_id,
+        &insurance_admin,
+        &approved_lines,
+        &Vec::new(&env),
+        &10000,
+        &2000,
+    );
+
+    client.process_payment(
+        &claim_id,
+        &insurance_admin,
+        &10000,
+        &1690100000,
+        &String::from_str(&env, "REF_123"),
+    );
+    client.apply_patient_payment(&claim_id, &patient_id, &2000, &1690200000);
+
+    let claim = client.get_claim(&claim_id);
+    assert_eq!(claim.status, ClaimStatus::Closed);
+    assert_eq!(claim.reconciliation_status, ReconciliationStatus::Reconciled);
+    assert_eq!(claim.insurer_paid_amount, 10000);
+    assert_eq!(claim.patient_paid_amount, 2000);
+    assert_eq!(client.get_insurer_payments(&claim_id).len(), 1);
+    assert_eq!(client.get_patient_payments(&claim_id).len(), 1);
+}
+
+#[test]
+fn test_partial_reconciliation_is_tracked() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalClaimsSystem);
+    let client = MedicalClaimsSystemClient::new(&env, &contract_id);
+
+    let provider_id = Address::generate(&env);
+    let patient_id = Address::generate(&env);
+    let insurance_admin = Address::generate(&env);
+
+    let claim_id = client.submit_claim(
+        &provider_id,
+        &patient_id,
+        &12345,
+        &1690000000,
+        &build_services(&env, 25000),
         &Vec::new(&env),
         &BytesN::from_array(&env, &[1; 32]),
         &25000,
     );
 
-    // Adjudicate: Deny
+    client.adjudicate_claim(
+        &claim_id,
+        &insurance_admin,
+        &Vec::new(&env),
+        &Vec::new(&env),
+        &20000,
+        &5000,
+    );
+    client.process_payment(
+        &claim_id,
+        &insurance_admin,
+        &12000,
+        &1690100000,
+        &String::from_str(&env, "REF_PARTIAL"),
+    );
+    client.apply_patient_payment(&claim_id, &patient_id, &2000, &1690200000);
+
+    let claim = client.get_claim(&claim_id);
+    assert_eq!(claim.status, ClaimStatus::Adjudicated);
+    assert_eq!(
+        claim.reconciliation_status,
+        ReconciliationStatus::PartiallyReconciled
+    );
+    assert_eq!(claim.insurer_paid_amount, 12000);
+    assert_eq!(claim.patient_paid_amount, 2000);
+}
+
+#[test]
+fn test_submit_claim_rejects_inconsistent_total() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalClaimsSystem);
+    let client = MedicalClaimsSystemClient::new(&env, &contract_id);
+
+    let provider_id = Address::generate(&env);
+    let patient_id = Address::generate(&env);
+
+    let result = client.try_submit_claim(
+        &provider_id,
+        &patient_id,
+        &12345,
+        &1690000000,
+        &build_services(&env, 10000),
+        &Vec::new(&env),
+        &BytesN::from_array(&env, &[2; 32]),
+        &9000,
+    );
+    assert!(matches!(result, Err(Ok(Error::InvalidAmount))));
+}
+
+#[test]
+fn test_adjudication_rejects_over_allocated_totals() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalClaimsSystem);
+    let client = MedicalClaimsSystemClient::new(&env, &contract_id);
+
+    let provider_id = Address::generate(&env);
+    let patient_id = Address::generate(&env);
+    let insurance_admin = Address::generate(&env);
+
+    let claim_id = client.submit_claim(
+        &provider_id,
+        &patient_id,
+        &12345,
+        &1690000000,
+        &build_services(&env, 15000),
+        &Vec::new(&env),
+        &BytesN::from_array(&env, &[3; 32]),
+        &15000,
+    );
+
+    let result = client.try_adjudicate_claim(
+        &claim_id,
+        &insurance_admin,
+        &Vec::new(&env),
+        &Vec::new(&env),
+        &12000,
+        &4000,
+    );
+    assert!(matches!(result, Err(Ok(Error::InvalidAmount))));
+}
+
+#[test]
+fn test_payment_application_is_bounded() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalClaimsSystem);
+    let client = MedicalClaimsSystemClient::new(&env, &contract_id);
+
+    let provider_id = Address::generate(&env);
+    let patient_id = Address::generate(&env);
+    let insurance_admin = Address::generate(&env);
+
+    let claim_id = client.submit_claim(
+        &provider_id,
+        &patient_id,
+        &12345,
+        &1690000000,
+        &build_services(&env, 15000),
+        &Vec::new(&env),
+        &BytesN::from_array(&env, &[4; 32]),
+        &15000,
+    );
+
+    client.adjudicate_claim(
+        &claim_id,
+        &insurance_admin,
+        &Vec::new(&env),
+        &Vec::new(&env),
+        &10000,
+        &2000,
+    );
+
+    let insurer_overpay = client.try_process_payment(
+        &claim_id,
+        &insurance_admin,
+        &11000,
+        &1690100000,
+        &String::from_str(&env, "REF_OVER"),
+    );
+    assert!(matches!(insurer_overpay, Err(Ok(Error::InvalidAmount))));
+
+    let patient_overpay = client.try_apply_patient_payment(&claim_id, &patient_id, &3000, &1690200000);
+    assert!(matches!(patient_overpay, Err(Ok(Error::InvalidAmount))));
+}
+
+#[test]
+fn test_appeal_workflow_still_functions() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalClaimsSystem);
+    let client = MedicalClaimsSystemClient::new(&env, &contract_id);
+
+    let provider_id = Address::generate(&env);
+    let patient_id = Address::generate(&env);
+    let insurance_admin = Address::generate(&env);
+
+    let claim_id = client.submit_claim(
+        &provider_id,
+        &patient_id,
+        &12345,
+        &1690000000,
+        &build_services(&env, 25000),
+        &Vec::new(&env),
+        &BytesN::from_array(&env, &[5; 32]),
+        &25000,
+    );
+
     let mut denials = Vec::new(&env);
     denials.push_back(DenialInfo {
         line_number: 1,
@@ -118,30 +255,26 @@ fn test_appeal_workflow() {
     client.adjudicate_claim(
         &claim_id,
         &insurance_admin,
-        &Vec::new(&env), // none approved
+        &Vec::new(&env),
         &denials,
         &0,
         &0,
     );
-
-    // Appeal level 1
     client.appeal_denial(
         &claim_id,
         &provider_id,
         &1,
-        &BytesN::from_array(&env, &[2; 32]),
+        &BytesN::from_array(&env, &[6; 32]),
     );
 
-    // Try invalid appeal levels
     let res1 = client.try_appeal_denial(
         &claim_id,
         &provider_id,
-        &1, // already at level 1
-        &BytesN::from_array(&env, &[2; 32]),
+        &1,
+        &BytesN::from_array(&env, &[7; 32]),
     );
-    assert!(res1.is_err()); // InvalidStateTransition or InvalidAppealLevel
+    assert!(matches!(res1, Err(Ok(Error::InvalidStateTransition))));
 
-    // Re-adjudicate after appeal
     client.adjudicate_claim(
         &claim_id,
         &insurance_admin,
@@ -150,16 +283,13 @@ fn test_appeal_workflow() {
         &0,
         &0,
     );
-
-    // Appeal level 2
     client.appeal_denial(
         &claim_id,
         &provider_id,
         &2,
-        &BytesN::from_array(&env, &[3; 32]),
+        &BytesN::from_array(&env, &[8; 32]),
     );
 
-    // Re-adjudicate
     client.adjudicate_claim(
         &claim_id,
         &insurance_admin,
@@ -168,12 +298,14 @@ fn test_appeal_workflow() {
         &0,
         &0,
     );
-
-    // Appeal level 3
     client.appeal_denial(
         &claim_id,
         &provider_id,
         &3,
-        &BytesN::from_array(&env, &[4; 32]),
+        &BytesN::from_array(&env, &[9; 32]),
     );
+
+    let claim = client.get_claim(&claim_id);
+    assert_eq!(claim.appeal_level, 3);
+    assert_eq!(claim.status, ClaimStatus::Appealed);
 }

--- a/contracts/medical-claims/src/types.rs
+++ b/contracts/medical-claims/src/types.rs
@@ -8,6 +8,8 @@ pub enum Error {
     ClaimNotFound = 2,
     InvalidAppealLevel = 3,
     InvalidStateTransition = 4,
+    InvalidAmount = 5,
+    AmountOverflow = 6,
 }
 
 #[contracttype]
@@ -18,6 +20,14 @@ pub enum ClaimStatus {
     Appealed,
     Paid,
     Closed,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReconciliationStatus {
+    Unreconciled,
+    PartiallyReconciled,
+    Reconciled,
 }
 
 #[contracttype]
@@ -41,6 +51,21 @@ pub struct DenialInfo {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InsurerPaymentRecord {
+    pub payment_date: u64,
+    pub payment_amount: i128,
+    pub payment_reference: String,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PatientPaymentRecord {
+    pub payment_date: u64,
+    pub payment_amount: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ClaimRecord {
     pub claim_id: u64,
     pub provider_id: Address,
@@ -55,17 +80,20 @@ pub struct ClaimRecord {
     pub approved_amount: Option<i128>,
     pub patient_responsibility: Option<i128>,
     pub appeal_level: u32,
+    pub insurer_paid_amount: i128,
+    pub patient_paid_amount: i128,
+    pub reconciliation_status: ReconciliationStatus,
 }
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataKey {
     ClaimCounter,
-    Claim(u64),              // claim_id -> ClaimRecord
-    DenialInfos(u64),        // claim_id -> Vec<DenialInfo>
-    ApprovedLines(u64),      // claim_id -> Vec<u64>
-    ProviderClaims(Address), // provider_id -> Vec<u64>
-    PatientClaims(Address),  // patient_id -> Vec<u64>
-    ClaimPayment(u64),       // claim_id -> (u64, String) // payment_date, payment_reference
-    PatientPayment(u64),     // claim_id -> (u64, i128) // payment_date, payment_amount
+    Claim(u64),
+    DenialInfos(u64),
+    ApprovedLines(u64),
+    ProviderClaims(Address),
+    PatientClaims(Address),
+    ClaimPayment(u64),
+    PatientPayment(u64),
 }

--- a/contracts/medical-device-tracking/src/lib.rs
+++ b/contracts/medical-device-tracking/src/lib.rs
@@ -15,9 +15,21 @@ pub struct MedicalDeviceRegistry;
 
 #[contractimpl]
 impl MedicalDeviceRegistry {
+    /// Configure the regulator address allowed to issue emergency recalls.
+    pub fn initialize(env: Env, regulator: Address) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Regulator) {
+            return Err(Error::AlreadyInitialized);
+        }
+
+        regulator.require_auth();
+        env.storage().instance().set(&DataKey::Regulator, &regulator);
+        Ok(())
+    }
+
     /// Register a medical device with its Unique Device Identifier (UDI).
     pub fn register_device(
         env: Env,
+        manufacturer_id: Address,
         device_udi: String,
         device_type: Symbol,
         manufacturer: String,
@@ -27,6 +39,8 @@ impl MedicalDeviceRegistry {
         expiration_date: Option<u64>,
         device_specs_hash: BytesN<32>,
     ) -> Result<u64, Error> {
+        manufacturer_id.require_auth();
+
         let count: u64 = env
             .storage()
             .instance()
@@ -41,6 +55,7 @@ impl MedicalDeviceRegistry {
             device_id: new_id,
             device_udi,
             device_type,
+            manufacturer_id,
             manufacturer,
             model_number,
             lot_number,
@@ -223,6 +238,11 @@ impl MedicalDeviceRegistry {
     ) -> Result<u64, Error> {
         manufacturer.require_auth();
 
+        if device_ids.is_empty() {
+            return Err(Error::InvalidInput);
+        }
+        Self::assert_manufacturer_controls_devices(&env, &manufacturer, &device_ids)?;
+
         let count: u64 = env
             .storage()
             .instance()
@@ -236,11 +256,89 @@ impl MedicalDeviceRegistry {
         let recall = RecallInfo {
             recall_id: new_id,
             device_ids: device_ids.clone(),
+            issuer: manufacturer,
+            issuer_role: Symbol::new(&env, "maker"),
             recall_reason,
             severity,
             recall_date,
             action_required,
             resolution_deadline: None,
+            emergency_scope: None,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::RecallInfo(new_id), &recall);
+
+        for device_id in device_ids {
+            let mut device_recalls: Vec<u64> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::DeviceRecalls(device_id))
+                .unwrap_or(Vec::new(&env));
+            device_recalls.push_back(new_id);
+            env.storage()
+                .persistent()
+                .set(&DataKey::DeviceRecalls(device_id), &device_recalls);
+        }
+
+        Ok(new_id)
+    }
+
+    /// Issue an emergency recall under regulator authority for a defined scope.
+    pub fn issue_regulator_recall(
+        env: Env,
+        regulator: Address,
+        device_ids: Vec<u64>,
+        recall_reason: String,
+        severity: Symbol,
+        recall_date: u64,
+        action_required: String,
+        emergency_scope: String,
+    ) -> Result<u64, Error> {
+        regulator.require_auth();
+
+        if device_ids.is_empty() || emergency_scope.is_empty() {
+            return Err(Error::InvalidInput);
+        }
+
+        let configured_regulator: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Regulator)
+            .ok_or(Error::NotAuthorized)?;
+        if regulator != configured_regulator {
+            return Err(Error::NotAuthorized);
+        }
+
+        for device_id in device_ids.iter() {
+            if !env
+                .storage()
+                .persistent()
+                .has(&DataKey::DeviceRecord(device_id))
+            {
+                return Err(Error::RecordNotFound);
+            }
+        }
+
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RecallCounter)
+            .unwrap_or(0);
+        let new_id = count + 1;
+        env.storage().instance().set(&DataKey::RecallCounter, &new_id);
+
+        let recall = RecallInfo {
+            recall_id: new_id,
+            device_ids: device_ids.clone(),
+            issuer: regulator,
+            issuer_role: Symbol::new(&env, "reg"),
+            recall_reason,
+            severity,
+            recall_date,
+            action_required,
+            resolution_deadline: None,
+            emergency_scope: Some(emergency_scope),
         };
         env.storage()
             .persistent()
@@ -421,5 +519,24 @@ impl MedicalDeviceRegistry {
         }
 
         Ok(recalls)
+    }
+
+    fn assert_manufacturer_controls_devices(
+        env: &Env,
+        manufacturer: &Address,
+        device_ids: &Vec<u64>,
+    ) -> Result<(), Error> {
+        for device_id in device_ids.iter() {
+            let device: DeviceRecord = env
+                .storage()
+                .persistent()
+                .get(&DataKey::DeviceRecord(device_id))
+                .ok_or(Error::RecordNotFound)?;
+            if device.manufacturer_id != *manufacturer {
+                return Err(Error::NotAuthorized);
+            }
+        }
+
+        Ok(())
     }
 }

--- a/contracts/medical-device-tracking/src/test.rs
+++ b/contracts/medical-device-tracking/src/test.rs
@@ -8,8 +8,21 @@ fn dummy_hash(env: &Env) -> BytesN<32> {
     BytesN::from_array(env, &[0u8; 32])
 }
 
-fn register_device_helper(env: &Env, client: &MedicalDeviceRegistryClient) -> u64 {
+fn setup_client(env: &Env) -> MedicalDeviceRegistryClient<'_> {
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(env, &contract_id);
+    let regulator = Address::generate(env);
+    client.initialize(&regulator);
+    client
+}
+
+fn register_device_helper(
+    env: &Env,
+    client: &MedicalDeviceRegistryClient,
+    manufacturer_id: &Address,
+) -> u64 {
     client.register_device(
+        manufacturer_id,
         &String::from_str(env, "UDI-12345-ABC"),
         &Symbol::new(env, "IMPLANT"),
         &String::from_str(env, "MedCorp"),
@@ -26,13 +39,13 @@ fn test_register_device() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
+    let manufacturer = Address::generate(&env);
 
-    let id = register_device_helper(&env, &client);
+    let id = register_device_helper(&env, &client, &manufacturer);
     assert_eq!(id, 1);
 
-    let id2 = register_device_helper(&env, &client);
+    let id2 = register_device_helper(&env, &client, &manufacturer);
     assert_eq!(id2, 2);
 }
 
@@ -41,10 +54,11 @@ fn test_register_device_with_expiration() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
+    let manufacturer = Address::generate(&env);
 
     let id = client.register_device(
+        &manufacturer,
         &String::from_str(&env, "UDI-99999-XYZ"),
         &Symbol::new(&env, "DME"),
         &String::from_str(&env, "DeviceMaker"),
@@ -62,13 +76,13 @@ fn test_implant_device() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
 
     let patient_id = Address::generate(&env);
     let provider_id = Address::generate(&env);
+    let manufacturer = Address::generate(&env);
 
-    let device_id = register_device_helper(&env, &client);
+    let device_id = register_device_helper(&env, &client, &manufacturer);
 
     let implant_id = client.implant_device(
         &patient_id,
@@ -96,8 +110,7 @@ fn test_implant_device_nonexistent_returns_error() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
 
     let patient_id = Address::generate(&env);
     let provider_id = Address::generate(&env);
@@ -118,12 +131,12 @@ fn test_prescribe_dme() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
 
     let patient_id = Address::generate(&env);
     let provider_id = Address::generate(&env);
-    let device_id = register_device_helper(&env, &client);
+    let manufacturer = Address::generate(&env);
+    let device_id = register_device_helper(&env, &client, &manufacturer);
 
     let rx_id = client.prescribe_dme(
         &patient_id,
@@ -153,14 +166,14 @@ fn test_record_device_maintenance() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
 
     let patient_id = Address::generate(&env);
     let provider_id = Address::generate(&env);
     let technician = Address::generate(&env);
+    let manufacturer = Address::generate(&env);
 
-    let device_id = register_device_helper(&env, &client);
+    let device_id = register_device_helper(&env, &client, &manufacturer);
     let implant_id = client.implant_device(
         &patient_id,
         &device_id,
@@ -215,11 +228,10 @@ fn test_issue_device_recall() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
 
     let manufacturer = Address::generate(&env);
-    let device_id = register_device_helper(&env, &client);
+    let device_id = register_device_helper(&env, &client, &manufacturer);
 
     let mut device_ids: Vec<u64> = Vec::new(&env);
     device_ids.push_back(device_id);
@@ -240,15 +252,14 @@ fn test_notify_affected_patients() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
 
     let patient1 = Address::generate(&env);
     let patient2 = Address::generate(&env);
     let provider = Address::generate(&env);
     let manufacturer = Address::generate(&env);
 
-    let device_id = register_device_helper(&env, &client);
+    let device_id = register_device_helper(&env, &client, &manufacturer);
 
     client.implant_device(
         &patient1,
@@ -290,15 +301,14 @@ fn test_notify_affected_patients_excludes_removed() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
 
     let patient1 = Address::generate(&env);
     let patient2 = Address::generate(&env);
     let provider = Address::generate(&env);
     let manufacturer = Address::generate(&env);
 
-    let device_id = register_device_helper(&env, &client);
+    let device_id = register_device_helper(&env, &client, &manufacturer);
 
     let implant_id1 = client.implant_device(
         &patient1,
@@ -348,8 +358,7 @@ fn test_notify_affected_patients_recall_not_found() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
 
     let res = client.try_notify_affected_patients(&999u64, &1750100000u64);
     assert!(res.is_err());
@@ -360,13 +369,13 @@ fn test_remove_implant() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
 
     let patient_id = Address::generate(&env);
     let provider_id = Address::generate(&env);
+    let manufacturer = Address::generate(&env);
 
-    let device_id = register_device_helper(&env, &client);
+    let device_id = register_device_helper(&env, &client, &manufacturer);
     let implant_id = client.implant_device(
         &patient_id,
         &device_id,
@@ -400,8 +409,7 @@ fn test_remove_implant_not_found() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
 
     let provider_id = Address::generate(&env);
     let res = client.try_remove_implant(
@@ -419,13 +427,13 @@ fn test_remove_implant_already_inactive() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
 
     let patient_id = Address::generate(&env);
     let provider_id = Address::generate(&env);
+    let manufacturer = Address::generate(&env);
 
-    let device_id = register_device_helper(&env, &client);
+    let device_id = register_device_helper(&env, &client, &manufacturer);
     let implant_id = client.implant_device(
         &patient_id,
         &device_id,
@@ -459,13 +467,13 @@ fn test_track_device_performance_no_complications() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
 
     let patient_id = Address::generate(&env);
     let provider_id = Address::generate(&env);
+    let manufacturer = Address::generate(&env);
 
-    let device_id = register_device_helper(&env, &client);
+    let device_id = register_device_helper(&env, &client, &manufacturer);
     let implant_id = client.implant_device(
         &patient_id,
         &device_id,
@@ -489,13 +497,12 @@ fn test_track_device_performance_with_complications() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
 
     let patient_id = Address::generate(&env);
     let provider_id = Address::generate(&env);
-
-    let device_id = register_device_helper(&env, &client);
+    let manufacturer = Address::generate(&env);
+    let device_id = register_device_helper(&env, &client, &manufacturer);
     let implant_id = client.implant_device(
         &patient_id,
         &device_id,
@@ -542,14 +549,14 @@ fn test_get_patient_implants_active_only_filter() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
 
     let patient_id = Address::generate(&env);
     let provider_id = Address::generate(&env);
     let requester = Address::generate(&env);
+    let manufacturer = Address::generate(&env);
 
-    let device_id = register_device_helper(&env, &client);
+    let device_id = register_device_helper(&env, &client, &manufacturer);
 
     let implant_id1 = client.implant_device(
         &patient_id,
@@ -588,11 +595,10 @@ fn test_check_device_recalls() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
 
     let manufacturer = Address::generate(&env);
-    let device_id = register_device_helper(&env, &client);
+    let device_id = register_device_helper(&env, &client, &manufacturer);
 
     let no_recalls = client.check_device_recalls(&device_id);
     assert_eq!(no_recalls.len(), 0);
@@ -630,9 +636,72 @@ fn test_check_device_recalls_no_results_for_unknown_device() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
-    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let client = setup_client(&env);
 
     let recalls = client.check_device_recalls(&999u64);
     assert_eq!(recalls.len(), 0);
+}
+
+#[test]
+fn test_recall_rejected_for_unrelated_manufacturer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = setup_client(&env);
+    let manufacturer = Address::generate(&env);
+    let spoofing_manufacturer = Address::generate(&env);
+    let device_id = register_device_helper(&env, &client, &manufacturer);
+
+    let mut device_ids: Vec<u64> = Vec::new(&env);
+    device_ids.push_back(device_id);
+
+    let result = client.try_issue_device_recall(
+        &spoofing_manufacturer,
+        &device_ids,
+        &String::from_str(&env, "Spoofed recall"),
+        &Symbol::new(&env, "HIGH"),
+        &1750000000u64,
+        &String::from_str(&env, "Ignore"),
+    );
+    assert_eq!(result, Err(Ok(Error::NotAuthorized)));
+}
+
+#[test]
+fn test_regulator_emergency_recall_records_scope() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, MedicalDeviceRegistry);
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+    let regulator = Address::generate(&env);
+    client.initialize(&regulator);
+
+    let manufacturer_a = Address::generate(&env);
+    let manufacturer_b = Address::generate(&env);
+    let device_a = register_device_helper(&env, &client, &manufacturer_a);
+    let device_b = register_device_helper(&env, &client, &manufacturer_b);
+
+    let mut device_ids: Vec<u64> = Vec::new(&env);
+    device_ids.push_back(device_a);
+    device_ids.push_back(device_b);
+
+    let recall_id = client.issue_regulator_recall(
+        &regulator,
+        &device_ids,
+        &String::from_str(&env, "Cross-manufacturer safety event"),
+        &Symbol::new(&env, "CRITICAL"),
+        &1750000000u64,
+        &String::from_str(&env, "Immediate quarantine"),
+        &String::from_str(&env, "national-device-hold"),
+    );
+
+    let recalls = client.check_device_recalls(&device_a);
+    let recall = recalls.get(0).unwrap();
+    assert_eq!(recall_id, recall.recall_id);
+    assert_eq!(recall.issuer, regulator);
+    assert_eq!(recall.issuer_role, Symbol::new(&env, "reg"));
+    assert_eq!(
+        recall.emergency_scope,
+        Some(String::from_str(&env, "national-device-hold"))
+    );
 }

--- a/contracts/medical-device-tracking/src/types.rs
+++ b/contracts/medical-device-tracking/src/types.rs
@@ -3,6 +3,7 @@ use soroban_sdk::{contracterror, contracttype, Address, BytesN, String, Symbol, 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataKey {
+    Regulator,
     DeviceCounter,
     ImplantCounter,
     DmeCounter,
@@ -26,6 +27,8 @@ pub enum Error {
     NotAuthorized = 1,
     RecordNotFound = 2,
     DeviceNotActive = 3,
+    InvalidInput = 4,
+    AlreadyInitialized = 5,
 }
 
 #[contracttype]
@@ -34,6 +37,7 @@ pub struct DeviceRecord {
     pub device_id: u64,
     pub device_udi: String,
     pub device_type: Symbol,
+    pub manufacturer_id: Address,
     pub manufacturer: String,
     pub model_number: String,
     pub lot_number: String,
@@ -98,9 +102,12 @@ pub struct PerformanceReport {
 pub struct RecallInfo {
     pub recall_id: u64,
     pub device_ids: Vec<u64>,
+    pub issuer: Address,
+    pub issuer_role: Symbol,
     pub recall_reason: String,
     pub severity: Symbol,
     pub recall_date: u64,
     pub action_required: String,
     pub resolution_deadline: Option<u64>,
+    pub emergency_scope: Option<String>,
 }

--- a/contracts/pacs-integration/src/lib.rs
+++ b/contracts/pacs-integration/src/lib.rs
@@ -204,6 +204,7 @@ impl PacsContract {
         patient_id: Address,
         viewer_id: Address,
         access_type: Symbol,
+        purpose: String,
         expires_at: Option<u64>,
     ) -> Result<(), Error> {
         patient_id.require_auth();
@@ -212,23 +213,91 @@ impl PacsContract {
         if study.patient_id != patient_id {
             return Err(Error::Unauthorized);
         }
+        if purpose.is_empty() {
+            return Err(Error::InvalidInput);
+        }
+        if let Some(exp) = expires_at {
+            if exp <= env.ledger().timestamp() {
+                return Err(Error::InvalidInput);
+            }
+        }
 
         let grant = AccessGrant {
             viewer_id: viewer_id.clone(),
             access_type,
+            purpose: purpose.clone(),
             granted_at: env.ledger().timestamp(),
             expires_at,
+            revoked_at: None,
         };
 
-        let mut grants = load_access_list(&env, study_id);
-        grants.push_back(grant);
-        save_access_list(&env, study_id, &grants);
+        let grants = load_access_list(&env, study_id);
+        let mut updated_grants = Vec::new(&env);
+        let mut replaced = false;
+
+        for existing in grants.iter() {
+            if existing.viewer_id == viewer_id && existing.purpose == purpose {
+                if !replaced {
+                    updated_grants.push_back(grant.clone());
+                    replaced = true;
+                }
+                continue;
+            }
+            updated_grants.push_back(existing);
+        }
+
+        if !replaced {
+            updated_grants.push_back(grant);
+        }
+        save_access_list(&env, study_id, &updated_grants);
 
         env.events().publish(
             (symbol_short!("acc_grant"), study_id),
-            (patient_id, viewer_id),
+            (patient_id, viewer_id, purpose),
         );
 
+        Ok(())
+    }
+
+    /// Patient revokes a viewer's purpose-scoped access grant.
+    pub fn revoke_imaging_access(
+        env: Env,
+        study_id: u64,
+        patient_id: Address,
+        viewer_id: Address,
+        purpose: String,
+    ) -> Result<(), Error> {
+        patient_id.require_auth();
+
+        let study = load_study(&env, study_id).ok_or(Error::NotFound)?;
+        if study.patient_id != patient_id {
+            return Err(Error::Unauthorized);
+        }
+        if purpose.is_empty() {
+            return Err(Error::InvalidInput);
+        }
+
+        let grants = load_access_list(&env, study_id);
+        let mut updated_grants = Vec::new(&env);
+        let mut revoked = false;
+
+        for mut existing in grants.iter() {
+            if existing.viewer_id == viewer_id && existing.purpose == purpose && existing.revoked_at.is_none() {
+                existing.revoked_at = Some(env.ledger().timestamp());
+                revoked = true;
+            }
+            updated_grants.push_back(existing);
+        }
+
+        if !revoked {
+            return Err(Error::NotFound);
+        }
+
+        save_access_list(&env, study_id, &updated_grants);
+        env.events().publish(
+            (symbol_short!("acc_rev"), study_id),
+            (patient_id, viewer_id, purpose),
+        );
         Ok(())
     }
 
@@ -346,6 +415,7 @@ impl PacsContract {
         env: Env,
         study_id: u64,
         viewer_id: Address,
+        purpose: String,
         view_timestamp: u64,
         view_duration: u32,
     ) -> Result<(), Error> {
@@ -356,23 +426,7 @@ impl PacsContract {
         let is_owner = study.patient_id == viewer_id || study.ordering_provider == viewer_id;
 
         if !is_owner {
-            let now = env.ledger().timestamp();
-            let grants = load_access_list(&env, study_id);
-            let mut allowed = false;
-            for grant in grants.iter() {
-                if grant.viewer_id == viewer_id {
-                    if let Some(exp) = grant.expires_at {
-                        if now > exp {
-                            return Err(Error::AccessExpired);
-                        }
-                    }
-                    allowed = true;
-                    break;
-                }
-            }
-            if !allowed {
-                return Err(Error::Unauthorized);
-            }
+            Self::assert_active_grant(&env, study_id, &viewer_id, &purpose)?;
         }
 
         let record = ViewRecord {
@@ -397,11 +451,11 @@ impl PacsContract {
         env: Env,
         patient_id: Address,
         requester: Address,
+        access_purpose: String,
         filters: ImagingFilters,
     ) -> Result<Vec<ImagingStudy>, Error> {
         requester.require_auth();
 
-        let now = env.ledger().timestamp();
         let study_ids = load_patient_studies(&env, &patient_id);
         let mut results: Vec<ImagingStudy> = Vec::new(&env);
 
@@ -413,19 +467,7 @@ impl PacsContract {
                 let mut allowed = is_owner;
 
                 if !allowed {
-                    let grants = load_access_list(&env, sid);
-                    for grant in grants.iter() {
-                        if grant.viewer_id == requester {
-                            let active = match grant.expires_at {
-                                Some(exp) => now <= exp,
-                                None => true,
-                            };
-                            if active {
-                                allowed = true;
-                            }
-                            break;
-                        }
-                    }
+                    allowed = Self::assert_active_grant(&env, sid, &requester, &access_purpose).is_ok();
                 }
 
                 if !allowed {
@@ -464,5 +506,51 @@ impl PacsContract {
         }
 
         Ok(results)
+    }
+
+    /// Return grants for a study to the patient owner or ordering provider.
+    pub fn get_access_grants(
+        env: Env,
+        study_id: u64,
+        requester: Address,
+    ) -> Result<Vec<AccessGrant>, Error> {
+        requester.require_auth();
+
+        let study = load_study(&env, study_id).ok_or(Error::NotFound)?;
+        if requester != study.patient_id && requester != study.ordering_provider {
+            return Err(Error::Unauthorized);
+        }
+
+        Ok(load_access_list(&env, study_id))
+    }
+
+    fn assert_active_grant(
+        env: &Env,
+        study_id: u64,
+        viewer_id: &Address,
+        purpose: &String,
+    ) -> Result<(), Error> {
+        if purpose.is_empty() {
+            return Err(Error::InvalidInput);
+        }
+
+        let now = env.ledger().timestamp();
+        let grants = load_access_list(env, study_id);
+
+        for grant in grants.iter() {
+            if grant.viewer_id == *viewer_id && grant.purpose == *purpose {
+                if grant.revoked_at.is_some() {
+                    return Err(Error::GrantRevoked);
+                }
+                if let Some(exp) = grant.expires_at {
+                    if now > exp {
+                        return Err(Error::AccessExpired);
+                    }
+                }
+                return Ok(());
+            }
+        }
+
+        Err(Error::Unauthorized)
     }
 }

--- a/contracts/pacs-integration/src/test.rs
+++ b/contracts/pacs-integration/src/test.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Symbol, Vec};
 
-use crate::types::{ComparisonCriteria, ImagingFilters};
+use crate::types::{ComparisonCriteria, Error, ImagingFilters};
 use crate::{PacsContract, PacsContractClient};
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -211,9 +211,16 @@ fn grant_access_and_track_view() {
         &patient,
         &viewer,
         &Symbol::new(&env, "view_only"),
+        &String::from_str(&env, "clinical-review"),
         &None,
     );
-    client.track_study_views(&sid, &viewer, &1_700_001_000_u64, &30_u32);
+    client.track_study_views(
+        &sid,
+        &viewer,
+        &String::from_str(&env, "clinical-review"),
+        &1_700_001_000_u64,
+        &30_u32,
+    );
 }
 
 #[test]
@@ -223,8 +230,20 @@ fn patient_and_provider_can_view_without_grant() {
     let (client, patient, provider) = setup(&env);
     let sid = register_ct_chest(&env, &client, &patient, &provider);
 
-    client.track_study_views(&sid, &patient, &1_700_001_100_u64, &10_u32);
-    client.track_study_views(&sid, &provider, &1_700_001_200_u64, &5_u32);
+    client.track_study_views(
+        &sid,
+        &patient,
+        &String::from_str(&env, ""),
+        &1_700_001_100_u64,
+        &10_u32,
+    );
+    client.track_study_views(
+        &sid,
+        &provider,
+        &String::from_str(&env, ""),
+        &1_700_001_200_u64,
+        &5_u32,
+    );
 }
 
 #[test]
@@ -235,7 +254,13 @@ fn unauthorized_viewer_fails() {
     let sid = register_ct_chest(&env, &client, &patient, &provider);
     let stranger = Address::generate(&env);
 
-    let result = client.try_track_study_views(&sid, &stranger, &0_u64, &0_u32);
+    let result = client.try_track_study_views(
+        &sid,
+        &stranger,
+        &String::from_str(&env, "clinical-review"),
+        &0_u64,
+        &0_u32,
+    );
     assert!(result.is_err());
 }
 
@@ -320,7 +345,12 @@ fn search_studies_modality_filter() {
         end_date: None,
         has_critical_findings: None,
     };
-    let results = client.search_imaging_studies(&patient, &patient, &filters);
+    let results = client.search_imaging_studies(
+        &patient,
+        &patient,
+        &String::from_str(&env, ""),
+        &filters,
+    );
     assert_eq!(results.len(), 1);
 }
 
@@ -338,7 +368,12 @@ fn search_studies_wrong_modality_no_results() {
         end_date: None,
         has_critical_findings: None,
     };
-    let results = client.search_imaging_studies(&patient, &patient, &filters);
+    let results = client.search_imaging_studies(
+        &patient,
+        &patient,
+        &String::from_str(&env, ""),
+        &filters,
+    );
     assert_eq!(results.len(), 0);
 }
 
@@ -366,6 +401,104 @@ fn search_studies_critical_findings_filter() {
         end_date: None,
         has_critical_findings: Some(true),
     };
-    let results = client.search_imaging_studies(&patient, &patient, &filters);
+    let results = client.search_imaging_studies(
+        &patient,
+        &patient,
+        &String::from_str(&env, ""),
+        &filters,
+    );
     assert_eq!(results.len(), 1);
+}
+
+#[test]
+fn repeated_grant_deduplicates_by_viewer_and_purpose() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, patient, provider) = setup(&env);
+    let sid = register_ct_chest(&env, &client, &patient, &provider);
+    let viewer = Address::generate(&env);
+
+    client.grant_imaging_access(
+        &sid,
+        &patient,
+        &viewer,
+        &Symbol::new(&env, "view_only"),
+        &String::from_str(&env, "tumor-board"),
+        &Some(1_700_100_000_u64),
+    );
+    client.grant_imaging_access(
+        &sid,
+        &patient,
+        &viewer,
+        &Symbol::new(&env, "download"),
+        &String::from_str(&env, "tumor-board"),
+        &Some(1_700_200_000_u64),
+    );
+
+    let grants = client.get_access_grants(&sid, &patient);
+    assert_eq!(grants.len(), 1);
+    let grant = grants.get(0).unwrap();
+    assert_eq!(grant.access_type, Symbol::new(&env, "download"));
+    assert_eq!(grant.purpose, String::from_str(&env, "tumor-board"));
+    assert_eq!(grant.expires_at, Some(1_700_200_000_u64));
+}
+
+#[test]
+fn revoked_grant_blocks_subsequent_reads() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, patient, provider) = setup(&env);
+    let sid = register_ct_chest(&env, &client, &patient, &provider);
+    let viewer = Address::generate(&env);
+
+    client.grant_imaging_access(
+        &sid,
+        &patient,
+        &viewer,
+        &Symbol::new(&env, "view_only"),
+        &String::from_str(&env, "qa-review"),
+        &None,
+    );
+    client.revoke_imaging_access(
+        &sid,
+        &patient,
+        &viewer,
+        &String::from_str(&env, "qa-review"),
+    );
+
+    let result = client.try_track_study_views(
+        &sid,
+        &viewer,
+        &String::from_str(&env, "qa-review"),
+        &1_700_001_500_u64,
+        &15_u32,
+    );
+    assert!(matches!(result, Err(Ok(Error::GrantRevoked))));
+}
+
+#[test]
+fn wrong_purpose_cannot_use_grant() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, patient, provider) = setup(&env);
+    let sid = register_ct_chest(&env, &client, &patient, &provider);
+    let viewer = Address::generate(&env);
+
+    client.grant_imaging_access(
+        &sid,
+        &patient,
+        &viewer,
+        &Symbol::new(&env, "view_only"),
+        &String::from_str(&env, "care-coordination"),
+        &None,
+    );
+
+    let result = client.try_track_study_views(
+        &sid,
+        &viewer,
+        &String::from_str(&env, "research"),
+        &1_700_001_600_u64,
+        &12_u32,
+    );
+    assert!(matches!(result, Err(Ok(Error::Unauthorized))));
 }

--- a/contracts/pacs-integration/src/types.rs
+++ b/contracts/pacs-integration/src/types.rs
@@ -10,6 +10,7 @@ pub enum Error {
     AlreadyExists = 4,
     AccessExpired = 5,
     ReportAlreadyExists = 6,
+    GrantRevoked = 7,
 }
 
 #[contracttype]
@@ -72,8 +73,10 @@ pub struct ImagingReport {
 pub struct AccessGrant {
     pub viewer_id: Address,
     pub access_type: Symbol,
+    pub purpose: String,
     pub granted_at: u64,
     pub expires_at: Option<u64>,
+    pub revoked_at: Option<u64>,
 }
 
 #[contracttype]

--- a/contracts/provider-registry/src/lib.rs
+++ b/contracts/provider-registry/src/lib.rs
@@ -3,7 +3,7 @@
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, vec,
-    Address, Env, String, Vec,
+    Address, BytesN, Env, String, Vec,
 };
 
 mod test;
@@ -18,6 +18,9 @@ pub enum ContractError {
     Unauthorized = 4,
     NotFound = 5,
     AlreadyInitialized = 6,
+    InvalidCredential = 7,
+    CredentialExpired = 8,
+    CredentialRevoked = 9,
 }
 
 #[contracttype]
@@ -34,7 +37,26 @@ pub struct ProviderRateWindow {
     pub window_start: u64,
 }
 
-/// A stored medical record with its creator tracked for ownership transfer.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CredentialAnchor {
+    pub credential_hash: BytesN<32>,
+    pub issuer: Address,
+    pub attestation_hash: BytesN<32>,
+    pub expires_at: u64,
+    pub revocation_reference: BytesN<32>,
+    pub revoked_at: Option<u64>,
+    pub revoked_by: Option<Address>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderProfile {
+    pub credential: CredentialAnchor,
+    pub active: bool,
+    pub registered_at: u64,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Record {
@@ -59,7 +81,7 @@ pub enum DataKey {
     RateLimitConfig,
     ProviderRate(Address),
     ProviderReputation(Address),
-    ProviderRatingByPatient(Address, Address), // (provider, patient)
+    ProviderRatingByPatient(Address, Address),
 }
 
 #[contract]
@@ -67,7 +89,6 @@ pub struct ProviderRegistry;
 
 #[contractimpl]
 impl ProviderRegistry {
-    /// Initialize the contract with an admin address.
     pub fn initialize(env: Env, admin: Address) -> Result<(), ContractError> {
         if env.storage().persistent().has(&DataKey::Admin) {
             return Err(ContractError::AlreadyInitialized);
@@ -77,8 +98,6 @@ impl ProviderRegistry {
         Ok(())
     }
 
-    /// Configure rolling per-provider rate limit for `add_record`. Admin only.
-    /// Use `max_records = 0` or `window_seconds = 0` to disable limiting.
     pub fn set_rate_limit(env: Env, admin: Address, max_records: u32, window_seconds: u64) {
         Self::assert_admin(&env, &admin);
         env.storage().instance().set(
@@ -90,35 +109,77 @@ impl ProviderRegistry {
         );
     }
 
-    /// Whitelist a provider address. Admin only.
-    pub fn register_provider(env: Env, admin: Address, provider: Address) {
+    pub fn register_provider(
+        env: Env,
+        admin: Address,
+        provider: Address,
+        issuer: Address,
+        credential_hash: BytesN<32>,
+        attestation_hash: BytesN<32>,
+        expires_at: u64,
+        revocation_reference: BytesN<32>,
+    ) -> Result<(), ContractError> {
         Self::assert_admin(&env, &admin);
+        provider.require_auth();
+        issuer.require_auth();
+        Self::assert_future_expiry(&env, expires_at)?;
+
+        let profile = ProviderProfile {
+            credential: CredentialAnchor {
+                credential_hash,
+                issuer,
+                attestation_hash,
+                expires_at,
+                revocation_reference,
+                revoked_at: None,
+                revoked_by: None,
+            },
+            active: true,
+            registered_at: env.ledger().timestamp(),
+        };
+
         env.storage()
             .persistent()
-            .set(&DataKey::Provider(provider.clone()), &true);
+            .set(&DataKey::Provider(provider.clone()), &profile);
         env.events()
             .publish((symbol_short!("reg_prov"), provider), symbol_short!("ok"));
+        Ok(())
     }
 
-    /// Remove a provider from the whitelist. Admin only.
-    pub fn revoke_provider(env: Env, admin: Address, provider: Address) {
+    pub fn revoke_provider(env: Env, admin: Address, provider: Address) -> Result<(), ContractError> {
         Self::assert_admin(&env, &admin);
-        env.storage()
+
+        let key = DataKey::Provider(provider.clone());
+        let mut profile: ProviderProfile = env
+            .storage()
             .persistent()
-            .remove(&DataKey::Provider(provider.clone()));
+            .get(&key)
+            .ok_or(ContractError::NotFound)?;
+
+        profile.active = false;
+        profile.credential.revoked_at = Some(env.ledger().timestamp());
+        profile.credential.revoked_by = Some(admin.clone());
+        env.storage().persistent().set(&key, &profile);
+
         env.events()
             .publish((symbol_short!("rev_prov"), provider), symbol_short!("ok"));
+        Ok(())
     }
 
-    /// Returns true if the address is a whitelisted provider.
     pub fn is_provider(env: Env, provider: Address) -> bool {
+        Self::provider_is_active(&env, &provider)
+    }
+
+    pub fn get_provider_profile(
+        env: Env,
+        provider: Address,
+    ) -> Result<ProviderProfile, ContractError> {
         env.storage()
             .persistent()
             .get(&DataKey::Provider(provider))
-            .unwrap_or(false)
+            .ok_or(ContractError::NotFound)
     }
 
-    /// Add a medical record. Caller must be a whitelisted provider.
     pub fn add_record(
         env: Env,
         provider: Address,
@@ -126,9 +187,7 @@ impl ProviderRegistry {
         data: String,
     ) -> Result<(), ContractError> {
         provider.require_auth();
-        if !Self::is_provider(env.clone(), provider.clone()) {
-            return Err(ContractError::Unauthorized);
-        }
+        Self::load_active_provider(&env, &provider)?;
         Self::consume_provider_rate_slot(&env, &provider)?;
 
         let record = Record {
@@ -139,7 +198,6 @@ impl ProviderRegistry {
             .persistent()
             .set(&DataKey::Record(record_id.clone()), &record);
 
-        // Track this record_id under the provider's list for batch transfer.
         let list_key = DataKey::ProviderRecords(provider.clone());
         let mut ids: Vec<String> = env
             .storage()
@@ -160,7 +218,6 @@ impl ProviderRegistry {
         Ok(())
     }
 
-    /// Retrieve a medical record by ID.
     pub fn get_record(env: Env, record_id: String) -> Result<Record, ContractError> {
         env.storage()
             .persistent()
@@ -168,7 +225,6 @@ impl ProviderRegistry {
             .ok_or(ContractError::NotFound)
     }
 
-    /// Retrieve the total number of records ever created by a provider.
     pub fn get_provider_record_count(env: Env, provider: Address) -> u64 {
         env.storage()
             .persistent()
@@ -176,8 +232,6 @@ impl ProviderRegistry {
             .unwrap_or(0)
     }
 
-    /// Rate a provider with score 1..=5.
-    /// A patient can only rate the same provider once.
     pub fn rate_provider(
         env: Env,
         patient: Address,
@@ -189,9 +243,7 @@ impl ProviderRegistry {
         if !(1..=5).contains(&score) {
             return Err(ContractError::InvalidScore);
         }
-        if !Self::is_provider(env.clone(), provider.clone()) {
-            return Err(ContractError::NotFound);
-        }
+        Self::load_active_provider(&env, &provider)?;
 
         let patient_rating_key = DataKey::ProviderRatingByPatient(provider.clone(), patient);
         if env.storage().persistent().has(&patient_rating_key) {
@@ -220,7 +272,6 @@ impl ProviderRegistry {
         Ok(())
     }
 
-    /// Returns (total_ratings, average_score_scaled_by_100).
     pub fn get_provider_reputation(env: Env, provider: Address) -> (u64, u64) {
         let reputation_key = DataKey::ProviderReputation(provider);
         let reputation: ProviderReputation = env
@@ -239,12 +290,15 @@ impl ProviderRegistry {
         (reputation.total_ratings, average_scaled)
     }
 
-    /// Deactivate a provider: reassign all their records to `successor`,
-    /// remove them from the whitelist, and emit deactivation events. Admin only.
-    pub fn deactivate_provider(env: Env, admin: Address, provider: Address, successor: Address) {
+    pub fn deactivate_provider(
+        env: Env,
+        admin: Address,
+        provider: Address,
+        successor: Address,
+    ) -> Result<(), ContractError> {
         Self::assert_admin(&env, &admin);
+        Self::load_active_provider(&env, &successor)?;
 
-        // Batch-transfer every record created_by `provider` to `successor`.
         let list_key = DataKey::ProviderRecords(provider.clone());
         let ids: Vec<String> = env
             .storage()
@@ -261,7 +315,6 @@ impl ProviderRegistry {
             }
         }
 
-        // Move the record-id list to the successor's index.
         if count > 0 {
             let succ_key = DataKey::ProviderRecords(successor.clone());
             let mut succ_ids: Vec<String> = env
@@ -276,10 +329,16 @@ impl ProviderRegistry {
         }
         env.storage().persistent().remove(&list_key);
 
-        // Remove provider from whitelist.
-        env.storage()
+        let key = DataKey::Provider(provider.clone());
+        let mut profile: ProviderProfile = env
+            .storage()
             .persistent()
-            .remove(&DataKey::Provider(provider.clone()));
+            .get(&key)
+            .ok_or(ContractError::NotFound)?;
+        profile.active = false;
+        profile.credential.revoked_at = Some(env.ledger().timestamp());
+        profile.credential.revoked_by = Some(admin.clone());
+        env.storage().persistent().set(&key, &profile);
 
         env.events().publish(
             (symbol_short!("prov_deac"), provider.clone()),
@@ -287,9 +346,8 @@ impl ProviderRegistry {
         );
         env.events()
             .publish((symbol_short!("rec_xfer"), provider, successor), count);
+        Ok(())
     }
-
-    // ── helpers ──────────────────────────────────────────────────────────────
 
     fn assert_admin(env: &Env, caller: &Address) {
         caller.require_auth();
@@ -303,7 +361,49 @@ impl ProviderRegistry {
         }
     }
 
-    /// Per-provider counter with window start; resets when ledger time passes the window.
+    fn assert_future_expiry(env: &Env, expires_at: u64) -> Result<(), ContractError> {
+        if expires_at <= env.ledger().timestamp() {
+            return Err(ContractError::CredentialExpired);
+        }
+        Ok(())
+    }
+
+    fn provider_is_active(env: &Env, provider: &Address) -> bool {
+        let Some(profile) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, ProviderProfile>(&DataKey::Provider(provider.clone()))
+        else {
+            return false;
+        };
+
+        profile.active && Self::credential_is_active(env, &profile.credential).is_ok()
+    }
+
+    fn load_active_provider(env: &Env, provider: &Address) -> Result<ProviderProfile, ContractError> {
+        let profile: ProviderProfile = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Provider(provider.clone()))
+            .ok_or(ContractError::NotFound)?;
+
+        if !profile.active {
+            return Err(ContractError::Unauthorized);
+        }
+        Self::credential_is_active(env, &profile.credential)?;
+        Ok(profile)
+    }
+
+    fn credential_is_active(env: &Env, credential: &CredentialAnchor) -> Result<(), ContractError> {
+        if credential.revoked_at.is_some() {
+            return Err(ContractError::CredentialRevoked);
+        }
+        if credential.expires_at <= env.ledger().timestamp() {
+            return Err(ContractError::CredentialExpired);
+        }
+        Ok(())
+    }
+
     fn consume_provider_rate_slot(env: &Env, provider: &Address) -> Result<(), ContractError> {
         let config_opt: Option<RateLimitConfig> =
             env.storage().instance().get(&DataKey::RateLimitConfig);
@@ -316,14 +416,14 @@ impl ProviderRegistry {
 
         let now = env.ledger().timestamp();
         let key = DataKey::ProviderRate(provider.clone());
-        let mut state: ProviderRateWindow =
-            env.storage()
-                .persistent()
-                .get(&key)
-                .unwrap_or(ProviderRateWindow {
-                    count: 0,
-                    window_start: 0,
-                });
+        let mut state: ProviderRateWindow = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(ProviderRateWindow {
+                count: 0,
+                window_start: 0,
+            });
 
         let window_end = state.window_start.saturating_add(config.window_seconds);
         if state.window_start == 0 || now >= window_end {

--- a/contracts/provider-registry/src/test.rs
+++ b/contracts/provider-registry/src/test.rs
@@ -1,7 +1,9 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, Env, String};
+use soroban_sdk::{
+    testutils::Address as _, testutils::Ledger as _, Address, BytesN, Env, String,
+};
 
 fn setup() -> (Env, Address, ProviderRegistryClient<'static>) {
     let env = Env::default();
@@ -13,26 +15,67 @@ fn setup() -> (Env, Address, ProviderRegistryClient<'static>) {
     (env, admin, client)
 }
 
+fn dummy_hash(env: &Env, byte: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[byte; 32])
+}
+
+fn register_provider_with_anchor(
+    env: &Env,
+    client: &ProviderRegistryClient<'_>,
+    admin: &Address,
+    provider: &Address,
+) {
+    let issuer = Address::generate(env);
+    client.register_provider(
+        admin,
+        provider,
+        &issuer,
+        &dummy_hash(env, 1),
+        &dummy_hash(env, 2),
+        &4_100_000_000_u64,
+        &dummy_hash(env, 3),
+    );
+}
+
 #[test]
 fn test_register_and_is_provider() {
     let (env, admin, client) = setup();
     let provider = Address::generate(&env);
 
     assert!(!client.is_provider(&provider));
-    client.register_provider(&admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
     assert!(client.is_provider(&provider));
 }
 
 #[test]
-fn test_revoke_provider() {
+fn test_register_provider_exposes_profile() {
     let (env, admin, client) = setup();
     let provider = Address::generate(&env);
 
-    client.register_provider(&admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
+
+    let profile = client.get_provider_profile(&provider);
+    assert_eq!(profile.credential.credential_hash, dummy_hash(&env, 1));
+    assert_eq!(profile.credential.attestation_hash, dummy_hash(&env, 2));
+    assert_eq!(profile.credential.revocation_reference, dummy_hash(&env, 3));
+    assert!(profile.active);
+}
+
+#[test]
+fn test_revoke_provider_preserves_profile_but_disables_membership() {
+    let (env, admin, client) = setup();
+    let provider = Address::generate(&env);
+
+    register_provider_with_anchor(&env, &client, &admin, &provider);
     assert!(client.is_provider(&provider));
 
     client.revoke_provider(&admin, &provider);
     assert!(!client.is_provider(&provider));
+
+    let profile = client.get_provider_profile(&provider);
+    assert!(!profile.active);
+    assert!(profile.credential.revoked_at.is_some());
+    assert_eq!(profile.credential.revoked_by, Some(admin));
 }
 
 #[test]
@@ -40,7 +83,7 @@ fn test_add_record_by_whitelisted_provider() {
     let (env, admin, client) = setup();
     let provider = Address::generate(&env);
 
-    client.register_provider(&admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
     client.add_record(
         &provider,
         &String::from_str(&env, "REC001"),
@@ -66,7 +109,7 @@ fn test_provider_record_count_persists_across_multiple_records() {
     let (env, admin, client) = setup();
     let provider = Address::generate(&env);
 
-    client.register_provider(&admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
 
     client.add_record(
         &provider,
@@ -88,63 +131,120 @@ fn test_provider_record_count_persists_across_multiple_records() {
 }
 
 #[test]
-#[should_panic(expected = "Unauthorized: not a whitelisted provider")]
 fn test_add_record_rejected_for_non_provider() {
     let (env, _admin, client) = setup();
     let stranger = Address::generate(&env);
 
-    client.add_record(
+    let result = client.try_add_record(
         &stranger,
         &String::from_str(&env, "REC002"),
         &String::from_str(&env, "Malicious data"),
     );
+    assert!(matches!(result, Err(Ok(ContractError::NotFound))));
 }
 
 #[test]
-#[should_panic(expected = "Unauthorized: not a whitelisted provider")]
 fn test_add_record_rejected_after_revocation() {
     let (env, admin, client) = setup();
     let provider = Address::generate(&env);
 
-    client.register_provider(&admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
     client.revoke_provider(&admin, &provider);
 
-    client.add_record(
+    let result = client.try_add_record(
         &provider,
         &String::from_str(&env, "REC003"),
         &String::from_str(&env, "Should fail"),
     );
+    assert!(matches!(result, Err(Ok(ContractError::Unauthorized))));
 }
 
 #[test]
-#[should_panic(expected = "Unauthorized: admin only")]
 fn test_register_provider_non_admin_rejected() {
     let (env, _admin, client) = setup();
     let non_admin = Address::generate(&env);
     let provider = Address::generate(&env);
+    let issuer = Address::generate(&env);
 
-    client.register_provider(&non_admin, &provider);
+    let result = client.try_register_provider(
+        &non_admin,
+        &provider,
+        &issuer,
+        &dummy_hash(&env, 1),
+        &dummy_hash(&env, 2),
+        &4_100_000_000_u64,
+        &dummy_hash(&env, 3),
+    );
+    assert!(matches!(result, Err(Ok(ContractError::Unauthorized))));
 }
 
 #[test]
-#[should_panic(expected = "Unauthorized: admin only")]
 fn test_revoke_provider_non_admin_rejected() {
     let (env, admin, client) = setup();
     let non_admin = Address::generate(&env);
     let provider = Address::generate(&env);
 
-    client.register_provider(&admin, &provider);
-    client.revoke_provider(&non_admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
+
+    let result = client.try_revoke_provider(&non_admin, &provider);
+    assert!(matches!(result, Err(Ok(ContractError::Unauthorized))));
 }
 
 #[test]
-#[should_panic(expected = "Already initialized")]
 fn test_double_initialize() {
     let (_env, admin, client) = setup();
-    client.initialize(&admin);
+    let result = client.try_initialize(&admin);
+    assert!(matches!(result, Err(Ok(ContractError::AlreadyInitialized))));
 }
 
-// --- Rate limit: within limit (max 50/hour, add 3) ---
+#[test]
+fn test_register_provider_rejects_expired_anchor() {
+    let (env, admin, client) = setup();
+    let provider = Address::generate(&env);
+    let issuer = Address::generate(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 100);
+    let result = client.try_register_provider(
+        &admin,
+        &provider,
+        &issuer,
+        &dummy_hash(&env, 1),
+        &dummy_hash(&env, 2),
+        &100_u64,
+        &dummy_hash(&env, 3),
+    );
+    assert!(matches!(result, Err(Ok(ContractError::CredentialExpired))));
+}
+
+#[test]
+fn test_expired_provider_loses_membership() {
+    let (env, admin, client) = setup();
+    let provider = Address::generate(&env);
+    let issuer = Address::generate(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 10);
+    client.register_provider(
+        &admin,
+        &provider,
+        &issuer,
+        &dummy_hash(&env, 1),
+        &dummy_hash(&env, 2),
+        &20_u64,
+        &dummy_hash(&env, 3),
+    );
+    assert!(client.is_provider(&provider));
+
+    env.ledger().with_mut(|li| li.timestamp = 21);
+    assert!(!client.is_provider(&provider));
+
+    let result = client.try_add_record(
+        &provider,
+        &String::from_str(&env, "REC-EXP"),
+        &String::from_str(&env, "expired"),
+    );
+    assert!(matches!(result, Err(Ok(ContractError::CredentialExpired))));
+}
+
 #[test]
 fn test_rate_limit_within_limit() {
     let (env, admin, client) = setup();
@@ -152,7 +252,7 @@ fn test_rate_limit_within_limit() {
 
     env.ledger().with_mut(|li| li.timestamp = 1_000_000);
 
-    client.register_provider(&admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
     client.set_rate_limit(&admin, &50, &3600);
 
     for id in ["REC-W-0", "REC-W-1", "REC-W-2"] {
@@ -164,7 +264,6 @@ fn test_rate_limit_within_limit() {
     }
 }
 
-// --- At limit: exactly max_records succeed, next fails ---
 #[test]
 fn test_rate_limit_at_limit() {
     let (env, admin, client) = setup();
@@ -172,7 +271,7 @@ fn test_rate_limit_at_limit() {
 
     env.ledger().with_mut(|li| li.timestamp = 2_000_000);
 
-    client.register_provider(&admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
     const MAX: u32 = 5;
     client.set_rate_limit(&admin, &MAX, &3600);
 
@@ -193,7 +292,6 @@ fn test_rate_limit_at_limit() {
     assert!(matches!(over, Err(Ok(ContractError::RateLimitExceeded))));
 }
 
-// --- Over limit (same as at-limit verification) ---
 #[test]
 fn test_rate_limit_over_limit_rejected() {
     let (env, admin, client) = setup();
@@ -201,7 +299,7 @@ fn test_rate_limit_over_limit_rejected() {
 
     env.ledger().with_mut(|li| li.timestamp = 3_000_000);
 
-    client.register_provider(&admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
     client.set_rate_limit(&admin, &2, &100);
 
     client.add_record(
@@ -223,7 +321,6 @@ fn test_rate_limit_over_limit_rejected() {
     assert!(matches!(third, Err(Ok(ContractError::RateLimitExceeded))));
 }
 
-// --- Window resets after window_seconds; can record again ---
 #[test]
 fn test_rate_limit_window_reset_allows_again() {
     let (env, admin, client) = setup();
@@ -232,7 +329,7 @@ fn test_rate_limit_window_reset_allows_again() {
     let t0 = 10_000u64;
     env.ledger().with_mut(|li| li.timestamp = t0);
 
-    client.register_provider(&admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
     client.set_rate_limit(&admin, &3, &3600);
 
     for id in ["REC-R-0", "REC-R-1", "REC-R-2"] {
@@ -250,7 +347,6 @@ fn test_rate_limit_window_reset_allows_again() {
     );
     assert!(matches!(blocked, Err(Ok(ContractError::RateLimitExceeded))));
 
-    // Past window end: new window starts
     env.ledger().with_mut(|li| li.timestamp = t0 + 3600);
 
     client.add_record(
@@ -266,16 +362,14 @@ fn test_rate_limit_window_reset_allows_again() {
     );
 }
 
-// ── deactivate_provider tests ─────────────────────────────────────────────────
-
 #[test]
 fn test_deactivate_provider_transfers_records_and_removes_whitelist() {
     let (env, admin, client) = setup();
     let provider = Address::generate(&env);
     let successor = Address::generate(&env);
 
-    client.register_provider(&admin, &provider);
-    client.register_provider(&admin, &successor);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &successor);
 
     client.add_record(
         &provider,
@@ -288,22 +382,9 @@ fn test_deactivate_provider_transfers_records_and_removes_whitelist() {
         &String::from_str(&env, "data2"),
     );
 
-    // Confirm original ownership.
-    assert_eq!(
-        client.get_record(&String::from_str(&env, "R1")).created_by,
-        provider
-    );
-    assert_eq!(
-        client.get_record(&String::from_str(&env, "R2")).created_by,
-        provider
-    );
-
     client.deactivate_provider(&admin, &provider, &successor);
 
-    // Provider removed from whitelist.
     assert!(!client.is_provider(&provider));
-
-    // Both records now owned by successor.
     assert_eq!(
         client.get_record(&String::from_str(&env, "R1")).created_by,
         successor
@@ -320,22 +401,24 @@ fn test_deactivate_provider_no_records() {
     let provider = Address::generate(&env);
     let successor = Address::generate(&env);
 
-    client.register_provider(&admin, &provider);
-    // No records added — deactivation should still succeed.
+    register_provider_with_anchor(&env, &client, &admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &successor);
     client.deactivate_provider(&admin, &provider, &successor);
     assert!(!client.is_provider(&provider));
 }
 
 #[test]
-#[should_panic(expected = "Unauthorized: admin only")]
 fn test_deactivate_provider_non_admin_rejected() {
     let (env, admin, client) = setup();
     let provider = Address::generate(&env);
     let successor = Address::generate(&env);
     let non_admin = Address::generate(&env);
 
-    client.register_provider(&admin, &provider);
-    client.deactivate_provider(&non_admin, &provider, &successor);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &successor);
+
+    let result = client.try_deactivate_provider(&non_admin, &provider, &successor);
+    assert!(matches!(result, Err(Ok(ContractError::Unauthorized))));
 }
 
 #[test]
@@ -344,16 +427,14 @@ fn test_deactivate_provider_successor_accumulates_records() {
     let provider = Address::generate(&env);
     let successor = Address::generate(&env);
 
-    client.register_provider(&admin, &provider);
-    client.register_provider(&admin, &successor);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &successor);
 
-    // Successor already has a record.
     client.add_record(
         &successor,
         &String::from_str(&env, "S1"),
         &String::from_str(&env, "succ data"),
     );
-    // Provider has two records.
     client.add_record(
         &provider,
         &String::from_str(&env, "P1"),
@@ -367,7 +448,6 @@ fn test_deactivate_provider_successor_accumulates_records() {
 
     client.deactivate_provider(&admin, &provider, &successor);
 
-    // All three records now belong to successor.
     assert_eq!(
         client.get_record(&String::from_str(&env, "S1")).created_by,
         successor
@@ -389,12 +469,12 @@ fn test_rate_limit_disabled_with_zero_max() {
 
     env.ledger().with_mut(|li| li.timestamp = 4_000_000);
 
-    client.register_provider(&admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
     client.set_rate_limit(&admin, &0, &3600);
 
     let ids = [
-        "REC-D-0", "REC-D-1", "REC-D-2", "REC-D-3", "REC-D-4", "REC-D-5", "REC-D-6", "REC-D-7",
-        "REC-D-8", "REC-D-9",
+        "REC-D-0", "REC-D-1", "REC-D-2", "REC-D-3", "REC-D-4", "REC-D-5", "REC-D-6",
+        "REC-D-7", "REC-D-8", "REC-D-9",
     ];
     for id in ids {
         client.add_record(
@@ -411,7 +491,7 @@ fn test_rate_provider_success() {
     let provider = Address::generate(&env);
     let patient = Address::generate(&env);
 
-    client.register_provider(&admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
     client.rate_provider(&patient, &provider, &5);
 
     let (total_ratings, average_score) = client.get_provider_reputation(&provider);
@@ -425,7 +505,7 @@ fn test_rate_provider_prevents_double_rating() {
     let provider = Address::generate(&env);
     let patient = Address::generate(&env);
 
-    client.register_provider(&admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
     client.rate_provider(&patient, &provider, &4);
 
     let second = client.try_rate_provider(&patient, &provider, &5);
@@ -438,7 +518,7 @@ fn test_rate_provider_invalid_score() {
     let provider = Address::generate(&env);
     let patient = Address::generate(&env);
 
-    client.register_provider(&admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
     let result = client.try_rate_provider(&patient, &provider, &0);
     assert!(matches!(result, Err(Ok(ContractError::InvalidScore))));
 }
@@ -451,13 +531,12 @@ fn test_get_provider_reputation_average_scaled() {
     let patient_b = Address::generate(&env);
     let patient_c = Address::generate(&env);
 
-    client.register_provider(&admin, &provider);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
     client.rate_provider(&patient_a, &provider, &5);
     client.rate_provider(&patient_b, &provider, &4);
     client.rate_provider(&patient_c, &provider, &3);
 
     let (total_ratings, average_score) = client.get_provider_reputation(&provider);
     assert_eq!(total_ratings, 3);
-    // (5 + 4 + 3) / 3 = 4.00 => 400 scaled
     assert_eq!(average_score, 400);
 }


### PR DESCRIPTION
## PR Description

Closes #244 
Closes #250 
Closes #253 
Closes #256 

This branch hardens four contract areas that previously relied on weak or overly permissive state transitions. Device recalls are now tied to authenticated manufacturers with a regulator override path that leaves issuer and emergency scope on-chain. Registry membership for providers, hospitals, and insurers is now anchored to credential proofs with issuer attestations, expiry, and revocation references so membership can be independently verified. PACS access grants now have a predictable lifecycle with deduplication, revocation, purpose enforcement, and expiry-aware reads. Medical claims now enforce strict monetary invariants and track reconciliation explicitly so payments and balances remain mathematically consistent and auditable.