### PR TITLE
afeat(health-records): harden record creation and retrieval with patie…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,6 +841,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "health-records"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "healthcare-analytics"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
   "contracts",
+  "contracts/health-records",
   "contracts/patient-registry",
   "contracts/hospital-registry",
   "contracts/insurer-registry",

--- a/contracts/health-records/src/lib.rs
+++ b/contracts/health-records/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, Address, Bytes, BytesN, Env, String,
+    contract, contracterror, contractimpl, contracttype, xdr::ToXdr, Address, Bytes, BytesN, Env,
+    String,
 };
 
 #[contracttype]
@@ -20,6 +21,7 @@ pub struct MedicalRecord {
 pub enum DataKey {
     Record(u64),
     RecordCounter,
+    Consent(Address, Address), // (patient, provider) -> bool
 }
 
 #[contracterror]
@@ -27,6 +29,8 @@ pub enum DataKey {
 #[repr(u32)]
 pub enum Error {
     RecordNotFound = 1,
+    Unauthorized = 2,
+    ConsentNotGranted = 3,
 }
 
 fn compute_hash(
@@ -39,30 +43,24 @@ fn compute_hash(
     timestamp: u64,
 ) -> BytesN<32> {
     let mut data = Bytes::new(env);
-
-    // record_id as 8 big-endian bytes
     data.extend_from_array(&record_id.to_be_bytes());
-
-    // patient address bytes
     let patient_bytes = patient.clone().to_xdr(env);
     data.append(&patient_bytes);
-
-    // provider address bytes
     let provider_bytes = provider.clone().to_xdr(env);
     data.append(&provider_bytes);
-
-    // ipfs_cid bytes
     let cid_bytes = ipfs_cid.clone().to_xdr(env);
     data.append(&cid_bytes);
-
-    // record_type bytes
     let type_bytes = record_type.clone().to_xdr(env);
     data.append(&type_bytes);
-
-    // timestamp as 8 big-endian bytes
     data.extend_from_array(&timestamp.to_be_bytes());
+    env.crypto().sha256(&data).into()
+}
 
-    env.crypto().sha256(&data)
+fn has_consent(env: &Env, patient: &Address, provider: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Consent(patient.clone(), provider.clone()))
+        .unwrap_or(false)
 }
 
 #[contract]
@@ -70,14 +68,36 @@ pub struct HealthRecords;
 
 #[contractimpl]
 impl HealthRecords {
+    /// Patient grants a provider consent to create/access their records.
+    pub fn grant_consent(env: Env, patient: Address, provider: Address) {
+        patient.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Consent(patient, provider), &true);
+    }
+
+    /// Patient revokes a provider's consent.
+    pub fn revoke_consent(env: Env, patient: Address, provider: Address) {
+        patient.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Consent(patient, provider), &false);
+    }
+
+    /// Create a record. Requires both patient and provider auth, plus prior patient consent.
     pub fn create_record(
         env: Env,
         patient: Address,
         provider: Address,
         ipfs_cid: String,
         record_type: String,
-    ) -> u64 {
+    ) -> Result<u64, Error> {
         patient.require_auth();
+        provider.require_auth();
+
+        if !has_consent(&env, &patient, &provider) {
+            return Err(Error::ConsentNotGranted);
+        }
 
         let counter_key = DataKey::RecordCounter;
         let record_id: u64 = env
@@ -114,28 +134,50 @@ impl HealthRecords {
             .set(&DataKey::Record(record_id), &record);
         env.storage().persistent().set(&counter_key, &record_id);
 
-        record_id
+        Ok(record_id)
     }
 
-    pub fn get_record(env: Env, record_id: u64) -> Result<MedicalRecord, Error> {
-        env.storage()
+    /// Retrieve a record. Caller must be the patient or a consented provider.
+    pub fn get_record(env: Env, caller: Address, record_id: u64) -> Result<MedicalRecord, Error> {
+        caller.require_auth();
+
+        let record: MedicalRecord = env
+            .storage()
             .persistent()
             .get(&DataKey::Record(record_id))
-            .ok_or(Error::RecordNotFound)
+            .ok_or(Error::RecordNotFound)?;
+
+        if caller != record.patient && !has_consent(&env, &record.patient, &caller) {
+            return Err(Error::Unauthorized);
+        }
+
+        Ok(record)
     }
 
-    pub fn verify_record_integrity(env: Env, record_id: u64, expected_hash: Bytes) -> bool {
+    /// Verify integrity. Caller must be the patient or a consented provider.
+    pub fn verify_record_integrity(
+        env: Env,
+        caller: Address,
+        record_id: u64,
+        expected_hash: Bytes,
+    ) -> Result<bool, Error> {
+        caller.require_auth();
+
         let record: MedicalRecord = match env
             .storage()
             .persistent()
             .get(&DataKey::Record(record_id))
         {
             Some(r) => r,
-            None => return false,
+            None => return Ok(false),
         };
 
+        if caller != record.patient && !has_consent(&env, &record.patient, &caller) {
+            return Err(Error::Unauthorized);
+        }
+
         if expected_hash.len() != 32 {
-            return false;
+            return Ok(false);
         }
 
         let recomputed = compute_hash(
@@ -148,9 +190,8 @@ impl HealthRecords {
             record.timestamp,
         );
 
-        // Compare expected_hash (Bytes) against recomputed (BytesN<32>)
         let recomputed_bytes: Bytes = recomputed.into();
-        recomputed_bytes == expected_hash
+        Ok(recomputed_bytes == expected_hash)
     }
 }
 

--- a/contracts/health-records/src/test.rs
+++ b/contracts/health-records/src/test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::{HealthRecords, HealthRecordsClient};
+    use crate::{Error, HealthRecords, HealthRecordsClient};
     use soroban_sdk::{testutils::Address as _, Address, Bytes, Env, String};
 
     fn setup(env: &Env) -> (HealthRecordsClient<'static>, Address, Address) {
@@ -12,21 +12,98 @@ mod tests {
     }
 
     #[test]
-    fn test_create_record_stores_integrity_hash() {
+    fn test_create_record_with_consent() {
         let env = Env::default();
         env.mock_all_auths();
         let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider);
 
         let cid = String::from_str(&env, "QmTestCID123");
         let rtype = String::from_str(&env, "LAB_RESULT");
 
         let record_id = client.create_record(&patient, &provider, &cid, &rtype);
-        let record = client.get_record(&record_id);
+        let record = client.get_record(&patient, &record_id);
 
-        // integrity_hash must be 32 bytes and non-zero
         assert_eq!(record.integrity_hash.len(), 32);
         let hash_bytes: Bytes = record.integrity_hash.into();
         assert_ne!(hash_bytes, Bytes::new(&env));
+    }
+
+    #[test]
+    fn test_create_record_without_consent_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        let cid = String::from_str(&env, "QmTestCID");
+        let rtype = String::from_str(&env, "LAB_RESULT");
+
+        let result = client.try_create_record(&patient, &provider, &cid, &rtype);
+        assert_eq!(result, Err(Ok(Error::ConsentNotGranted)));
+    }
+
+    #[test]
+    fn test_get_record_by_patient() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider);
+        let cid = String::from_str(&env, "QmCID");
+        let rtype = String::from_str(&env, "PRESCRIPTION");
+        let record_id = client.create_record(&patient, &provider, &cid, &rtype);
+
+        let record = client.get_record(&patient, &record_id);
+        assert_eq!(record.record_id, record_id);
+    }
+
+    #[test]
+    fn test_get_record_by_consented_provider() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider);
+        let cid = String::from_str(&env, "QmCID");
+        let rtype = String::from_str(&env, "DIAGNOSIS");
+        let record_id = client.create_record(&patient, &provider, &cid, &rtype);
+
+        let record = client.get_record(&provider, &record_id);
+        assert_eq!(record.record_id, record_id);
+    }
+
+    #[test]
+    fn test_get_record_unauthorized_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+        let stranger = Address::generate(&env);
+
+        client.grant_consent(&patient, &provider);
+        let cid = String::from_str(&env, "QmCID");
+        let rtype = String::from_str(&env, "XRAY");
+        let record_id = client.create_record(&patient, &provider, &cid, &rtype);
+
+        let result = client.try_get_record(&stranger, &record_id);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    }
+
+    #[test]
+    fn test_get_record_after_consent_revoked_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider);
+        let cid = String::from_str(&env, "QmCID");
+        let rtype = String::from_str(&env, "LAB");
+        let record_id = client.create_record(&patient, &provider, &cid, &rtype);
+
+        client.revoke_consent(&patient, &provider);
+
+        let result = client.try_get_record(&provider, &record_id);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
     }
 
     #[test]
@@ -35,14 +112,14 @@ mod tests {
         env.mock_all_auths();
         let (client, patient, provider) = setup(&env);
 
+        client.grant_consent(&patient, &provider);
         let cid = String::from_str(&env, "QmValidCID");
         let rtype = String::from_str(&env, "PRESCRIPTION");
-
         let record_id = client.create_record(&patient, &provider, &cid, &rtype);
-        let record = client.get_record(&record_id);
+        let record = client.get_record(&patient, &record_id);
 
         let stored_hash: Bytes = record.integrity_hash.into();
-        assert!(client.verify_record_integrity(&record_id, &stored_hash));
+        assert!(client.verify_record_integrity(&patient, &record_id, &stored_hash));
     }
 
     #[test]
@@ -51,24 +128,41 @@ mod tests {
         env.mock_all_auths();
         let (client, patient, provider) = setup(&env);
 
+        client.grant_consent(&patient, &provider);
         let cid = String::from_str(&env, "QmOriginalCID");
         let rtype = String::from_str(&env, "DIAGNOSIS");
-
         let record_id = client.create_record(&patient, &provider, &cid, &rtype);
 
-        // Provide a tampered (all-zeros) 32-byte hash
         let tampered_hash = Bytes::from_array(&env, &[0u8; 32]);
-        assert!(!client.verify_record_integrity(&record_id, &tampered_hash));
+        assert!(!client.verify_record_integrity(&patient, &record_id, &tampered_hash));
+    }
+
+    #[test]
+    fn test_verify_integrity_unauthorized_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+        let stranger = Address::generate(&env);
+
+        client.grant_consent(&patient, &provider);
+        let cid = String::from_str(&env, "QmCID");
+        let rtype = String::from_str(&env, "XRAY");
+        let record_id = client.create_record(&patient, &provider, &cid, &rtype);
+        let record = client.get_record(&patient, &record_id);
+        let hash: Bytes = record.integrity_hash.into();
+
+        let result = client.try_verify_record_integrity(&stranger, &record_id, &hash);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
     }
 
     #[test]
     fn test_verify_nonexistent_record_returns_false() {
         let env = Env::default();
         env.mock_all_auths();
-        let (client, _, _) = setup(&env);
+        let (client, patient, _) = setup(&env);
 
         let hash = Bytes::from_array(&env, &[0u8; 32]);
-        assert!(!client.verify_record_integrity(&999u64, &hash));
+        assert!(!client.verify_record_integrity(&patient, &999u64, &hash));
     }
 
     #[test]
@@ -77,13 +171,12 @@ mod tests {
         env.mock_all_auths();
         let (client, patient, provider) = setup(&env);
 
+        client.grant_consent(&patient, &provider);
         let cid = String::from_str(&env, "QmCID");
         let rtype = String::from_str(&env, "XRAY");
-
         let record_id = client.create_record(&patient, &provider, &cid, &rtype);
 
-        // Only 16 bytes — wrong length
         let short_hash = Bytes::from_array(&env, &[0u8; 16]);
-        assert!(!client.verify_record_integrity(&record_id, &short_hash));
+        assert!(!client.verify_record_integrity(&patient, &record_id, &short_hash));
     }
 }

--- a/contracts/patient-registry/fuzz/Cargo.lock
+++ b/contracts/patient-registry/fuzz/Cargo.lock
@@ -532,9 +532,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"
@@ -921,6 +921,7 @@ dependencies = [
 name = "patient-registry-fuzz"
 version = "0.0.0"
 dependencies = [
+ "ethnum",
  "libfuzzer-sys",
  "patient-registry",
 ]

--- a/contracts/patient-registry/fuzz/Cargo.toml
+++ b/contracts/patient-registry/fuzz/Cargo.toml
@@ -10,6 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 patient-registry = { path = ".." }
+ethnum = "=1.5.3"
 
 [workspace]
 members = ["."]

--- a/contracts/patient-registry/src/lib.rs
+++ b/contracts/patient-registry/src/lib.rs
@@ -237,8 +237,8 @@ pub fn validate_cid(cid: &Bytes) -> Result<(), ContractError> {
         return Err(ContractError::InvalidCID);
     }
     let mut buf = [0u8; 512];
-    for i in 0..len {
-        buf[i] = cid.get(i as u32).ok_or(ContractError::InvalidCID)?;
+    for (i, slot) in buf[..len].iter_mut().enumerate() {
+        *slot = cid.get(i as u32).ok_or(ContractError::InvalidCID)?;
     }
     validation::validate_cid_bytes(&buf[..len]).map_err(|_| ContractError::InvalidCID)
 }
@@ -282,7 +282,7 @@ fn next_export_nonce(env: &Env, patient: &Address, issued_at: u64) -> BytesN<32>
     preimage.extend_from_array(&issued_at.to_be_bytes());
     preimage.extend_from_array(&nonce_counter.to_be_bytes());
 
-    env.crypto().sha256(&preimage)
+    env.crypto().sha256(&preimage).into()
 }
 
 fn sign_export_ticket(
@@ -298,7 +298,7 @@ fn sign_export_ticket(
     payload.extend_from_array(&expires_at.to_be_bytes());
     payload.append(&Bytes::from(nonce.clone()));
 
-    env.crypto().sha256(&payload)
+    env.crypto().sha256(&payload).into()
 }
 
 /// Enforces that `caller` is the patient, their guardian, or an authorized doctor.
@@ -972,7 +972,7 @@ impl MedicalRegistry {
     ) -> Result<(), ContractError> {
         Self::require_not_frozen(&env);
         patient.require_auth();
-        Self::require_not_on_hold(&env, &patient);
+        Self::require_not_on_hold(&env, &patient)?;
 
         let record_data: RecordData = env
             .storage()
@@ -1000,7 +1000,7 @@ impl MedicalRegistry {
         Ok(())
     }
 
-    pub fn revoke_access(env: Env, patient: Address, caller: Address, doctor: Address) {
+    pub fn revoke_access(env: Env, patient: Address, caller: Address, doctor: Address) -> Result<(), ContractError> {
         Self::require_not_frozen(&env);
         require_patient_or_guardian(&env, &patient, &caller)?;
         Self::require_not_on_hold(&env, &patient)?;
@@ -1092,7 +1092,7 @@ impl MedicalRegistry {
 
         if !access_map.contains_key(doctor.clone()) {
             return Err(ContractError::NotAuthorized);
-        }     }
+        }
 
         let timestamp = env.ledger().timestamp();
 
@@ -1487,7 +1487,7 @@ impl MedicalRegistry {
 
         let mut filtered = Vec::new(&env);
         for id in record_ids.iter() {
-            let record_id: u64 = id.into();
+            let record_id: u64 = id;
             if let Some(record_data) = env
                 .storage()
                 .persistent()

--- a/contracts/patient-registry/src/validation.rs
+++ b/contracts/patient-registry/src/validation.rs
@@ -4,8 +4,7 @@
 //! inputs never rely on Soroban host APIs. All return `Result` — **no panics**
 //! on malformed input.
 
-/// CID rules mirror [`super::validate_cid`](crate::validate_cid): length bounds,
-/// CIDv1 base32 (`b`…), CIDv0 `Qm…`, or raw multihash `0x12 0x20` + 32 bytes.
+#[allow(clippy::result_unit_err)]
 pub fn validate_cid_bytes(cid: &[u8]) -> Result<(), ()> {
     let len = cid.len();
     if len == 0 || len > 512 {
@@ -29,6 +28,7 @@ pub fn validate_cid_bytes(cid: &[u8]) -> Result<(), ()> {
 
 /// Minimal W3C DID Core–style check: UTF-8, `did:` prefix, non-empty method,
 /// non-empty method-specific id. Designed to reject garbage without panicking.
+#[allow(clippy::result_unit_err, clippy::manual_range_contains)]
 pub fn validate_did_bytes(did: &[u8]) -> Result<(), ()> {
     let len = did.len();
     if len < 7 || len > 256 {
@@ -64,6 +64,7 @@ pub fn validate_did_bytes(did: &[u8]) -> Result<(), ()> {
 pub const SCORE_MIN: i32 = 0;
 pub const SCORE_MAX: i32 = 100;
 
+#[allow(clippy::result_unit_err)]
 pub fn validate_score_i32(score: i32) -> Result<(), ()> {
     if (SCORE_MIN..=SCORE_MAX).contains(&score) {
         Ok(())


### PR DESCRIPTION
…nt-provider-consent triad checks

- Add grant_consent/revoke_consent for patient-controlled provider access
- Require both patient and provider auth plus prior consent on create_record
- Enforce caller is patient or consented provider on get_record and verify_record_integrity
- Add workspace membership for health-records crate

Closes #257