### PR TITLE
feat: Add immutable appeal history and decision lineage in prior authorization

### DIFF
--- a/contracts/prior-authorization/src/lib.rs
+++ b/contracts/prior-authorization/src/lib.rs
@@ -8,11 +8,50 @@ mod types;
 #[cfg(test)]
 mod test;
 
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, String, Symbol, Vec};
 use storage::*;
 use types::*;
 
 const MAX_APPEAL_LEVEL: u32 = 3;
+
+fn compute_review_entry_hash(env: &Env, review: &ReviewRecord) -> BytesN<32> {
+    let mut data = Bytes::new(env);
+    data.extend_from_array(&review.review_id.to_be_bytes());
+    data.extend_from_array(&review.auth_request_id.to_be_bytes());
+    data.append(&review.reviewer_id.clone().to_xdr(env));
+    data.append(&review.decision.clone().to_xdr(env));
+    data.append(&review.review_notes_hash.clone().to_xdr(env));
+    if let Some(prev_hash) = &review.prior_review_hash {
+        data.append(&prev_hash.clone().to_xdr(env));
+    }
+    data.extend_from_array(&review.timestamp.to_be_bytes());
+    env.crypto().sha256(&data)
+}
+
+fn compute_appeal_chain_hash(
+    env: &Env,
+    previous_appeal_hash: Option<BytesN<32>>,
+    ruling_dependency_hash: BytesN<32>,
+    appeal_reason_hash: BytesN<32>,
+    additional_evidence_hash: Option<BytesN<32>>,
+    provider_id: &Address,
+    appeal_level: u32,
+    submitted_at: u64,
+) -> BytesN<32> {
+    let mut data = Bytes::new(env);
+    if let Some(prev) = previous_appeal_hash {
+        data.append(&prev.clone().to_xdr(env));
+    }
+    data.append(&ruling_dependency_hash.clone().to_xdr(env));
+    data.append(&appeal_reason_hash.clone().to_xdr(env));
+    if let Some(additional) = additional_evidence_hash {
+        data.append(&additional.clone().to_xdr(env));
+    }
+    data.append(&provider_id.clone().to_xdr(env));
+    data.extend_from_array(&appeal_level.to_be_bytes());
+    data.extend_from_array(&submitted_at.to_be_bytes());
+    env.crypto().sha256(&data)
+}
 
 #[contract]
 pub struct PriorAuthorizationContract;
@@ -153,11 +192,41 @@ impl PriorAuthorizationContract {
 
         req.decision = Some(decision.clone());
 
+        // Persist review history in an append-only sequence.
+        let history = load_review_history(&env, auth_request_id);
+        let prior_review_hash = if history.is_empty() {
+            None
+        } else {
+            let last_review = history.get(history.len() - 1).unwrap();
+            Some(last_review.review_entry_hash.clone())
+        };
+        let review_notes_hash = env
+            .crypto()
+            .sha256(&review_notes.clone().to_xdr(&env));
+        let review_id = next_review_id(&env);
+        let mut review_record = ReviewRecord {
+            review_id,
+            auth_request_id,
+            reviewer_id: reviewer_id.clone(),
+            decision: decision.clone(),
+            review_notes_hash,
+            prior_review_hash,
+            review_entry_hash: BytesN::from_array(&env, &[0u8; 32]),
+            timestamp: env.ledger().timestamp(),
+        };
+        review_record.review_entry_hash = compute_review_entry_hash(&env, &review_record);
+        save_review_record(&env, &review_record);
+
         save_auth_request(&env, &req);
 
         env.events().publish(
             (Symbol::new(&env, "auth_reviewed"),),
-            (auth_request_id, decision, reviewer_id),
+            (
+                auth_request_id,
+                decision,
+                reviewer_id,
+                review_record.review_entry_hash,
+            ),
         );
 
         Ok(())
@@ -282,6 +351,39 @@ impl PriorAuthorizationContract {
 
         let appeal_id = next_appeal_id(&env);
 
+        let previous_appeal_id = if existing.is_empty() {
+            None
+        } else {
+            Some(existing.get(existing.len() - 1).unwrap().appeal_id)
+        };
+        let previous_appeal_hash = if existing.is_empty() {
+            None
+        } else {
+            Some(existing.get(existing.len() - 1).unwrap().appeal_chain_hash.clone())
+        };
+
+        let review_history = load_review_history(&env, auth_request_id);
+        let ruling_dependency_hash = if review_history.is_empty() {
+            env.crypto().sha256(&Bytes::new(&env))
+        } else {
+            review_history
+                .get(review_history.len() - 1)
+                .unwrap()
+                .review_entry_hash
+                .clone()
+        };
+
+        let appeal_chain_hash = compute_appeal_chain_hash(
+            &env,
+            previous_appeal_hash.clone(),
+            ruling_dependency_hash.clone(),
+            appeal_reason_hash.clone(),
+            additional_evidence_hash.clone(),
+            &provider_id,
+            appeal_level,
+            env.ledger().timestamp(),
+        );
+
         let appeal = Appeal {
             appeal_id,
             auth_request_id,
@@ -290,6 +392,10 @@ impl PriorAuthorizationContract {
             appeal_reason_hash,
             additional_evidence_hash,
             submitted_at: env.ledger().timestamp(),
+            previous_appeal_id,
+            previous_appeal_hash,
+            ruling_dependency_hash,
+            appeal_chain_hash,
         };
 
         save_appeal(&env, &appeal);
@@ -461,5 +567,25 @@ impl PriorAuthorizationContract {
             submitted_at: req.submitted_at,
             decision_date: req.decision_date,
         })
+    }
+
+    /// Return the full appeal timeline for an authorization request.
+    pub fn get_appeal_history(
+        env: Env,
+        auth_request_id: u64,
+        requester: Address,
+    ) -> Result<Vec<Appeal>, Error> {
+        requester.require_auth();
+        Ok(load_appeals_for_auth(&env, auth_request_id))
+    }
+
+    /// Return the full review history for an authorization request.
+    pub fn get_review_history(
+        env: Env,
+        auth_request_id: u64,
+        requester: Address,
+    ) -> Result<Vec<ReviewRecord>, Error> {
+        requester.require_auth();
+        Ok(load_review_history(&env, auth_request_id))
     }
 }

--- a/contracts/prior-authorization/src/storage.rs
+++ b/contracts/prior-authorization/src/storage.rs
@@ -2,7 +2,7 @@ use soroban_sdk::{Address, Env, Vec};
 
 use crate::types::{
     Appeal, AuthorizationRequest, DataKey, ExtensionRequest, PeerToPeerRequest,
-    SupportingDocument, UsageRecord,
+    ReviewRecord, SupportingDocument, UsageRecord,
 };
 
 // -----------------------------------------------------------------------
@@ -32,6 +32,19 @@ pub fn next_appeal_id(env: &Env) -> u64 {
     env.storage()
         .persistent()
         .set(&DataKey::AppealCounter, &next);
+    next
+}
+
+pub fn next_review_id(env: &Env) -> u64 {
+    let id: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ReviewCounter)
+        .unwrap_or(0);
+    let next = id + 1;
+    env.storage()
+        .persistent()
+        .set(&DataKey::ReviewCounter, &next);
     next
 }
 
@@ -133,6 +146,33 @@ pub fn load_appeals_for_auth(env: &Env, auth_request_id: u64) -> Vec<Appeal> {
     env.storage()
         .persistent()
         .get(&DataKey::Appeals(auth_request_id))
+        .unwrap_or(Vec::new(env))
+}
+
+// -----------------------------------------------------------------------
+// Review records
+// -----------------------------------------------------------------------
+
+pub fn save_review_record(env: &Env, review: &ReviewRecord) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Review(review.review_id), review);
+
+    let mut history: Vec<ReviewRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ReviewHistory(review.auth_request_id))
+        .unwrap_or(Vec::new(env));
+    history.push_back(review.clone());
+    env.storage()
+        .persistent()
+        .set(&DataKey::ReviewHistory(review.auth_request_id), &history);
+}
+
+pub fn load_review_history(env: &Env, auth_request_id: u64) -> Vec<ReviewRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ReviewHistory(auth_request_id))
         .unwrap_or(Vec::new(env))
 }
 

--- a/contracts/prior-authorization/src/test.rs
+++ b/contracts/prior-authorization/src/test.rs
@@ -442,6 +442,46 @@ fn test_appeal_with_additional_evidence() {
         .unwrap();
 }
 
+#[test]
+fn test_review_history_and_appeal_chain_is_tamper_evident() {
+    let (env, provider, patient) = setup();
+    let client = register_contract(&env);
+    let id = submit(&env, &client, &provider, &patient);
+    let reviewer = Address::generate(&env);
+
+    client
+        .review_authorization(
+            &id,
+            &reviewer,
+            &Symbol::new(&env, "denied"),
+            &None,
+            &None,
+            &None,
+            &String::from_str(&env, "Initial denial based on policy criteria"),
+        )
+        .unwrap();
+
+    let review_history = client.get_review_history(&id, &provider).unwrap();
+    assert_eq!(review_history.len(), 1);
+    let first_review = review_history.get(0).unwrap();
+    assert_eq!(first_review.reviewer_id, reviewer);
+    assert!(first_review.prior_review_hash.is_none());
+    assert_ne!(first_review.review_entry_hash, BytesN::from_array(&env, &[0u8; 32]));
+
+    let reason_hash = BytesN::from_array(&env, &[13u8; 32]);
+    client
+        .appeal_denial(&id, &provider, &1u32, &reason_hash, &None)
+        .unwrap();
+
+    let appeals = client.get_appeal_history(&id, &provider).unwrap();
+    assert_eq!(appeals.len(), 1);
+    let first_appeal = appeals.get(0).unwrap();
+    assert!(first_appeal.previous_appeal_id.is_none());
+    assert!(first_appeal.previous_appeal_hash.is_none());
+    assert_eq!(first_appeal.ruling_dependency_hash, first_review.review_entry_hash);
+    assert_ne!(first_appeal.appeal_chain_hash, BytesN::from_array(&env, &[0u8; 32]));
+}
+
 // -----------------------------------------------------------------------
 // expedite_authorization
 // -----------------------------------------------------------------------

--- a/contracts/prior-authorization/src/types.rs
+++ b/contracts/prior-authorization/src/types.rs
@@ -106,6 +106,20 @@ pub struct PeerToPeerRequest {
     pub medical_director: Option<Address>,
 }
 
+/// A recorded review decision for an authorization request.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReviewRecord {
+    pub review_id: u64,
+    pub auth_request_id: u64,
+    pub reviewer_id: Address,
+    pub decision: Symbol,
+    pub review_notes_hash: BytesN<32>,
+    pub prior_review_hash: Option<BytesN<32>>,
+    pub review_entry_hash: BytesN<32>,
+    pub timestamp: u64,
+}
+
 /// An appeal against a denied authorization.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -117,6 +131,10 @@ pub struct Appeal {
     pub appeal_reason_hash: BytesN<32>,
     pub additional_evidence_hash: Option<BytesN<32>>,
     pub submitted_at: u64,
+    pub previous_appeal_id: Option<u64>,
+    pub previous_appeal_hash: Option<BytesN<32>>,
+    pub ruling_dependency_hash: BytesN<32>,
+    pub appeal_chain_hash: BytesN<32>,
 }
 
 /// An extension request for an existing authorization.
@@ -148,6 +166,8 @@ pub enum DataKey {
     AuthCounter,
     /// Auto-increment counter for appeals.
     AppealCounter,
+    /// Auto-increment counter for reviews.
+    ReviewCounter,
     /// auth_request_id -> AuthorizationRequest
     AuthRequest(u64),
     /// auth_request_id -> Vec<SupportingDocument>
@@ -158,6 +178,10 @@ pub enum DataKey {
     Appeals(u64),
     /// appeal_id -> Appeal
     Appeal(u64),
+    /// auth_request_id -> Vec<ReviewRecord>
+    ReviewHistory(u64),
+    /// review_id -> ReviewRecord
+    Review(u64),
     /// auth_request_id -> ExtensionRequest
     Extension(u64),
     /// auth_request_id -> Vec<UsageRecord>


### PR DESCRIPTION
Implemented a tamper evident appeal timeline. Changes implemented include:
Updated types.rs

Added ReviewRecord to capture review decisions with:
reviewer_id,decision, review_notes_hash, prior_review_hash, review_entry_hash

Extended Appeal with:
previous_appeal_id, previous_appeal_hash, ruling_dependency_hash, appeal_chain_hash, Added storage keys for review counters and history.

Updated storage.rs:
Added next_review_id
Added save_review_record and load_review_history
Kept appeal storage append-only
Updated lib.rs

Review decisions now persist an append-only ReviewRecord. Review history chains prior review hashes into a tamper-evident record. Appeals now reference prior appeal state and the ruling dependency hash
Added get_review_history and get_appeal_history query methods
Updated test.rs

Added regression test verifying:
the review history is stored, reviewer identity is persisted, appeal chain references prior review hash and preserves lineage

Closes #252 