### PR TITLE
fix: eliminate unwrap/expect in production paths

### DIFF
--- a/contracts/lab-management/src/lib.rs
+++ b/contracts/lab-management/src/lib.rs
@@ -87,7 +87,7 @@ impl LabManagementContract {
             .storage()
             .persistent()
             .get(&order_id)
-            .expect("Order not found");
+            .unwrap_or_else(|| panic_with_error!(&env, Error::NotFound));
         order.lab_id = Some(lab_id);
         order.status = Symbol::new(&env, "Assigned");
         env.storage().persistent().set(&order_id, &order);
@@ -102,7 +102,11 @@ impl LabManagementContract {
         qc_passed: bool,
     ) {
         lab_id.require_auth();
-        let mut order: LabOrder = env.storage().persistent().get(&order_id).expect("No Order");
+        let mut order: LabOrder = env
+            .storage()
+            .persistent()
+            .get(&order_id)
+            .unwrap_or_else(|| panic_with_error!(&env, Error::NotFound));
 
         if !qc_passed {
             panic_with_error!(&env, Error::QCFieldFailed);

--- a/contracts/patient-registry/src/lib.rs
+++ b/contracts/patient-registry/src/lib.rs
@@ -446,7 +446,7 @@ impl MedicalRegistry {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("Not initialized");
+            .ok_or(ContractError::NotFound)?;
         admin.require_auth();
         if amount < 0 {
             return Err(ContractError::InvalidFee);
@@ -468,7 +468,7 @@ impl MedicalRegistry {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("Not initialized");
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotFound));
         admin.require_auth();
         env.storage()
             .persistent()
@@ -483,7 +483,7 @@ impl MedicalRegistry {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("Not initialized");
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotFound));
         admin.require_auth();
         env.storage()
             .persistent()
@@ -498,7 +498,7 @@ impl MedicalRegistry {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("Not initialized");
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotFound));
         admin.require_auth();
         env.storage()
             .persistent()
@@ -525,7 +525,7 @@ impl MedicalRegistry {
             .storage()
             .persistent()
             .get(&DataKey::ConsentVersion)
-            .expect("No consent version published");
+            .ok_or(ContractError::NotFound)?;
         if current != version_hash {
             return Err(ContractError::ConsentVersionMismatch);
         }
@@ -713,7 +713,7 @@ impl MedicalRegistry {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("Not initialized");
+            .unwrap_or_else(|| panic_with_error!(&env, ContractError::NotFound));
 
         let is_admin = admin == patient;
         if is_admin {
@@ -1068,12 +1068,12 @@ impl MedicalRegistry {
                 .storage()
                 .instance()
                 .get(&DataKey::FeeToken)
-                .expect("Fee token not configured");
+                .ok_or(ContractError::NotFound)?;
             let treasury: Address = env
                 .storage()
                 .instance()
                 .get(&DataKey::Treasury)
-                .expect("Treasury not configured");
+                .ok_or(ContractError::NotFound)?;
             token::TokenClient::new(&env, &token_id).transfer(&doctor, &treasury, &fee);
         }
 
@@ -1231,7 +1231,7 @@ impl MedicalRegistry {
                     .storage()
                     .instance()
                     .get(&DataKey::Admin)
-                    .expect("Not initialized");
+                    .ok_or(ContractError::NotFound)?;
                 if caller != admin {
                     return Err(ContractError::NotAuthorized);
                 }
@@ -1278,7 +1278,7 @@ impl MedicalRegistry {
                     .storage()
                     .instance()
                     .get(&DataKey::Admin)
-                    .expect("Not initialized");
+                    .ok_or(ContractError::NotFound)?;
                 if caller != admin {
                     return Err(ContractError::NotAuthorized);
                 }
@@ -1314,7 +1314,7 @@ impl MedicalRegistry {
             );
         }
 
-        let mut latest = records.get(0).unwrap().clone();
+        let mut latest = records.get(0).ok_or(ContractError::NoRecordsFound)?.clone();
         for r in records.iter() {
             if r.timestamp > latest.timestamp {
                 latest = r.clone();
@@ -1585,7 +1585,7 @@ impl MedicalRegistry {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("Not initialized");
+            .ok_or(ContractError::NotFound)?;
         admin.require_auth();
 
         const SNAPSHOT_INTERVAL: u32 = 100_000;
@@ -1927,7 +1927,7 @@ impl MedicalRegistry {
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("Contract not initialized");
+            .unwrap_or_else(|| panic_with_error!(env, ContractError::NotFound));
         admin.require_auth();
     }
 

--- a/contracts/patient-registry/src/merkle.rs
+++ b/contracts/patient-registry/src/merkle.rs
@@ -11,7 +11,7 @@
 //!
 //! Odd-length layers: the dangling node is paired with itself.
 
-use soroban_sdk::{Bytes, BytesN, Env, Vec};
+use soroban_sdk::{panic_with_error, Bytes, BytesN, Env, Vec};
 
 const LEAF_TAG: u8 = 0x00;
 const NODE_TAG: u8 = 0x01;
@@ -72,20 +72,20 @@ pub fn compute_merkle_root(env: &Env, record_ids: &Vec<u64>) -> BytesN<32> {
         while i + 1 < len {
             next.push_back(hash_pair(
                 env,
-                layer.get(i).unwrap(),
-                layer.get(i + 1).unwrap(),
+                layer.get(i).unwrap_or_else(|| panic_with_error!(env, crate::ContractError::NotFound)),
+                layer.get(i + 1).unwrap_or_else(|| panic_with_error!(env, crate::ContractError::NotFound)),
             ));
             i += 2;
         }
         // Odd node: pair with itself
         if len % 2 == 1 {
-            let last = layer.get(len - 1).unwrap();
+            let last = layer.get(len - 1).unwrap_or_else(|| panic_with_error!(env, crate::ContractError::NotFound));
             next.push_back(hash_pair(env, last.clone(), last));
         }
         layer = next;
     }
 
-    layer.get(0).unwrap()
+    layer.get(0).unwrap_or_else(|| panic_with_error!(env, crate::ContractError::NotFound))
 }
 
 // ─── membership verification ───────────────────────────────────────────────

--- a/contracts/prescription-management/src/lib.rs
+++ b/contracts/prescription-management/src/lib.rs
@@ -819,4 +819,5 @@ fn contains_string(values: &Vec<String>, needle: &String) -> bool {
     false
 }
 
+#[cfg(test)]
 mod test;

--- a/contracts/prior-authorization/src/lib.rs
+++ b/contracts/prior-authorization/src/lib.rs
@@ -307,7 +307,8 @@ impl PriorAuthorizationContract {
         save_peer_to_peer(&env, &p2p);
 
         // Update auth status
-        let mut req = load_auth_request(&env, auth_request_id).unwrap();
+        let mut req = load_auth_request(&env, auth_request_id)
+            .ok_or(Error::AuthRequestNotFound)?;
         req.status = AuthStatus::PeerToPeerScheduled;
         save_auth_request(&env, &req);
 
@@ -350,7 +351,8 @@ impl PriorAuthorizationContract {
         // Verify level increases monotonically
         let existing = load_appeals_for_auth(&env, auth_request_id);
         if !existing.is_empty() {
-            let last = existing.get(existing.len() - 1).unwrap();
+            let last = existing.get(existing.len() - 1)
+                .ok_or(Error::AppealNotFound)?;
             if appeal_level <= last.appeal_level {
                 return Err(Error::MaxAppealLevelReached);
             }


### PR DESCRIPTION
- prior-authorization: replace .unwrap() in schedule_peer_to_peer and appeal_denial with .ok_or(Error::AuthRequestNotFound/AppealNotFound)?
- prescription-management: gate mod test with #[cfg(test)] to exclude test-only unwrap calls from production compilation
- lab-management: replace .expect() in assign_lab and submit_results with panic_with_error!(Error::NotFound)
- patient-registry lib: replace all .expect("Not initialized") calls with ok_or(ContractError::NotFound)? in Result-returning functions and panic_with_error! in void-returning functions
- patient-registry merkle: replace four Vec::get().unwrap() calls with panic_with_error!(ContractError::NotFound) fallbacks

Eliminate expect in lab-management production paths Fixes #183

Eliminate expect/unwrap in patient-registry production and merkle helpers Fixes #185

Eliminate unwrap in prescription-management production paths Fixes #186

Eliminate unwrap in prior-authorization production paths Fixes #187