### PR TITLE
docs: add missing README files for contract crates

### DIFF
--- a/contracts/access-control/README.md
+++ b/contracts/access-control/README.md
@@ -1,0 +1,65 @@
+# Access Control Contract
+
+## Purpose
+
+`access-control` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `EntityData` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- `initialize`
+
+### Messages / Entry Points
+- `check_access`
+- `deactivate_entity`
+- `get_authorized_parties`
+- `get_did`
+- `get_entity`
+- `get_entity_permissions`
+- `grant_access`
+- `register_did`
+- `register_entity`
+- `revoke_access`
+- `update_entity`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Contains admin-oriented flows; verify caller checks in each mutating method.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p access-control
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p access-control --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/access_control.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/access_control.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/care-plan/README.md
+++ b/contracts/care-plan/README.md
@@ -1,0 +1,53 @@
+# Care Plan Contract
+
+## Purpose
+
+`care-plan` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- State keys and records are defined in `src/lib.rs` and persisted in contract storage.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- No public entry points auto-detected; review `src/lib.rs` for exported methods.
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p care-plan
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p care-plan --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/care_plan.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/care_plan.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/clinical-guideline/README.md
+++ b/contracts/clinical-guideline/README.md
@@ -1,0 +1,61 @@
+# Clinical Guideline Contract
+
+## Purpose
+
+`clinical-guideline` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `GuidelineRecommendation` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `assess_risk_score`
+- `calculate_drug_dosage`
+- `check_preventive_care`
+- `create_reminder`
+- `evaluate_guideline`
+- `register_clinical_guideline`
+- `suggest_care_pathway`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Contains admin-oriented flows; verify caller checks in each mutating method.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p clinical-guideline
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p clinical-guideline --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/clinical_guideline.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/clinical_guideline.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/clinical-trial/README.md
+++ b/contracts/clinical-trial/README.md
@@ -1,0 +1,67 @@
+# Clinical Trial Contract
+
+## Purpose
+
+`clinical-trial` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `TrialRegistered` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- `initialize`
+
+### Messages / Entry Points
+- `check_patient_eligibility`
+- `define_eligibility_criteria`
+- `enroll_participant`
+- `export_deidentified_data`
+- `get_adverse_event`
+- `get_enrollment`
+- `get_trial`
+- `record_protocol_deviation`
+- `record_study_visit`
+- `register_clinical_trial`
+- `report_adverse_event`
+- `submit_safety_report`
+- `withdraw_participant`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Contains admin-oriented flows; verify caller checks in each mutating method.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p clinical-trial
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p clinical-trial --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/clinical_trial.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/clinical_trial.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/dental-records/README.md
+++ b/contracts/dental-records/README.md
@@ -1,0 +1,63 @@
+# Dental Records Contract
+
+## Purpose
+
+`dental-records` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- State keys and records are defined in `src/lib.rs` and persisted in contract storage.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `create_dental_chart`
+- `create_treatment_plan`
+- `document_informed_consent_dental`
+- `document_procedure_performed`
+- `prescribe_dental_medication`
+- `record_dental_radiograph`
+- `record_ortho_adjustment`
+- `record_periodontal_assessment`
+- `record_tooth_condition`
+- `schedule_dental_procedure`
+- `track_orthodontic_treatment`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p dental-records
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p dental-records --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/dental_records.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/dental_records.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/doctor-registry/README.md
+++ b/contracts/doctor-registry/README.md
@@ -1,0 +1,55 @@
+# Doctor Registry Contract
+
+## Purpose
+
+`doctor-registry` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `DoctorProfileData` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `create_doctor_profile`
+- `get_doctor_profile`
+- `update_doctor_profile`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p doctor-registry
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p doctor-registry --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/doctor_registry.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/doctor_registry.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/emergency-medical-info/README.md
+++ b/contracts/emergency-medical-info/README.md
@@ -1,0 +1,62 @@
+# Emergency Medical Info Contract
+
+## Purpose
+
+`emergency-medical-info` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `EmergencyContact` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `add_critical_alert`
+- `emergency_access_request`
+- `get_critical_alerts`
+- `get_dnr_order`
+- `get_emergency_access_logs`
+- `get_emergency_info`
+- `has_emergency_profile`
+- `notify_emergency_contacts`
+- `record_dnr_order`
+- `set_emergency_profile`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p emergency-medical-info
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p emergency-medical-info --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/emergency_medical_info.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/emergency_medical_info.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/financial-records/README.md
+++ b/contracts/financial-records/README.md
@@ -1,0 +1,60 @@
+# Financial Records Contract
+
+## Purpose
+
+`financial-records` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `FinancialRecord` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `add_financial_record`
+- `get_financial_records`
+- `get_records_by_date_range`
+- `get_records_by_type`
+- `grant_access`
+- `revoke_access`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Includes owner-gated controls for administrative paths.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p financial-records
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p financial-records --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/financial_records.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/financial_records.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/hai-tracking/README.md
+++ b/contracts/hai-tracking/README.md
@@ -1,0 +1,66 @@
+# Hai Tracking Contract
+
+## Purpose
+
+`hai-tracking` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `HandHygieneRecord` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `alert_infection_control_team`
+- `calculate_infection_rate`
+- `get_active_isolations`
+- `get_active_outbreaks`
+- `get_infection_case`
+- `identify_outbreak_cluster`
+- `initiate_outbreak_investigation`
+- `record_antibiotic_susceptibility`
+- `record_organism`
+- `report_infection`
+- `report_to_nhsn`
+- `track_antibiotic_stewardship`
+- `track_hand_hygiene_compliance`
+- `track_isolation_precaution`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p hai-tracking
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p hai-tracking --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/hai_tracking.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/hai_tracking.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/health-records/README.md
+++ b/contracts/health-records/README.md
@@ -1,0 +1,58 @@
+# Health Records Contract
+
+## Purpose
+
+`health-records` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `MedicalRecord` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `create_record`
+- `get_record`
+- `grant_consent`
+- `revoke_consent`
+- `verify_record_integrity`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p health-records
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p health-records --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/health_records.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/health_records.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/healthcare-analytics/README.md
+++ b/contracts/healthcare-analytics/README.md
@@ -1,0 +1,57 @@
+# Healthcare Analytics Contract
+
+## Purpose
+
+`healthcare-analytics` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `MetricRecord` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `get_quality_metrics`
+- `get_statistics`
+- `record_metric`
+- `record_quality_metric`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p healthcare-analytics
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p healthcare-analytics --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/healthcare_analytics.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/healthcare_analytics.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/healthcare-credentialing/README.md
+++ b/contracts/healthcare-credentialing/README.md
@@ -1,0 +1,68 @@
+# Healthcare Credentialing Contract
+
+## Purpose
+
+`healthcare-credentialing` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `VerificationRecord` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `check_sanctions`
+- `conduct_peer_reference`
+- `get_clinical_activities`
+- `get_credentialing_case`
+- `get_provider_privileges`
+- `grant_privileges`
+- `initiate_credentialing`
+- `reinstate_privileges`
+- `request_provisional_privileges`
+- `schedule_recredentialing`
+- `submit_credential_document`
+- `suspend_privileges`
+- `track_clinical_activity`
+- `trigger_focused_review`
+- `verify_credential`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p healthcare-credentialing
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p healthcare-credentialing --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/healthcare_credentialing.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/healthcare_credentialing.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/hospital-discharge-management/README.md
+++ b/contracts/hospital-discharge-management/README.md
@@ -1,0 +1,53 @@
+# Hospital Discharge Management Contract
+
+## Purpose
+
+`hospital-discharge-management` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- State keys and records are defined in `src/lib.rs` and persisted in contract storage.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- No public entry points auto-detected; review `src/lib.rs` for exported methods.
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p hospital-discharge-management
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p hospital-discharge-management --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/hospital_discharge_management.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/hospital_discharge_management.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/hospital-registry/README.md
+++ b/contracts/hospital-registry/README.md
@@ -1,0 +1,66 @@
+# Hospital Registry Contract
+
+## Purpose
+
+`hospital-registry` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `HospitalData` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `get_hospital`
+- `get_hospital_config`
+- `is_hospital_active`
+- `register_hospital`
+- `set_hospital_config`
+- `update_alerts`
+- `update_billing`
+- `update_departments`
+- `update_emergency_protocols`
+- `update_equipment`
+- `update_hospital`
+- `update_insurance_providers`
+- `update_locations`
+- `update_policies`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p hospital-registry
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p hospital-registry --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/hospital_registry.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/hospital_registry.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/imaging-radiology/README.md
+++ b/contracts/imaging-radiology/README.md
@@ -1,0 +1,67 @@
+# Imaging Radiology Contract
+
+## Purpose
+
+`imaging-radiology` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `ImagingOrder` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `get_dicom_images`
+- `get_final_report`
+- `get_imaging_order`
+- `get_imaging_schedule`
+- `get_patient_orders`
+- `get_peer_review`
+- `get_preliminary_report`
+- `get_provider_orders`
+- `order_imaging_study`
+- `request_peer_review`
+- `schedule_imaging`
+- `submit_final_report`
+- `submit_preliminary_report`
+- `upload_images`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p imaging-radiology
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p imaging-radiology --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/imaging_radiology.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/imaging_radiology.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/immunization-registry/README.md
+++ b/contracts/immunization-registry/README.md
@@ -1,0 +1,58 @@
+# Immunization Registry Contract
+
+## Purpose
+
+`immunization-registry` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- State keys and records are defined in `src/lib.rs` and persisted in contract storage.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `check_due_vaccines`
+- `get_immunization_history`
+- `record_adverse_event`
+- `record_immunization`
+- `register_vaccine_series`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Contains admin-oriented flows; verify caller checks in each mutating method.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p immunization-registry
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p immunization-registry --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/immunization_registry.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/immunization_registry.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/insurer-registry/README.md
+++ b/contracts/insurer-registry/README.md
@@ -1,0 +1,62 @@
+# Insurer Registry Contract
+
+## Purpose
+
+`insurer-registry` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `InsurerData` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `add_claims_reviewer`
+- `get_claims_reviewers`
+- `get_insurer`
+- `is_authorized_reviewer`
+- `is_insurer_active`
+- `register_insurer`
+- `remove_claims_reviewer`
+- `update_contact_details`
+- `update_coverage_policies`
+- `update_insurer`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p insurer-registry
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p insurer-registry --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/insurer_registry.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/insurer_registry.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/lab-management/README.md
+++ b/contracts/lab-management/README.md
@@ -1,0 +1,57 @@
+# Lab Management Contract
+
+## Purpose
+
+`lab-management` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `TestResult` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `assign_lab`
+- `flag_critical_value`
+- `order_lab_test`
+- `submit_results`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p lab-management
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p lab-management --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/lab_management.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/lab_management.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/medical-claims/README.md
+++ b/contracts/medical-claims/README.md
@@ -1,0 +1,63 @@
+# Medical Claims Contract
+
+## Purpose
+
+`medical-claims` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- State keys and records are defined in `src/lib.rs` and persisted in contract storage.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- `initialize`
+
+### Messages / Entry Points
+- `adjudicate_claim`
+- `appeal_denial`
+- `apply_patient_payment`
+- `get_claim`
+- `get_insurer_payments`
+- `get_patient_payments`
+- `process_payment`
+- `register_insurer`
+- `submit_claim`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Contains admin-oriented flows; verify caller checks in each mutating method.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p medical-claims
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p medical-claims --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/medical_claims.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/medical_claims.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/medical-device-tracking/README.md
+++ b/contracts/medical-device-tracking/README.md
@@ -1,0 +1,64 @@
+# Medical Device Tracking Contract
+
+## Purpose
+
+`medical-device-tracking` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- State keys and records are defined in `src/lib.rs` and persisted in contract storage.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- `initialize`
+
+### Messages / Entry Points
+- `check_device_recalls`
+- `get_patient_implants`
+- `implant_device`
+- `issue_device_recall`
+- `issue_regulator_recall`
+- `notify_affected_patients`
+- `prescribe_dme`
+- `record_device_maintenance`
+- `register_device`
+- `remove_implant`
+- `track_device_performance`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p medical-device-tracking
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p medical-device-tracking --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/medical_device_tracking.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/medical_device_tracking.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/mental-health/README.md
+++ b/contracts/mental-health/README.md
@@ -1,0 +1,65 @@
+# Mental Health Contract
+
+## Purpose
+
+`mental-health` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `MentalHealthAssessment` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `assess_suicide_risk`
+- `conduct_mental_health_assessment`
+- `create_safety_plan`
+- `create_treatment_plan`
+- `document_hospitalization`
+- `record_gad7_score`
+- `record_phq9_score`
+- `record_therapy_session`
+- `request_substance_screening`
+- `set_enhanced_privacy_flag`
+- `track_symptom_severity`
+- `track_treatment_outcomes`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p mental-health
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p mental-health --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/mental_health.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/mental_health.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/multisig-governance/README.md
+++ b/contracts/multisig-governance/README.md
@@ -1,0 +1,55 @@
+# Multisig Governance Contract
+
+## Purpose
+
+`multisig-governance` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `Proposal` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- `initialize`
+
+### Messages / Entry Points
+- `approve_multisig_action`
+- `get_proposal`
+- `propose_multisig_action`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p multisig-governance
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p multisig-governance --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/multisig_governance.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/multisig_governance.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/nutrition-care-management/README.md
+++ b/contracts/nutrition-care-management/README.md
@@ -1,0 +1,53 @@
+# Nutrition Care Management Contract
+
+## Purpose
+
+`nutrition-care-management` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- State keys and records are defined in `src/lib.rs` and persisted in contract storage.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- No public entry points auto-detected; review `src/lib.rs` for exported methods.
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p nutrition-care-management
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p nutrition-care-management --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/nutrition_care_management.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/nutrition_care_management.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/pacs-integration/README.md
+++ b/contracts/pacs-integration/README.md
@@ -1,0 +1,55 @@
+# Pacs Integration Contract
+
+## Purpose
+
+`pacs-integration` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- State keys and records are defined in `src/lib.rs` and persisted in contract storage.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- No public entry points auto-detected; review `src/lib.rs` for exported methods.
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Includes owner-gated controls for administrative paths.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p pacs-integration
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p pacs-integration --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/pacs_integration.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/pacs_integration.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/patient-registry/README.md
+++ b/contracts/patient-registry/README.md
@@ -1,0 +1,109 @@
+# Patient Registry Contract
+
+## Purpose
+
+`patient-registry` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `PatientData` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- `initialize`
+
+### Messages / Entry Points
+- `acknowledge_consent`
+- `add_medical_record`
+- `assign_guardian`
+- `create_share_link`
+- `deregister_patient`
+- `emit_state_snapshot`
+- `extend_patient_ttl`
+- `freeze_contract`
+- `get_authorized_doctors`
+- `get_consent_status`
+- `get_doctor`
+- `get_global_records_by_type`
+- `get_global_type_count`
+- `get_guardian`
+- `get_hold`
+- `get_last_snapshot_ledger`
+- `get_latest_record`
+- `get_medical_records`
+- `get_merkle_root`
+- `get_patient`
+- `get_record_fee`
+- `get_record_fields`
+- `get_record_history`
+- `get_records_by_ids`
+- `get_records_by_type`
+- `get_total_access_grants`
+- `get_total_patients`
+- `get_total_providers`
+- `get_total_records_created`
+- `grant_access`
+- `grant_field_access`
+- `is_frozen`
+- `is_hold_active`
+- `is_patient_registered`
+- `lift_hold`
+- `place_hold`
+- `publish_consent_version`
+- `register_doctor`
+- `register_institution`
+- `register_patient`
+- `request_data_export`
+- `revoke_access`
+- `revoke_guardian`
+- `set_record_fee`
+- `soft_delete_record`
+- `unfreeze_contract`
+- `update_patient`
+- `update_record`
+- `use_share_link`
+- `validate_cid`
+- `validate_did`
+- `validate_export_ticket`
+- `validate_score`
+- `verify_doctor`
+- `verify_record_membership`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Contains admin-oriented flows; verify caller checks in each mutating method.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p patient-registry
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p patient-registry --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/patient_registry.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/patient_registry.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/patient-vitals/README.md
+++ b/contracts/patient-vitals/README.md
@@ -1,0 +1,54 @@
+# Patient Vitals Contract
+
+## Purpose
+
+`patient-vitals` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- State keys and records are defined in `src/lib.rs` and persisted in contract storage.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- No public entry points auto-detected; review `src/lib.rs` for exported methods.
+
+## Auth Model
+
+- Review mutating entrypoints in `src/lib.rs` and ensure caller validation is enforced consistently.
+- Use contract-level role checks (admin/owner/provider/patient as applicable) for write operations.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p patient-vitals
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p patient-vitals --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/patient_vitals.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/patient_vitals.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/prenatal-pediatric/README.md
+++ b/contracts/prenatal-pediatric/README.md
@@ -1,0 +1,73 @@
+# Prenatal Pediatric Contract
+
+## Purpose
+
+`prenatal-pediatric` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `PregnancyRecord` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `calculate_growth_percentiles`
+- `create_pregnancy_record`
+- `document_labor_admission`
+- `get_delivery_record`
+- `get_growth_record`
+- `get_labor_record`
+- `get_newborn_record`
+- `get_pregnancy_record`
+- `get_prenatal_screening`
+- `get_prenatal_visit`
+- `get_ultrasound`
+- `record_delivery`
+- `record_developmental_milestone`
+- `record_newborn`
+- `record_newborn_screening`
+- `record_prenatal_screening`
+- `record_prenatal_visit`
+- `record_ultrasound`
+- `track_pediatric_growth`
+- `track_well_child_visit`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p prenatal-pediatric
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p prenatal-pediatric --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/prenatal_pediatric.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/prenatal_pediatric.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/prescription-management/README.md
+++ b/contracts/prescription-management/README.md
@@ -1,0 +1,69 @@
+# Prescription Management Contract
+
+## Purpose
+
+`prescription-management` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `TransferRecord` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- `accept_transfer`
+- `add_interaction`
+- `cancel_prescription`
+- `check_allergy_interaction`
+- `check_interactions`
+- `dispense_prescription`
+- `get_contraindications`
+- `issue_prescription`
+- `override_interaction_warning`
+- `refill_prescription`
+- `register_medication`
+- `set_medication_contraindications`
+- `set_patient_allergies`
+- `set_patient_conditions`
+- `transfer_prescription`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Includes owner-gated controls for administrative paths.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p prescription-management
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p prescription-management --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/prescription_management.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/prescription_management.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/prior-authorization/README.md
+++ b/contracts/prior-authorization/README.md
@@ -1,0 +1,55 @@
+# Prior Authorization Contract
+
+## Purpose
+
+`prior-authorization` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- State keys and records are defined in `src/lib.rs` and persisted in contract storage.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- No public entry points auto-detected; review `src/lib.rs` for exported methods.
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Contains admin-oriented flows; verify caller checks in each mutating method.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p prior-authorization
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p prior-authorization --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/prior_authorization.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/prior_authorization.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/provider-registry/README.md
+++ b/contracts/provider-registry/README.md
@@ -1,0 +1,60 @@
+# Provider Registry Contract
+
+## Purpose
+
+`provider-registry` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- State keys and records are defined in `src/lib.rs` and persisted in contract storage.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- `initialize`
+
+### Messages / Entry Points
+- `add_record`
+- `get_provider_profile`
+- `get_record`
+- `is_provider`
+- `register_provider`
+- `revoke_provider`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Contains admin-oriented flows; verify caller checks in each mutating method.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p provider-registry
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p provider-registry --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/provider_registry.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/provider_registry.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/referral/README.md
+++ b/contracts/referral/README.md
@@ -1,0 +1,54 @@
+# Referral Contract
+
+## Purpose
+
+`referral` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- State keys and records are defined in `src/lib.rs` and persisted in contract storage.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- No public entry points auto-detected; review `src/lib.rs` for exported methods.
+
+## Auth Model
+
+- Review mutating entrypoints in `src/lib.rs` and ensure caller validation is enforced consistently.
+- Use contract-level role checks (admin/owner/provider/patient as applicable) for write operations.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p referral
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p referral --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/referral.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/referral.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/telemedicine/README.md
+++ b/contracts/telemedicine/README.md
@@ -1,0 +1,54 @@
+# Telemedicine Contract
+
+## Purpose
+
+`telemedicine` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- State keys and records are defined in `src/lib.rs` and persisted in contract storage.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- No public entry points auto-detected; review `src/lib.rs` for exported methods.
+
+## Auth Model
+
+- Review mutating entrypoints in `src/lib.rs` and ensure caller validation is enforced consistently.
+- Use contract-level role checks (admin/owner/provider/patient as applicable) for write operations.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p telemedicine
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p telemedicine --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/telemedicine.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/telemedicine.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/upgrade-governance/README.md
+++ b/contracts/upgrade-governance/README.md
@@ -1,0 +1,57 @@
+# Upgrade Governance Contract
+
+## Purpose
+
+`upgrade-governance` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `UpgradeProposal` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- `initialize`
+
+### Messages / Entry Points
+- `execute_upgrade`
+- `get_proposal`
+- `propose_upgrade`
+- `vote_upgrade`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p upgrade-governance
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p upgrade-governance --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/upgrade_governance.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/upgrade_governance.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/zk-eligibility-verifier/README.md
+++ b/contracts/zk-eligibility-verifier/README.md
@@ -1,0 +1,54 @@
+# Zk Eligibility Verifier Contract
+
+## Purpose
+
+`zk-eligibility-verifier` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- State keys and records are defined in `src/lib.rs` and persisted in contract storage.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- Constructor/init method names were not auto-detected; review `src/lib.rs`.
+
+### Messages / Entry Points
+- No public entry points auto-detected; review `src/lib.rs` for exported methods.
+
+## Auth Model
+
+- Review mutating entrypoints in `src/lib.rs` and ensure caller validation is enforced consistently.
+- Use contract-level role checks (admin/owner/provider/patient as applicable) for write operations.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p zk-eligibility-verifier
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p zk-eligibility-verifier --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/zk_eligibility_verifier.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/zk_eligibility_verifier.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.

--- a/contracts/zk-eligibility/README.md
+++ b/contracts/zk-eligibility/README.md
@@ -1,0 +1,59 @@
+# Zk Eligibility Contract
+
+## Purpose
+
+`zk-eligibility` implements healthcare workflow/business logic for this workspace as an on-chain contract crate.
+This README provides a quick operational map for integration, testing, and deployment.
+
+## Storage Model
+
+- This crate defines state structures such as `VerifierKeyEntry` in `src/lib.rs`.
+- Persistent state is committed on-chain through contract storage abstractions in this crate.
+- Events and error enums in `src/lib.rs` should be treated as part of the external contract interface.
+
+## Public Methods
+
+### Constructors / Initialization
+- `initialize`
+
+### Messages / Entry Points
+- `deprecate_verifier_key`
+- `get_verifier_key`
+- `is_nullified`
+- `register_verifier_key`
+- `verify_eligibility`
+
+## Auth Model
+
+- Uses `require_auth()` checks before privileged operations.
+- Contains admin-oriented flows; verify caller checks in each mutating method.
+- Returns explicit authorization errors for disallowed actions.
+
+## Test Steps
+
+```bash
+# Run unit/integration tests for this crate
+cargo test -p zk-eligibility
+```
+
+## Deploy Steps
+
+```bash
+# 1) Build optimized wasm artifact
+cargo build -p zk-eligibility --release --target wasm32-unknown-unknown
+
+# 2) (optional) Optimize wasm artifact
+soroban contract optimize \
+  --wasm target/wasm32-unknown-unknown/release/zk_eligibility.wasm
+
+# 3) Deploy
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/zk_eligibility.wasm \
+  --source <IDENTITY> \
+  --network <NETWORK>
+```
+
+## Notes
+
+- Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
+- If this contract depends on external registries/contracts, document those dependencies before release.


### PR DESCRIPTION
Closes #197

---

## Summary
- Add missing local `README.md` files for contract crates under `contracts/*`.
- Document each crate's purpose, storage model, public methods, auth model, and standard test/deploy steps.
- Improve discoverability of API usage, deployment flow, and constraints across contracts.

## Test plan
- [x] Verify every contract crate directory with `Cargo.toml` includes a local `README.md`.
- [x] Confirm branch is clean and pushed.
- [ ] Spot-check representative READMEs against `src/lib.rs` during review for wording precision.

Made with [Cursor](https://cursor.com)