### PR TITLE
fix: harden PACS view logs for audit integrity

### DIFF
--- a/contracts/pacs-integration/src/lib.rs
+++ b/contracts/pacs-integration/src/lib.rs
@@ -9,10 +9,36 @@ mod types;
 mod test;
 
 use soroban_sdk::{
-    contract, contractimpl, symbol_short, Address, BytesN, Env, String, Symbol, Vec,
+    contract, contractimpl, symbol_short, Address, Bytes, BytesN, Env, String, Symbol, Vec,
 };
+use soroban_sdk::xdr::ToXdr;
 use storage::*;
 use types::*;
+
+const MAX_VIEW_TIMESTAMP_DRIFT_SECS: u64 = 300;
+
+fn compute_view_log_entry_hash(
+    env: &Env,
+    study_id: u64,
+    viewer_id: &Address,
+    purpose: &String,
+    view_timestamp: u64,
+    view_duration: u32,
+    recorded_at: u64,
+    previous_entry_hash: &Option<BytesN<32>>,
+) -> BytesN<32> {
+    let mut data = Bytes::new(env);
+    data.extend_from_array(&study_id.to_be_bytes());
+    data.append(&viewer_id.clone().to_xdr(env));
+    data.append(&purpose.clone().to_xdr(env));
+    data.extend_from_array(&view_timestamp.to_be_bytes());
+    data.extend_from_array(&view_duration.to_be_bytes());
+    data.extend_from_array(&recorded_at.to_be_bytes());
+    if let Some(prev) = previous_entry_hash {
+        data.append(&prev.clone().to_xdr(env));
+    }
+    env.crypto().sha256(&data).into()
+}
 
 #[contract]
 pub struct PacsContract;
@@ -422,6 +448,7 @@ impl PacsContract {
         viewer_id.require_auth();
 
         let study = load_study(&env, study_id).ok_or(Error::NotFound)?;
+        let now = env.ledger().timestamp();
 
         let is_owner = study.patient_id == viewer_id || study.ordering_provider == viewer_id;
 
@@ -429,20 +456,55 @@ impl PacsContract {
             Self::assert_active_grant(&env, study_id, &viewer_id, &purpose)?;
         }
 
-        let record = ViewRecord {
-            viewer_id: viewer_id.clone(),
+        let earliest_allowed = now.saturating_sub(MAX_VIEW_TIMESTAMP_DRIFT_SECS);
+        let latest_allowed = now.saturating_add(MAX_VIEW_TIMESTAMP_DRIFT_SECS);
+        if view_timestamp < earliest_allowed || view_timestamp > latest_allowed {
+            return Err(Error::TimestampOutOfBounds);
+        }
+
+        if let Some(previous_ts) = load_viewer_last_view_timestamp(&env, study_id, &viewer_id) {
+            if view_timestamp <= previous_ts {
+                return Err(Error::NonMonotonicViewTimestamp);
+            }
+        }
+
+        let previous_entry_hash = load_viewer_view_chain_head(&env, study_id, &viewer_id);
+        let entry_hash = compute_view_log_entry_hash(
+            &env,
+            study_id,
+            &viewer_id,
+            &purpose,
             view_timestamp,
             view_duration,
+            now,
+            &previous_entry_hash,
+        );
+
+        let record = ViewRecord {
+            viewer_id: viewer_id.clone(),
+            purpose: purpose.clone(),
+            view_timestamp,
+            view_duration,
+            recorded_at: now,
+            previous_entry_hash,
+            entry_hash: entry_hash.clone(),
         };
 
         append_view_log(&env, study_id, &record);
+        save_viewer_last_view_timestamp(&env, study_id, &viewer_id, view_timestamp);
+        save_viewer_view_chain_head(&env, study_id, &viewer_id, &entry_hash);
 
         env.events().publish(
             (symbol_short!("view_log"), study_id),
-            (viewer_id, view_timestamp),
+            (viewer_id, view_timestamp, entry_hash),
         );
 
         Ok(())
+    }
+
+    /// Return all view records for a study.
+    pub fn get_study_view_logs(env: Env, study_id: u64) -> Vec<ViewRecord> {
+        load_view_logs(&env, study_id)
     }
 
     /// Return studies for a patient that pass the filters and that the requester

--- a/contracts/pacs-integration/src/storage.rs
+++ b/contracts/pacs-integration/src/storage.rs
@@ -1,7 +1,7 @@
 use crate::types::{
     AccessGrant, CdRecord, DataKey, ImagingReport, ImagingStudy, QcReview, SeriesInfo, ViewRecord,
 };
-use soroban_sdk::{Address, Env, String, Vec};
+use soroban_sdk::{Address, BytesN, Env, String, Vec};
 
 const BUMP_AMOUNT: u32 = 518400; // ~60 days in ledgers (assuming 5s ledger)
 const BUMP_THRESHOLD: u32 = 259200; // ~30 days
@@ -110,6 +110,51 @@ pub fn append_view_log(env: &Env, study_id: u64, record: &ViewRecord) {
     env.storage()
         .persistent()
         .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+}
+
+pub fn load_view_logs(env: &Env, study_id: u64) -> Vec<ViewRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ViewLog(study_id))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn save_viewer_last_view_timestamp(
+    env: &Env,
+    study_id: u64,
+    viewer_id: &Address,
+    view_timestamp: u64,
+) {
+    let key = DataKey::ViewerLastViewTs(study_id, viewer_id.clone());
+    env.storage().persistent().set(&key, &view_timestamp);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+}
+
+pub fn load_viewer_last_view_timestamp(env: &Env, study_id: u64, viewer_id: &Address) -> Option<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ViewerLastViewTs(study_id, viewer_id.clone()))
+}
+
+pub fn save_viewer_view_chain_head(
+    env: &Env,
+    study_id: u64,
+    viewer_id: &Address,
+    entry_hash: &BytesN<32>,
+) {
+    let key = DataKey::ViewerViewChainHead(study_id, viewer_id.clone());
+    env.storage().persistent().set(&key, entry_hash);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, BUMP_THRESHOLD, BUMP_AMOUNT);
+}
+
+pub fn load_viewer_view_chain_head(env: &Env, study_id: u64, viewer_id: &Address) -> Option<BytesN<32>> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ViewerViewChainHead(study_id, viewer_id.clone()))
 }
 
 pub fn save_qc_review(env: &Env, review: &QcReview) {

--- a/contracts/pacs-integration/src/test.rs
+++ b/contracts/pacs-integration/src/test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Symbol, Vec};
+use soroban_sdk::{testutils::{Address as _, Ledger}, Address, BytesN, Env, String, Symbol, Vec};
 
 use crate::types::{ComparisonCriteria, Error, ImagingFilters};
 use crate::{PacsContract, PacsContractClient};
@@ -214,11 +214,12 @@ fn grant_access_and_track_view() {
         &String::from_str(&env, "clinical-review"),
         &None,
     );
+    env.ledger().set_timestamp(1_000);
     client.track_study_views(
         &sid,
         &viewer,
         &String::from_str(&env, "clinical-review"),
-        &1_700_001_000_u64,
+        &1_000_u64,
         &30_u32,
     );
 }
@@ -230,18 +231,20 @@ fn patient_and_provider_can_view_without_grant() {
     let (client, patient, provider) = setup(&env);
     let sid = register_ct_chest(&env, &client, &patient, &provider);
 
+    env.ledger().set_timestamp(1_100);
     client.track_study_views(
         &sid,
         &patient,
         &String::from_str(&env, ""),
-        &1_700_001_100_u64,
+        &1_100_u64,
         &10_u32,
     );
+    env.ledger().set_timestamp(1_200);
     client.track_study_views(
         &sid,
         &provider,
         &String::from_str(&env, ""),
-        &1_700_001_200_u64,
+        &1_200_u64,
         &5_u32,
     );
 }
@@ -466,11 +469,12 @@ fn revoked_grant_blocks_subsequent_reads() {
         &String::from_str(&env, "qa-review"),
     );
 
+    env.ledger().set_timestamp(1_500);
     let result = client.try_track_study_views(
         &sid,
         &viewer,
         &String::from_str(&env, "qa-review"),
-        &1_700_001_500_u64,
+        &1_500_u64,
         &15_u32,
     );
     assert!(matches!(result, Err(Ok(Error::GrantRevoked))));
@@ -493,12 +497,121 @@ fn wrong_purpose_cannot_use_grant() {
         &None,
     );
 
+    env.ledger().set_timestamp(1_600);
     let result = client.try_track_study_views(
         &sid,
         &viewer,
         &String::from_str(&env, "research"),
-        &1_700_001_600_u64,
+        &1_600_u64,
         &12_u32,
     );
     assert!(matches!(result, Err(Ok(Error::Unauthorized))));
+}
+
+#[test]
+fn view_timestamp_outside_drift_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, patient, provider) = setup(&env);
+    let sid = register_ct_chest(&env, &client, &patient, &provider);
+    let viewer = Address::generate(&env);
+
+    client.grant_imaging_access(
+        &sid,
+        &patient,
+        &viewer,
+        &Symbol::new(&env, "view_only"),
+        &String::from_str(&env, "audit"),
+        &None,
+    );
+
+    env.ledger().set_timestamp(10_000);
+    let result = client.try_track_study_views(
+        &sid,
+        &viewer,
+        &String::from_str(&env, "audit"),
+        &9_699_u64, // 301s behind ledger time
+        &20_u32,
+    );
+    assert!(matches!(result, Err(Ok(Error::TimestampOutOfBounds))));
+}
+
+#[test]
+fn view_timestamp_must_be_monotonic_per_viewer_study() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, patient, provider) = setup(&env);
+    let sid = register_ct_chest(&env, &client, &patient, &provider);
+    let viewer = Address::generate(&env);
+
+    client.grant_imaging_access(
+        &sid,
+        &patient,
+        &viewer,
+        &Symbol::new(&env, "view_only"),
+        &String::from_str(&env, "audit"),
+        &None,
+    );
+
+    env.ledger().set_timestamp(2_000);
+    client.track_study_views(
+        &sid,
+        &viewer,
+        &String::from_str(&env, "audit"),
+        &2_000_u64,
+        &10_u32,
+    );
+
+    env.ledger().set_timestamp(2_010);
+    let result = client.try_track_study_views(
+        &sid,
+        &viewer,
+        &String::from_str(&env, "audit"),
+        &2_000_u64,
+        &8_u32,
+    );
+    assert!(matches!(result, Err(Ok(Error::NonMonotonicViewTimestamp))));
+}
+
+#[test]
+fn view_records_include_hash_chain_links() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, patient, provider) = setup(&env);
+    let sid = register_ct_chest(&env, &client, &patient, &provider);
+    let viewer = Address::generate(&env);
+
+    client.grant_imaging_access(
+        &sid,
+        &patient,
+        &viewer,
+        &Symbol::new(&env, "view_only"),
+        &String::from_str(&env, "audit"),
+        &None,
+    );
+
+    env.ledger().set_timestamp(3_000);
+    client.track_study_views(
+        &sid,
+        &viewer,
+        &String::from_str(&env, "audit"),
+        &3_000_u64,
+        &7_u32,
+    );
+    env.ledger().set_timestamp(3_020);
+    client.track_study_views(
+        &sid,
+        &viewer,
+        &String::from_str(&env, "audit"),
+        &3_020_u64,
+        &9_u32,
+    );
+
+    let logs = client.get_study_view_logs(&sid);
+    assert_eq!(logs.len(), 2);
+
+    let first = logs.get(0).unwrap();
+    assert!(first.previous_entry_hash.is_none());
+    let second = logs.get(1).unwrap();
+    assert_eq!(second.previous_entry_hash, Some(first.entry_hash.clone()));
 }

--- a/contracts/pacs-integration/src/types.rs
+++ b/contracts/pacs-integration/src/types.rs
@@ -11,6 +11,8 @@ pub enum Error {
     AccessExpired = 5,
     ReportAlreadyExists = 6,
     GrantRevoked = 7,
+    TimestampOutOfBounds = 8,
+    NonMonotonicViewTimestamp = 9,
 }
 
 #[contracttype]
@@ -23,6 +25,8 @@ pub enum DataKey {
     AccessList(u64),
     PatientStudies(Address),
     ViewLog(u64),
+    ViewerLastViewTs(u64, Address),
+    ViewerViewChainHead(u64, Address),
     QcReview(u64),
     AnonymizedStudy(u64),
     CdRecord(u64),
@@ -83,8 +87,12 @@ pub struct AccessGrant {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ViewRecord {
     pub viewer_id: Address,
+    pub purpose: String,
     pub view_timestamp: u64,
     pub view_duration: u32,
+    pub recorded_at: u64,
+    pub previous_entry_hash: Option<BytesN<32>>,
+    pub entry_hash: BytesN<32>,
 }
 
 #[contracttype]


### PR DESCRIPTION
Closes #245

---

## Summary
- Enforce bounded drift between caller-provided `view_timestamp` and ledger time in `track_study_views`.
- Enforce strict monotonic ordering per `(viewer, study)` by persisting and validating the last accepted timestamp.
- Add tamper-evident hash chaining for view events via `previous_entry_hash` + `entry_hash`, and expose logs with `get_study_view_logs`.

## Test plan
- [x] `cargo test -p pacs-integration`
- [x] Added tests for timestamp drift bounds, monotonic ordering, and hash-chain linkage.
- [ ] Reviewer spot-check of hash preimage fields and compliance assumptions.

Made with [Cursor](https://cursor.com)