### PR TITLE
Remove unwrap/expect from insurer registry paths

### DIFF
--- a/contracts/insurer-registry/src/lib.rs
+++ b/contracts/insurer-registry/src/lib.rs
@@ -1,7 +1,24 @@
 #![no_std]
 #![allow(deprecated)]
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String, Vec,
+};
+
+/// --------------------
+/// Error Types
+/// --------------------
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    InsurerAlreadyRegistered = 1,
+    InsurerNotFound = 2,
+    ReviewerAlreadyAuthorized = 3,
+    ReviewerNotFound = 4,
+    NoReviewersFound = 5,
+    NotAuthorized = 6,
+}
 
 /// --------------------
 /// Insurer Structures
@@ -38,21 +55,18 @@ impl InsurerRegistry {
     /// * `name` - The name of the insurance company
     /// * `license_id` - Government-issued insurance license identifier
     /// * `metadata` - Additional information (contact details, coverage policies, etc.)
-    ///
-    /// # Panics
-    /// Panics if the insurer is already registered
     pub fn register_insurer(
         env: Env,
         wallet: Address,
         name: String,
         license_id: String,
         metadata: String,
-    ) {
+    ) -> Result<(), Error> {
         wallet.require_auth();
 
         let key = DataKey::Insurer(wallet.clone());
         if env.storage().persistent().has(&key) {
-            panic!("Insurer already registered");
+            return Err(Error::InsurerAlreadyRegistered);
         }
 
         let insurer = InsurerData {
@@ -72,6 +86,7 @@ impl InsurerRegistry {
 
         env.events()
             .publish((symbol_short!("reg_ins"), wallet), symbol_short!("success"));
+        Ok(())
     }
 
     /// Update insurance company metadata and operational information
@@ -79,10 +94,7 @@ impl InsurerRegistry {
     /// # Arguments
     /// * `wallet` - The wallet address of the insurance company
     /// * `metadata` - Updated metadata information
-    ///
-    /// # Panics
-    /// Panics if the insurer is not found
-    pub fn update_insurer(env: Env, wallet: Address, metadata: String) {
+    pub fn update_insurer(env: Env, wallet: Address, metadata: String) -> Result<(), Error> {
         wallet.require_auth();
 
         let key = DataKey::Insurer(wallet.clone());
@@ -90,13 +102,14 @@ impl InsurerRegistry {
             .storage()
             .persistent()
             .get(&key)
-            .expect("Insurer not found");
+            .ok_or(Error::InsurerNotFound)?;
 
         insurer.metadata = metadata;
         env.storage().persistent().set(&key, &insurer);
 
         env.events()
             .publish((symbol_short!("upd_ins"), wallet), symbol_short!("success"));
+        Ok(())
     }
 
     /// Update insurance company contact details
@@ -104,7 +117,11 @@ impl InsurerRegistry {
     /// # Arguments
     /// * `wallet` - The wallet address of the insurance company
     /// * `contact_details` - Updated contact information (phone, email, address)
-    pub fn update_contact_details(env: Env, wallet: Address, contact_details: String) {
+    pub fn update_contact_details(
+        env: Env,
+        wallet: Address,
+        contact_details: String,
+    ) -> Result<(), Error> {
         wallet.require_auth();
 
         let key = DataKey::Insurer(wallet.clone());
@@ -112,7 +129,7 @@ impl InsurerRegistry {
             .storage()
             .persistent()
             .get(&key)
-            .expect("Insurer not found");
+            .ok_or(Error::InsurerNotFound)?;
 
         insurer.contact_details = contact_details;
         env.storage().persistent().set(&key, &insurer);
@@ -121,6 +138,7 @@ impl InsurerRegistry {
             (symbol_short!("upd_cntct"), wallet),
             symbol_short!("success"),
         );
+        Ok(())
     }
 
     /// Update insurance company coverage policies
@@ -128,7 +146,11 @@ impl InsurerRegistry {
     /// # Arguments
     /// * `wallet` - The wallet address of the insurance company
     /// * `coverage_policies` - Updated coverage policy information
-    pub fn update_coverage_policies(env: Env, wallet: Address, coverage_policies: String) {
+    pub fn update_coverage_policies(
+        env: Env,
+        wallet: Address,
+        coverage_policies: String,
+    ) -> Result<(), Error> {
         wallet.require_auth();
 
         let key = DataKey::Insurer(wallet.clone());
@@ -136,13 +158,14 @@ impl InsurerRegistry {
             .storage()
             .persistent()
             .get(&key)
-            .expect("Insurer not found");
+            .ok_or(Error::InsurerNotFound)?;
 
         insurer.coverage_policies = coverage_policies;
         env.storage().persistent().set(&key, &insurer);
 
         env.events()
             .publish((symbol_short!("upd_cov"), wallet), symbol_short!("success"));
+        Ok(())
     }
 
     /// Retrieve insurance company data by wallet address
@@ -152,15 +175,12 @@ impl InsurerRegistry {
     ///
     /// # Returns
     /// The InsurerData for the given wallet address
-    ///
-    /// # Panics
-    /// Panics if the insurer is not found
-    pub fn get_insurer(env: Env, wallet: Address) -> InsurerData {
+    pub fn get_insurer(env: Env, wallet: Address) -> Result<InsurerData, Error> {
         let key = DataKey::Insurer(wallet);
         env.storage()
             .persistent()
             .get(&key)
-            .expect("Insurer not found")
+            .ok_or(Error::InsurerNotFound)
     }
 
     // =====================================================
@@ -172,16 +192,17 @@ impl InsurerRegistry {
     /// # Arguments
     /// * `insurer_wallet` - The wallet address of the insurance company
     /// * `reviewer_wallet` - The wallet address of the claims reviewer to add
-    ///
-    /// # Panics
-    /// Panics if the insurer is not registered or reviewer already exists
-    pub fn add_claims_reviewer(env: Env, insurer_wallet: Address, reviewer_wallet: Address) {
+    pub fn add_claims_reviewer(
+        env: Env,
+        insurer_wallet: Address,
+        reviewer_wallet: Address,
+    ) -> Result<(), Error> {
         insurer_wallet.require_auth();
 
         // Verify insurer exists
         let insurer_key = DataKey::Insurer(insurer_wallet.clone());
         if !env.storage().persistent().has(&insurer_key) {
-            panic!("Insurer not registered");
+            return Err(Error::InsurerNotFound);
         }
 
         let reviewers_key = DataKey::ClaimsReviewers(insurer_wallet.clone());
@@ -189,12 +210,12 @@ impl InsurerRegistry {
             .storage()
             .persistent()
             .get(&reviewers_key)
-            .unwrap_or(Vec::new(&env));
+            .unwrap_or_else(|| Vec::new(&env));
 
         // Check if reviewer already exists
         for i in 0..reviewers.len() {
-            if reviewers.get(i).unwrap() == reviewer_wallet {
-                panic!("Reviewer already authorized");
+            if reviewers.get(i).ok_or(Error::NotAuthorized)? == reviewer_wallet {
+                return Err(Error::ReviewerAlreadyAuthorized);
             }
         }
 
@@ -205,6 +226,7 @@ impl InsurerRegistry {
             (symbol_short!("add_rev"), insurer_wallet, reviewer_wallet),
             symbol_short!("success"),
         );
+        Ok(())
     }
 
     /// Remove a claims reviewer from the insurance company's authorized list
@@ -212,10 +234,11 @@ impl InsurerRegistry {
     /// # Arguments
     /// * `insurer_wallet` - The wallet address of the insurance company
     /// * `reviewer_wallet` - The wallet address of the claims reviewer to remove
-    ///
-    /// # Panics
-    /// Panics if the insurer is not registered or reviewer not found
-    pub fn remove_claims_reviewer(env: Env, insurer_wallet: Address, reviewer_wallet: Address) {
+    pub fn remove_claims_reviewer(
+        env: Env,
+        insurer_wallet: Address,
+        reviewer_wallet: Address,
+    ) -> Result<(), Error> {
         insurer_wallet.require_auth();
 
         let reviewers_key = DataKey::ClaimsReviewers(insurer_wallet.clone());
@@ -223,13 +246,13 @@ impl InsurerRegistry {
             .storage()
             .persistent()
             .get(&reviewers_key)
-            .expect("No reviewers found");
+            .ok_or(Error::NoReviewersFound)?;
 
         let mut new_reviewers: Vec<Address> = Vec::new(&env);
         let mut found = false;
 
         for i in 0..reviewers.len() {
-            let reviewer = reviewers.get(i).unwrap();
+            let reviewer = reviewers.get(i).ok_or(Error::NotAuthorized)?;
             if reviewer != reviewer_wallet {
                 new_reviewers.push_back(reviewer);
             } else {
@@ -238,7 +261,7 @@ impl InsurerRegistry {
         }
 
         if !found {
-            panic!("Reviewer not found");
+            return Err(Error::ReviewerNotFound);
         }
 
         env.storage()
@@ -249,6 +272,7 @@ impl InsurerRegistry {
             (symbol_short!("rm_rev"), insurer_wallet, reviewer_wallet),
             symbol_short!("success"),
         );
+        Ok(())
     }
 
     /// Get all authorized claims reviewers for an insurance company
@@ -263,7 +287,7 @@ impl InsurerRegistry {
         env.storage()
             .persistent()
             .get(&reviewers_key)
-            .unwrap_or(Vec::new(&env))
+            .unwrap_or_else(|| Vec::new(&env))
     }
 
     /// Check if a specific address is an authorized claims reviewer
@@ -280,15 +304,16 @@ impl InsurerRegistry {
         reviewer_wallet: Address,
     ) -> bool {
         let reviewers_key = DataKey::ClaimsReviewers(insurer_wallet);
-        let reviewers: Vec<Address> = env
-            .storage()
-            .persistent()
-            .get(&reviewers_key)
-            .unwrap_or(Vec::new(&env));
+        let reviewers: Vec<Address> = match env.storage().persistent().get(&reviewers_key) {
+            Some(r) => r,
+            None => return false,
+        };
 
         for i in 0..reviewers.len() {
-            if reviewers.get(i).unwrap() == reviewer_wallet {
-                return true;
+            if let Ok(reviewer) = reviewers.get(i).ok_or(()) {
+                if reviewer == reviewer_wallet {
+                    return true;
+                }
             }
         }
         false


### PR DESCRIPTION
Removes unsafe panic patterns from insurer registry logic.

Introduces proper error handling
Prevents unexpected contract crashes
Closes #182

Explanation (≤3 lines):
Replaces panic-prone calls with safe handling.
Improves contract robustness.
Keeps implementation minimal and focused.