### PR TITLE
Remove unwrap/expect from multisig governance paths

### DIFF
--- a/contracts/multisig-governance/src/lib.rs
+++ b/contracts/multisig-governance/src/lib.rs
@@ -2,12 +2,27 @@
 #![allow(deprecated)]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Bytes, Env, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Bytes, Env, Symbol,
+    Vec,
 };
 
 mod test;
 
-// ── Storage keys ─────────────────────────────────────────────────────────────
+// ── Error types ──────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+    InvalidThreshold = 2,
+    ProposalNotFound = 3,
+    ProposalAlreadyExecuted = 4,
+    NotInitialized = 5,
+    ProposalExpired = 6,
+    AlreadyApproved = 7,
+    Unauthorized = 8,
+}
 
 #[contracttype]
 pub enum DataKey {
@@ -44,29 +59,39 @@ pub struct MultisigGovernance;
 impl MultisigGovernance {
     /// Initialize with a set of admin signers, an approval threshold, and a
     /// proposal TTL in seconds.
-    pub fn initialize(env: Env, signers: Vec<Address>, threshold: u32, ttl_seconds: u64) {
+    pub fn initialize(
+        env: Env,
+        signers: Vec<Address>,
+        threshold: u32,
+        ttl_seconds: u64,
+    ) -> Result<(), Error> {
         if env.storage().persistent().has(&DataKey::Signers) {
-            panic!("Already initialized");
+            return Err(Error::AlreadyInitialized);
         }
         if threshold == 0 || threshold as usize > signers.len() as usize {
-            panic!("Invalid threshold");
+            return Err(Error::InvalidThreshold);
         }
         env.storage().persistent().set(&DataKey::Signers, &signers);
         env.storage()
             .persistent()
             .set(&DataKey::Threshold, &threshold);
         env.storage().persistent().set(&DataKey::Ttl, &ttl_seconds);
+        Ok(())
     }
 
-    /// Any admin signer may open a new proposal. Panics if one already exists
-    /// for the same action_id.
-    pub fn propose_multisig_action(env: Env, signer: Address, action_id: Symbol, payload: Bytes) {
+    /// Any admin signer may open a new proposal.
+    pub fn propose_multisig_action(
+        env: Env,
+        signer: Address,
+        action_id: Symbol,
+        payload: Bytes,
+    ) -> Result<(), Error> {
         signer.require_auth();
-        Self::assert_signer(&env, &signer);
+        Self::assert_signer(&env, &signer)?;
 
         let key = DataKey::Proposal(action_id.clone());
         if env.storage().persistent().has(&key) {
-            panic!("Proposal already exists");
+            return Err(Error::ProposalAlreadyExecuted);
         }
 
         let mut approvals: Vec<Address> = Vec::new(&env);
@@ -82,40 +107,45 @@ impl MultisigGovernance {
         env.storage().persistent().set(&key, &proposal);
         env.events()
             .publish((symbol_short!("proposed"), action_id), signer);
+        Ok(())
     }
 
     /// An admin signer approves an existing proposal. Once the approval count
     /// reaches the threshold the proposal is marked Executed and an event is
     /// emitted. Expired or already-executed proposals are rejected.
-    pub fn approve_multisig_action(env: Env, signer: Address, action_id: Symbol) {
+    pub fn approve_multisig_action(
+        env: Env,
+        signer: Address,
+        action_id: Symbol,
+    ) -> Result<(), Error> {
         signer.require_auth();
-        Self::assert_signer(&env, &signer);
+        Self::assert_signer(&env, &signer)?;
 
         let key = DataKey::Proposal(action_id.clone());
         let mut proposal: Proposal = env
             .storage()
             .persistent()
             .get(&key)
-            .expect("Proposal not found");
+            .ok_or(Error::ProposalNotFound)?;
 
         if proposal.status == ProposalStatus::Executed {
-            panic!("Proposal already executed");
+            return Err(Error::ProposalAlreadyExecuted);
         }
 
         let ttl: u64 = env
             .storage()
             .persistent()
             .get(&DataKey::Ttl)
-            .expect("Not initialized");
+            .ok_or(Error::NotInitialized)?;
 
         if env.ledger().timestamp() > proposal.proposed_at + ttl {
-            panic!("Proposal expired");
+            return Err(Error::ProposalExpired);
         }
 
         // Reject duplicate approvals from the same signer.
         for i in 0..proposal.approvals.len() {
-            if proposal.approvals.get(i).unwrap() == signer {
-                panic!("Already approved");
+            if proposal.approvals.get(i).ok_or(Error::Unauthorized)? == signer {
+                return Err(Error::AlreadyApproved);
             }
         }
 
@@ -125,7 +155,7 @@ impl MultisigGovernance {
             .storage()
             .persistent()
             .get(&DataKey::Threshold)
-            .expect("Not initialized");
+            .ok_or(Error::NotInitialized)?;
 
         if proposal.approvals.len() >= threshold {
             proposal.status = ProposalStatus::Executed;
@@ -137,29 +167,30 @@ impl MultisigGovernance {
             env.events()
                 .publish((symbol_short!("approved"), action_id), signer);
         }
+        Ok(())
     }
 
     /// Read a proposal by action_id.
-    pub fn get_proposal(env: Env, action_id: Symbol) -> Proposal {
+    pub fn get_proposal(env: Env, action_id: Symbol) -> Result<Proposal, Error> {
         env.storage()
             .persistent()
             .get(&DataKey::Proposal(action_id))
-            .expect("Proposal not found")
+            .ok_or(Error::ProposalNotFound)
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────
 
-    fn assert_signer(env: &Env, caller: &Address) {
+    fn assert_signer(env: &Env, caller: &Address) -> Result<(), Error> {
         let signers: Vec<Address> = env
             .storage()
             .persistent()
             .get(&DataKey::Signers)
-            .expect("Not initialized");
+            .ok_or(Error::NotInitialized)?;
         for i in 0..signers.len() {
-            if signers.get(i).unwrap() == *caller {
-                return;
+            if signers.get(i).ok_or(Error::Unauthorized)? == *caller {
+                return Ok(());
             }
         }
-        panic!("Unauthorized: not an admin signer");
+        Err(Error::Unauthorized)
     }
 }


### PR DESCRIPTION
Improves production safety by removing panic-prone calls.

Replaces unwrap/expect with safe error handling
Preserves existing logic and flow
Closes #184

Explanation (≤3 lines):
Eliminates panic risks in governance logic.
Ensures safer execution paths.
Maintains existing behavior with proper error handling.