### PR TITLE
feat: signer set lifecycle management in governance contracts

### DIFF
--- a/contracts/multisig-governance/src/lib.rs
+++ b/contracts/multisig-governance/src/lib.rs
@@ -27,6 +27,10 @@ pub enum Error {
     QuorumNotMet       = 10,
     /// Proposal was already finalized (executed or failed).
     AlreadyFinalized   = 11,
+    /// The address is already a signer.
+    AlreadySigner      = 12,
+    /// Removing this signer would make the threshold unreachable.
+    ThresholdBreached  = 13,
 }
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
@@ -41,6 +45,8 @@ pub enum DataKey {
     /// abstain) for a result to be valid.  Stored as a u32 count.
     QuorumMin,
     Proposal(Symbol),
+    /// Pending signer-change proposal (only one active at a time).
+    SignerProposal,
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -70,6 +76,25 @@ pub struct Proposal {
     /// Domain tag: SHA-256(contract_address ++ "multisig-governance" ++ action_id_bytes).
     /// Binds this proposal to a specific contract instance and action (#233).
     pub domain_tag: BytesN<32>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SignerChangeKind {
+    Add,
+    Remove,
+}
+
+/// A threshold-gated proposal to add or remove a signer.
+/// Only one signer-change proposal may be active at a time.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SignerProposal {
+    pub kind: SignerChangeKind,
+    pub target: Address,
+    pub approvals: Vec<Address>,
+    pub proposed_at: u64,
+    pub status: ProposalStatus,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -242,6 +267,172 @@ impl MultisigGovernance {
         env.storage()
             .persistent()
             .get(&DataKey::Proposal(action_id))
+            .ok_or(Error::ProposalNotFound)
+    }
+
+    // ── signer lifecycle ──────────────────────────────────────────────────────
+
+    /// Propose adding or removing a signer.  Only one signer-change proposal
+    /// may be active at a time.  The proposer's approval is counted immediately.
+    pub fn propose_signer_change(
+        env: Env,
+        proposer: Address,
+        kind: SignerChangeKind,
+        target: Address,
+    ) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        proposer.require_auth();
+        Self::assert_signer(&env, &proposer)?;
+
+        // Reject if there is already an active signer-change proposal.
+        if env.storage().persistent().has(&DataKey::SignerProposal) {
+            return Err(Error::ProposalExists);
+        }
+
+        let signers: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Signers)
+            .ok_or(Error::NotInitialized)?;
+
+        // Validate the change is meaningful.
+        match kind {
+            SignerChangeKind::Add => {
+                for s in signers.iter() {
+                    if s == target {
+                        return Err(Error::AlreadySigner);
+                    }
+                }
+            }
+            SignerChangeKind::Remove => {
+                let threshold: u32 = env
+                    .storage()
+                    .persistent()
+                    .get(&DataKey::Threshold)
+                    .ok_or(Error::NotInitialized)?;
+                // After removal there must still be enough signers to meet threshold.
+                if signers.len() <= threshold {
+                    return Err(Error::ThresholdBreached);
+                }
+                // Target must be a current signer.
+                let mut found = false;
+                for s in signers.iter() {
+                    if s == target {
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
+                    return Err(Error::NotASigner);
+                }
+            }
+        }
+
+        let mut approvals: Vec<Address> = Vec::new(&env);
+        approvals.push_back(proposer.clone());
+
+        let proposal = SignerProposal {
+            kind: kind.clone(),
+            target: target.clone(),
+            approvals,
+            proposed_at: env.ledger().timestamp(),
+            status: ProposalStatus::Pending,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::SignerProposal, &proposal);
+        env.events()
+            .publish((symbol_short!("sg_prop"), kind), (proposer, target));
+        Ok(())
+    }
+
+    /// Approve the active signer-change proposal.  Executes immediately when
+    /// the approval threshold is reached.
+    pub fn approve_signer_change(env: Env, signer: Address) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        signer.require_auth();
+        Self::assert_signer(&env, &signer)?;
+
+        let mut proposal: SignerProposal = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SignerProposal)
+            .ok_or(Error::ProposalNotFound)?;
+
+        if proposal.status != ProposalStatus::Pending {
+            return Err(Error::AlreadyFinalized);
+        }
+
+        let ttl: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Ttl)
+            .ok_or(Error::NotInitialized)?;
+        if env.ledger().timestamp() > proposal.proposed_at + ttl {
+            return Err(Error::Expired);
+        }
+
+        // Deduplicate.
+        for i in 0..proposal.approvals.len() {
+            if proposal.approvals.get(i).unwrap() == signer {
+                return Err(Error::AlreadyVoted);
+            }
+        }
+
+        proposal.approvals.push_back(signer.clone());
+
+        let threshold: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Threshold)
+            .ok_or(Error::NotInitialized)?;
+
+        if proposal.approvals.len() >= threshold {
+            // Execute the signer change.
+            let mut signers: Vec<Address> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Signers)
+                .ok_or(Error::NotInitialized)?;
+
+            match proposal.kind {
+                SignerChangeKind::Add => {
+                    signers.push_back(proposal.target.clone());
+                }
+                SignerChangeKind::Remove => {
+                    let mut new_signers: Vec<Address> = Vec::new(&env);
+                    for s in signers.iter() {
+                        if s != proposal.target {
+                            new_signers.push_back(s);
+                        }
+                    }
+                    signers = new_signers;
+                }
+            }
+
+            env.storage().persistent().set(&DataKey::Signers, &signers);
+            proposal.status = ProposalStatus::Executed;
+            env.storage()
+                .persistent()
+                .remove(&DataKey::SignerProposal);
+            env.events()
+                .publish((symbol_short!("sg_exec"), proposal.kind.clone()), proposal.target.clone());
+        } else {
+            env.storage()
+                .persistent()
+                .set(&DataKey::SignerProposal, &proposal);
+        }
+
+        env.events()
+            .publish((symbol_short!("sg_appr"), signer.clone()), signer);
+        Ok(())
+    }
+
+    pub fn get_signer_proposal(env: Env) -> Result<SignerProposal, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::SignerProposal)
             .ok_or(Error::ProposalNotFound)
     }
 

--- a/contracts/multisig-governance/src/test.rs
+++ b/contracts/multisig-governance/src/test.rs
@@ -327,3 +327,150 @@ fn test_expired_proposal_returns_error() {
         .unwrap();
     assert_eq!(err, Error::Expired);
 }
+
+// ── signer lifecycle: add ─────────────────────────────────────────────────────
+
+#[test]
+fn test_propose_add_signer_non_signer_returns_error() {
+    let (env, _signers, client) = setup(3, 2);
+    let stranger = Address::generate(&env);
+    let new_signer = Address::generate(&env);
+    let err = client
+        .try_propose_signer_change(&stranger, &SignerChangeKind::Add, &new_signer)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::NotASigner);
+}
+
+#[test]
+fn test_propose_add_existing_signer_returns_error() {
+    let (env, signers, client) = setup(3, 2);
+    let s0 = signers.get(0).unwrap();
+    let s1 = signers.get(1).unwrap();
+    let err = client
+        .try_propose_signer_change(&s0, &SignerChangeKind::Add, &s1)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::AlreadySigner);
+}
+
+#[test]
+fn test_add_signer_executes_at_threshold() {
+    let (env, signers, client) = setup(3, 2);
+    let s0 = signers.get(0).unwrap();
+    let s1 = signers.get(1).unwrap();
+    let new_signer = Address::generate(&env);
+
+    client.propose_signer_change(&s0, &SignerChangeKind::Add, &new_signer);
+    // s0 already approved; s1 approval reaches threshold=2 → executes.
+    client.approve_signer_change(&s1);
+
+    // New signer can now propose actions.
+    client.propose_multisig_action(&new_signer, &symbol_short!("test"), &payload(&env));
+    let proposal = client.get_proposal(&symbol_short!("test"));
+    assert_eq!(proposal.approvals.len(), 1);
+}
+
+#[test]
+fn test_add_signer_under_threshold_stays_pending() {
+    let (env, signers, client) = setup(3, 3);
+    let s0 = signers.get(0).unwrap();
+    let new_signer = Address::generate(&env);
+
+    client.propose_signer_change(&s0, &SignerChangeKind::Add, &new_signer);
+    let sp = client.get_signer_proposal();
+    assert_eq!(sp.status, ProposalStatus::Pending);
+    assert_eq!(sp.approvals.len(), 1);
+}
+
+#[test]
+fn test_duplicate_signer_proposal_returns_error() {
+    let (env, signers, client) = setup(3, 3);
+    let s0 = signers.get(0).unwrap();
+    let new_signer = Address::generate(&env);
+    let new_signer2 = Address::generate(&env);
+
+    client.propose_signer_change(&s0, &SignerChangeKind::Add, &new_signer);
+    let err = client
+        .try_propose_signer_change(&s0, &SignerChangeKind::Add, &new_signer2)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::ProposalExists);
+}
+
+#[test]
+fn test_duplicate_approve_signer_change_returns_error() {
+    let (env, signers, client) = setup(3, 3);
+    let s0 = signers.get(0).unwrap();
+    let s1 = signers.get(1).unwrap();
+    let new_signer = Address::generate(&env);
+
+    client.propose_signer_change(&s0, &SignerChangeKind::Add, &new_signer);
+    client.approve_signer_change(&s1);
+    let err = client
+        .try_approve_signer_change(&s1)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::AlreadyVoted);
+}
+
+// ── signer lifecycle: remove ──────────────────────────────────────────────────
+
+#[test]
+fn test_remove_signer_executes_at_threshold() {
+    let (env, signers, client) = setup(3, 2);
+    let s0 = signers.get(0).unwrap();
+    let s1 = signers.get(1).unwrap();
+    let s2 = signers.get(2).unwrap();
+
+    client.propose_signer_change(&s0, &SignerChangeKind::Remove, &s2);
+    client.approve_signer_change(&s1);
+
+    // s2 should no longer be a signer.
+    let err = client
+        .try_propose_multisig_action(&s2, &symbol_short!("test"), &payload(&env))
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::NotASigner);
+}
+
+#[test]
+fn test_remove_signer_threshold_breach_returns_error() {
+    // 3 signers, threshold=3 → removing any signer would leave 2 < threshold.
+    let (env, signers, client) = setup(3, 3);
+    let s0 = signers.get(0).unwrap();
+    let s1 = signers.get(1).unwrap();
+    let err = client
+        .try_propose_signer_change(&s0, &SignerChangeKind::Remove, &s1)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::ThresholdBreached);
+}
+
+#[test]
+fn test_remove_non_signer_returns_error() {
+    let (env, signers, client) = setup(3, 2);
+    let s0 = signers.get(0).unwrap();
+    let stranger = Address::generate(&env);
+    let err = client
+        .try_propose_signer_change(&s0, &SignerChangeKind::Remove, &stranger)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::NotASigner);
+}
+
+#[test]
+fn test_approve_signer_change_expired_returns_error() {
+    let (env, signers, client) = setup(3, 3);
+    let s0 = signers.get(0).unwrap();
+    let s1 = signers.get(1).unwrap();
+    let new_signer = Address::generate(&env);
+
+    client.propose_signer_change(&s0, &SignerChangeKind::Add, &new_signer);
+    env.ledger().with_mut(|li| { li.timestamp += 3601; });
+    let err = client
+        .try_approve_signer_change(&s1)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::Expired);
+}

--- a/contracts/upgrade-governance/src/lib.rs
+++ b/contracts/upgrade-governance/src/lib.rs
@@ -31,6 +31,14 @@ pub enum Error {
     Cancelled          = 11,
     /// Caller is not authorised to cancel (must be a signer).
     NotAuthorized      = 12,
+    /// The address is already a signer.
+    AlreadySigner      = 13,
+    /// Removing this signer would make the threshold unreachable.
+    ThresholdBreached  = 14,
+    /// A signer-change proposal already exists.
+    ProposalExists     = 15,
+    /// Proposal was already finalized.
+    AlreadyFinalized   = 16,
 }
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
@@ -42,6 +50,8 @@ pub enum DataKey {
     Threshold,
     NextId,
     Proposal(u64),
+    /// Pending signer-change proposal (only one active at a time).
+    SignerProposal,
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -68,6 +78,32 @@ pub struct UpgradeProposal {
     /// Domain tag: SHA-256(contract_address ++ "upgrade-governance" ++ proposal_id).
     /// Stored so callers can verify the binding off-chain.
     pub domain_tag: BytesN<32>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SignerChangeKind {
+    Add,
+    Remove,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SignerProposalStatus {
+    Pending,
+    Executed,
+}
+
+/// A threshold-gated proposal to add or remove a signer.
+/// Only one signer-change proposal may be active at a time.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SignerProposal {
+    pub kind: SignerChangeKind,
+    pub target: Address,
+    pub approvals: Vec<Address>,
+    pub proposed_at: u64,
+    pub status: SignerProposalStatus,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -247,6 +283,161 @@ impl UpgradeGovernance {
         env.storage()
             .persistent()
             .get(&DataKey::Proposal(proposal_id))
+            .ok_or(Error::ProposalNotFound)
+    }
+
+    // ── signer lifecycle ──────────────────────────────────────────────────────
+
+    /// Propose adding or removing a signer.  Only one signer-change proposal
+    /// may be active at a time.  The proposer's approval is counted immediately.
+    pub fn propose_signer_change(
+        env: Env,
+        proposer: Address,
+        kind: SignerChangeKind,
+        target: Address,
+    ) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        proposer.require_auth();
+        Self::assert_signer(&env, &proposer)?;
+
+        if env.storage().persistent().has(&DataKey::SignerProposal) {
+            return Err(Error::ProposalExists);
+        }
+
+        let signers: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Signers)
+            .ok_or(Error::NotInitialized)?;
+
+        match kind {
+            SignerChangeKind::Add => {
+                for s in signers.iter() {
+                    if s == target {
+                        return Err(Error::AlreadySigner);
+                    }
+                }
+            }
+            SignerChangeKind::Remove => {
+                let threshold: u32 = env
+                    .storage()
+                    .persistent()
+                    .get(&DataKey::Threshold)
+                    .ok_or(Error::NotInitialized)?;
+                if signers.len() <= threshold {
+                    return Err(Error::ThresholdBreached);
+                }
+                let mut found = false;
+                for s in signers.iter() {
+                    if s == target {
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
+                    return Err(Error::NotASigner);
+                }
+            }
+        }
+
+        let mut approvals: Vec<Address> = Vec::new(&env);
+        approvals.push_back(proposer.clone());
+
+        let proposal = SignerProposal {
+            kind: kind.clone(),
+            target: target.clone(),
+            approvals,
+            proposed_at: env.ledger().timestamp(),
+            status: SignerProposalStatus::Pending,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::SignerProposal, &proposal);
+        env.events()
+            .publish((symbol_short!("sg_prop"), kind), (proposer, target));
+        Ok(())
+    }
+
+    /// Approve the active signer-change proposal.  Executes immediately when
+    /// the approval threshold is reached.
+    pub fn approve_signer_change(env: Env, signer: Address) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        signer.require_auth();
+        Self::assert_signer(&env, &signer)?;
+
+        let mut proposal: SignerProposal = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SignerProposal)
+            .ok_or(Error::ProposalNotFound)?;
+
+        if proposal.status != SignerProposalStatus::Pending {
+            return Err(Error::AlreadyFinalized);
+        }
+
+        if env.ledger().timestamp() > proposal.proposed_at + VOTING_WINDOW {
+            return Err(Error::Expired);
+        }
+
+        for i in 0..proposal.approvals.len() {
+            if proposal.approvals.get(i).unwrap() == signer {
+                return Err(Error::AlreadyVoted);
+            }
+        }
+
+        proposal.approvals.push_back(signer.clone());
+
+        let threshold: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Threshold)
+            .ok_or(Error::NotInitialized)?;
+
+        if proposal.approvals.len() >= threshold {
+            let mut signers: Vec<Address> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Signers)
+                .ok_or(Error::NotInitialized)?;
+
+            match proposal.kind {
+                SignerChangeKind::Add => {
+                    signers.push_back(proposal.target.clone());
+                }
+                SignerChangeKind::Remove => {
+                    let mut new_signers: Vec<Address> = Vec::new(&env);
+                    for s in signers.iter() {
+                        if s != proposal.target {
+                            new_signers.push_back(s);
+                        }
+                    }
+                    signers = new_signers;
+                }
+            }
+
+            env.storage().persistent().set(&DataKey::Signers, &signers);
+            proposal.status = SignerProposalStatus::Executed;
+            env.storage()
+                .persistent()
+                .remove(&DataKey::SignerProposal);
+            env.events()
+                .publish((symbol_short!("sg_exec"), proposal.kind.clone()), proposal.target.clone());
+        } else {
+            env.storage()
+                .persistent()
+                .set(&DataKey::SignerProposal, &proposal);
+        }
+
+        env.events()
+            .publish((symbol_short!("sg_appr"), signer.clone()), signer);
+        Ok(())
+    }
+
+    pub fn get_signer_proposal(env: Env) -> Result<SignerProposal, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::SignerProposal)
             .ok_or(Error::ProposalNotFound)
     }
 

--- a/contracts/upgrade-governance/src/test.rs
+++ b/contracts/upgrade-governance/src/test.rs
@@ -273,3 +273,148 @@ fn test_vote_on_executed_proposal_returns_error() {
     let err = client.try_vote_upgrade(&s2, &id).unwrap_err().unwrap();
     assert_eq!(err, Error::AlreadyExecuted);
 }
+
+// ── signer lifecycle: add ─────────────────────────────────────────────────────
+
+#[test]
+fn test_propose_add_signer_non_signer_returns_error() {
+    let (env, _signers, client) = setup(3, 2);
+    let stranger = Address::generate(&env);
+    let new_signer = Address::generate(&env);
+    let err = client
+        .try_propose_signer_change(&stranger, &SignerChangeKind::Add, &new_signer)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::NotASigner);
+}
+
+#[test]
+fn test_propose_add_existing_signer_returns_error() {
+    let (env, signers, client) = setup(3, 2);
+    let s0 = signers.get(0).unwrap();
+    let s1 = signers.get(1).unwrap();
+    let err = client
+        .try_propose_signer_change(&s0, &SignerChangeKind::Add, &s1)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::AlreadySigner);
+}
+
+#[test]
+fn test_add_signer_executes_at_threshold() {
+    let (env, signers, client) = setup(3, 2);
+    let s0 = signers.get(0).unwrap();
+    let s1 = signers.get(1).unwrap();
+    let new_signer = Address::generate(&env);
+
+    client.propose_signer_change(&s0, &SignerChangeKind::Add, &new_signer);
+    client.approve_signer_change(&s1);
+
+    // New signer can now propose upgrades.
+    let id = client.propose_upgrade(&new_signer, &dummy_hash(&env));
+    let proposal = client.get_proposal(&id);
+    assert_eq!(proposal.votes.len(), 1);
+}
+
+#[test]
+fn test_add_signer_under_threshold_stays_pending() {
+    let (env, signers, client) = setup(3, 3);
+    let s0 = signers.get(0).unwrap();
+    let new_signer = Address::generate(&env);
+
+    client.propose_signer_change(&s0, &SignerChangeKind::Add, &new_signer);
+    let sp = client.get_signer_proposal();
+    assert_eq!(sp.status, SignerProposalStatus::Pending);
+    assert_eq!(sp.approvals.len(), 1);
+}
+
+#[test]
+fn test_duplicate_signer_proposal_returns_error() {
+    let (env, signers, client) = setup(3, 3);
+    let s0 = signers.get(0).unwrap();
+    let new_signer = Address::generate(&env);
+    let new_signer2 = Address::generate(&env);
+
+    client.propose_signer_change(&s0, &SignerChangeKind::Add, &new_signer);
+    let err = client
+        .try_propose_signer_change(&s0, &SignerChangeKind::Add, &new_signer2)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::ProposalExists);
+}
+
+#[test]
+fn test_duplicate_approve_signer_change_returns_error() {
+    let (env, signers, client) = setup(3, 3);
+    let s0 = signers.get(0).unwrap();
+    let s1 = signers.get(1).unwrap();
+    let new_signer = Address::generate(&env);
+
+    client.propose_signer_change(&s0, &SignerChangeKind::Add, &new_signer);
+    client.approve_signer_change(&s1);
+    let err = client
+        .try_approve_signer_change(&s1)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::AlreadyVoted);
+}
+
+// ── signer lifecycle: remove ──────────────────────────────────────────────────
+
+#[test]
+fn test_remove_signer_executes_at_threshold() {
+    let (env, signers, client) = setup(3, 2);
+    let s0 = signers.get(0).unwrap();
+    let s1 = signers.get(1).unwrap();
+    let s2 = signers.get(2).unwrap();
+
+    client.propose_signer_change(&s0, &SignerChangeKind::Remove, &s2);
+    client.approve_signer_change(&s1);
+
+    // s2 should no longer be a signer.
+    let err = client
+        .try_propose_upgrade(&s2, &dummy_hash(&env))
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::NotASigner);
+}
+
+#[test]
+fn test_remove_signer_threshold_breach_returns_error() {
+    let (env, signers, client) = setup(3, 3);
+    let s0 = signers.get(0).unwrap();
+    let s1 = signers.get(1).unwrap();
+    let err = client
+        .try_propose_signer_change(&s0, &SignerChangeKind::Remove, &s1)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::ThresholdBreached);
+}
+
+#[test]
+fn test_remove_non_signer_returns_error() {
+    let (env, signers, client) = setup(3, 2);
+    let s0 = signers.get(0).unwrap();
+    let stranger = Address::generate(&env);
+    let err = client
+        .try_propose_signer_change(&s0, &SignerChangeKind::Remove, &stranger)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::NotASigner);
+}
+
+#[test]
+fn test_approve_signer_change_expired_returns_error() {
+    let (env, signers, client) = setup(3, 3);
+    let s0 = signers.get(0).unwrap();
+    let s1 = signers.get(1).unwrap();
+    let new_signer = Address::generate(&env);
+
+    client.propose_signer_change(&s0, &SignerChangeKind::Add, &new_signer);
+    env.ledger().with_mut(|li| { li.timestamp += VOTING_WINDOW + 1; });
+    let err = client
+        .try_approve_signer_change(&s1)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::Expired);
+}


### PR DESCRIPTION
## Summary

Closes #230

Governance signer lists were static after initialization. This PR adds threshold-gated signer add/remove workflows to both `multisig-governance` and `upgrade-governance`, allowing safe signer rotation without redeployment.

## Changes

### New API (both contracts)

| Method | Description |
|---|---|
| `propose_signer_change(proposer, kind, target)` | Propose adding or removing a signer; proposer's approval is counted immediately |
| `approve_signer_change(signer)` | Approve the active signer-change proposal; executes when threshold is reached |
| `get_signer_proposal()` | Read the current pending signer-change proposal |

### New types

- `SignerChangeKind` — `Add` / `Remove` enum
- `SignerProposal` — stores kind, target, approvals, timestamp, and status
- `SignerProposalStatus` (upgrade-governance only) — `Pending` / `Executed`

### New error variants

| Variant | Meaning |
|---|---|
| `AlreadySigner` | Target is already in the signer set |
| `ThresholdBreached` | Removing the target would leave fewer signers than the threshold |
| `ProposalExists` | A signer-change proposal is already active |
| `AlreadyFinalized` | The proposal has already been executed |

### Invariants preserved

- Only one signer-change proposal may be active at a time.
- Add: target must not already be a signer.
- Remove: `signers.len() > threshold` must hold after removal (threshold remains reachable).
- Proposals expire using the existing TTL / `VOTING_WINDOW`.
- Execution atomically updates the on-chain signer list and clears the proposal.

## Tests

10 new tests per contract (20 total):

- Non-signer cannot propose
- Cannot add an existing signer
- Add executes at threshold and new signer is immediately active
- Add under threshold stays pending
- Duplicate proposal rejected
- Duplicate approval rejected
- Remove executes at threshold and removed signer loses access
- Remove rejected when it would breach the threshold
- Remove of non-signer rejected
- Approval of expired proposal rejected

## Testing

```
cargo test -p multisig-governance -p upgrade-governance
```