### PR TITLE
fix: enforce auditable upgrade metadata and deterministic eligibility

### DIFF
--- a/contracts/clinical-trial/README.md
+++ b/contracts/clinical-trial/README.md
@@ -65,3 +65,6 @@ soroban contract deploy \
 
 - Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
 - If this contract depends on external registries/contracts, document those dependencies before release.
+- Eligibility evaluation is deterministic: each rule is bound to an expected claim hash derived from
+  trial id, patient attestation hash, and rule fields. `check_patient_eligibility` now consumes
+  attestation/ZK evidence hashes and returns per-rule explainable pass/fail artifacts.

--- a/contracts/clinical-trial/src/lib.rs
+++ b/contracts/clinical-trial/src/lib.rs
@@ -3,8 +3,8 @@
 #![allow(clippy::too_many_arguments)]
 
 use soroban_sdk::{
-    contract, contractimpl, contracterror, contractevent, symbol_short, Address, BytesN, Env,
-    String, Symbol, Vec,
+    contract, contracterror, contractevent, contractimpl, symbol_short, Address, Bytes, BytesN,
+    Env, String, Symbol, Vec,
 };
 
 mod storage;
@@ -178,6 +178,7 @@ impl ClinicalTrialContract {
         trial_record_id: u64,
         patient_id: Address,
         patient_data_hash: BytesN<32>,
+        claim_evidence: Vec<EligibilityClaimEvidence>,
     ) -> Result<EligibilityResult, Error> {
         patient_id.require_auth();
 
@@ -187,22 +188,23 @@ impl ClinicalTrialContract {
         // Get eligibility criteria
         let criteria = storage::get_criteria(&env, trial_record_id)?;
 
-        // In a real implementation, this would evaluate criteria against patient data
-        // For now, we'll create a simplified check
-        let inclusion_count = criteria.inclusion_criteria.len();
-        let exclusion_count = criteria.exclusion_criteria.len();
-
         let mut met_inclusion = Vec::new(&env);
         let mut met_exclusion = Vec::new(&env);
         let disqualifying_factors = Vec::new(&env);
+        let mut evaluation_artifacts = Vec::new(&env);
 
-        // Simulate criteria evaluation (in production, this would use patient_data_hash)
-        for _ in 0..inclusion_count {
-            met_inclusion.push_back(true);
+        for rule in criteria.inclusion_criteria.iter() {
+            let (passed, artifact) =
+                Self::evaluate_rule(&env, trial_record_id, &patient_data_hash, &rule, &claim_evidence);
+            met_inclusion.push_back(passed);
+            evaluation_artifacts.push_back(artifact);
         }
 
-        for _ in 0..exclusion_count {
-            met_exclusion.push_back(false);
+        for rule in criteria.exclusion_criteria.iter() {
+            let (matched, artifact) =
+                Self::evaluate_rule(&env, trial_record_id, &patient_data_hash, &rule, &claim_evidence);
+            met_exclusion.push_back(matched);
+            evaluation_artifacts.push_back(artifact);
         }
 
         let eligible = met_inclusion.iter().all(|x| x) && met_exclusion.iter().all(|x| !x);
@@ -212,6 +214,7 @@ impl ClinicalTrialContract {
             met_inclusion,
             met_exclusion,
             disqualifying_factors,
+            evaluation_artifacts,
         })
     }
 
@@ -573,6 +576,74 @@ impl ClinicalTrialContract {
         }
 
         Ok(event)
+    }
+
+    fn evaluate_rule(
+        env: &Env,
+        trial_record_id: u64,
+        patient_data_hash: &BytesN<32>,
+        rule: &CriteriaRule,
+        claim_evidence: &Vec<EligibilityClaimEvidence>,
+    ) -> (bool, RuleEvaluationArtifact) {
+        let expected_claim_hash =
+            Self::compute_expected_claim_hash(env, trial_record_id, patient_data_hash, rule);
+
+        for evidence in claim_evidence.iter() {
+            if evidence.claim_hash == expected_claim_hash {
+                return (
+                    true,
+                    RuleEvaluationArtifact {
+                        criteria_type: rule.criteria_type.clone(),
+                        parameter: rule.parameter.clone(),
+                        operator: rule.operator.clone(),
+                        value: rule.value.clone(),
+                        expected_claim_hash: expected_claim_hash.clone(),
+                        matched_claim_hash: Some(evidence.claim_hash),
+                        evidence_type: Some(evidence.evidence_type),
+                        passed: true,
+                        explanation: String::from_str(
+                            env,
+                            "Matched deterministic claim hash from attestation/zk evidence",
+                        ),
+                    },
+                );
+            }
+        }
+
+        (
+            false,
+            RuleEvaluationArtifact {
+                criteria_type: rule.criteria_type.clone(),
+                parameter: rule.parameter.clone(),
+                operator: rule.operator.clone(),
+                value: rule.value.clone(),
+                expected_claim_hash,
+                matched_claim_hash: None,
+                evidence_type: None,
+                passed: false,
+                explanation: String::from_str(
+                    env,
+                    "No matching deterministic claim hash found for rule",
+                ),
+            },
+        )
+    }
+
+    fn compute_expected_claim_hash(
+        env: &Env,
+        trial_record_id: u64,
+        patient_data_hash: &BytesN<32>,
+        rule: &CriteriaRule,
+    ) -> BytesN<32> {
+        let mut payload = Bytes::new(env);
+        payload.append(&Bytes::from_slice(env, b"trial-eligibility-v1"));
+        payload.append(&Bytes::from_slice(env, &trial_record_id.to_be_bytes()));
+        payload.append(&patient_data_hash.clone().into());
+        payload.append(&rule.criteria_type.to_string().into());
+        payload.append(&rule.parameter.to_xdr(env));
+        payload.append(&rule.operator.to_string().into());
+        payload.append(&rule.value.to_xdr(env));
+        env.crypto().sha256(&payload).into()
     }
 }
 

--- a/contracts/clinical-trial/src/test.rs
+++ b/contracts/clinical-trial/src/test.rs
@@ -1,5 +1,12 @@
-use crate::{ClinicalTrialContractClient, Error};
-use soroban_sdk::{symbol_short, testutils::Address as _, Address, BytesN, Env, String};
+use crate::{
+    ClinicalTrialContractClient, CriteriaRule, EligibilityClaimEvidence, Error, EvidenceType,
+};
+use soroban_sdk::{
+    symbol_short,
+    testutils::Address as _,
+    xdr::ToXdr,
+    Address, Bytes, BytesN, Env, String, Vec,
+};
 
 fn create_test_env() -> (Env, Address, Address, Address, ClinicalTrialContractClient<'static>) {
     let env = Env::default();
@@ -20,6 +27,33 @@ fn create_test_env() -> (Env, Address, Address, Address, ClinicalTrialContractCl
 fn create_protocol_hash(env: &Env) -> BytesN<32> {
     let data = String::from_str(env, "protocol_v1");
     env.crypto().sha256(&data.into()).into()
+}
+
+fn make_rule(env: &Env, parameter: &str, value: &str) -> CriteriaRule {
+    CriteriaRule {
+        criteria_type: symbol_short!("demo"),
+        parameter: String::from_str(env, parameter),
+        operator: symbol_short!("eq"),
+        value: String::from_str(env, value),
+        mandatory: true,
+    }
+}
+
+fn expected_claim_hash(
+    env: &Env,
+    trial_record_id: u64,
+    patient_data_hash: &BytesN<32>,
+    rule: &CriteriaRule,
+) -> BytesN<32> {
+    let mut payload = Bytes::new(env);
+    payload.append(&Bytes::from_slice(env, b"trial-eligibility-v1"));
+    payload.append(&Bytes::from_slice(env, &trial_record_id.to_be_bytes()));
+    payload.append(&patient_data_hash.clone().into());
+    payload.append(&rule.criteria_type.to_string().into());
+    payload.append(&rule.parameter.to_xdr(env));
+    payload.append(&rule.operator.to_string().into());
+    payload.append(&rule.value.to_xdr(env));
+    env.crypto().sha256(&payload).into()
 }
 
 #[test]
@@ -116,4 +150,81 @@ fn test_invalid_date_range() {
     );
 
     assert!(result.is_err());
+}
+
+#[test]
+fn test_eligibility_is_deterministic_and_explainable() {
+    let (env, _admin, pi, patient, client) = create_test_env();
+    let trial_record_id = client.register_clinical_trial(
+        &pi,
+        &String::from_str(&env, "TRIAL-ELIG-1"),
+        &String::from_str(&env, "Eligibility Determinism"),
+        &symbol_short!("phase2"),
+        &create_protocol_hash(&env),
+        &1000,
+        &5000,
+        &100,
+        &String::from_str(&env, "IRB-ELIG-001"),
+    );
+
+    let inclusion_rule = make_rule(&env, "age_band", "adult");
+    let exclusion_rule = make_rule(&env, "pregnant", "yes");
+    let mut inclusion = Vec::new(&env);
+    inclusion.push_back(inclusion_rule.clone());
+    let mut exclusion = Vec::new(&env);
+    exclusion.push_back(exclusion_rule.clone());
+    client.define_eligibility_criteria(&trial_record_id, &pi, &inclusion, &exclusion);
+
+    let patient_data_hash = BytesN::from_array(&env, &[7u8; 32]);
+    let inclusion_claim = expected_claim_hash(&env, trial_record_id, &patient_data_hash, &inclusion_rule);
+    let mut evidence = Vec::new(&env);
+    evidence.push_back(EligibilityClaimEvidence {
+        claim_hash: inclusion_claim,
+        evidence_type: EvidenceType::ZkVerifiedClaim,
+    });
+
+    let result = client.check_patient_eligibility(
+        &trial_record_id,
+        &patient,
+        &patient_data_hash,
+        &evidence,
+    );
+
+    assert!(result.eligible);
+    assert_eq!(result.met_inclusion.get(0).unwrap(), true);
+    assert_eq!(result.met_exclusion.get(0).unwrap(), false);
+    assert_eq!(result.evaluation_artifacts.len(), 2);
+}
+
+#[test]
+fn test_eligibility_fails_when_required_claim_missing() {
+    let (env, _admin, pi, patient, client) = create_test_env();
+    let trial_record_id = client.register_clinical_trial(
+        &pi,
+        &String::from_str(&env, "TRIAL-ELIG-2"),
+        &String::from_str(&env, "Eligibility Missing Claim"),
+        &symbol_short!("phase2"),
+        &create_protocol_hash(&env),
+        &1000,
+        &5000,
+        &100,
+        &String::from_str(&env, "IRB-ELIG-002"),
+    );
+
+    let inclusion_rule = make_rule(&env, "diagnosis", "condition_a");
+    let mut inclusion = Vec::new(&env);
+    inclusion.push_back(inclusion_rule);
+    client.define_eligibility_criteria(&trial_record_id, &pi, &inclusion, &Vec::new(&env));
+
+    let patient_data_hash = BytesN::from_array(&env, &[8u8; 32]);
+    let result = client.check_patient_eligibility(
+        &trial_record_id,
+        &patient,
+        &patient_data_hash,
+        &Vec::new(&env),
+    );
+
+    assert!(!result.eligible);
+    assert_eq!(result.met_inclusion.get(0).unwrap(), false);
+    assert_eq!(result.evaluation_artifacts.get(0).unwrap().passed, false);
 }

--- a/contracts/clinical-trial/src/types.rs
+++ b/contracts/clinical-trial/src/types.rs
@@ -31,6 +31,38 @@ pub struct EligibilityResult {
     pub met_inclusion: Vec<bool>,
     pub met_exclusion: Vec<bool>,
     pub disqualifying_factors: Vec<String>,
+    pub evaluation_artifacts: Vec<RuleEvaluationArtifact>,
+}
+
+/// Type of evidence used for eligibility checks.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EvidenceType {
+    Attestation,
+    ZkVerifiedClaim,
+}
+
+/// Claim evidence supplied during deterministic eligibility evaluation.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct EligibilityClaimEvidence {
+    pub claim_hash: BytesN<32>,
+    pub evidence_type: EvidenceType,
+}
+
+/// Explainable pass/fail artifact for each rule evaluation.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RuleEvaluationArtifact {
+    pub criteria_type: Symbol,
+    pub parameter: String,
+    pub operator: Symbol,
+    pub value: String,
+    pub expected_claim_hash: BytesN<32>,
+    pub matched_claim_hash: Option<BytesN<32>>,
+    pub evidence_type: Option<EvidenceType>,
+    pub passed: bool,
+    pub explanation: String,
 }
 
 /// Clinical trial record

--- a/contracts/upgrade-governance/README.md
+++ b/contracts/upgrade-governance/README.md
@@ -17,6 +17,7 @@ This README provides a quick operational map for integration, testing, and deplo
 - `initialize`
 
 ### Messages / Entry Points
+- `approve_artifact_metadata`
 - `execute_upgrade`
 - `get_proposal`
 - `propose_upgrade`
@@ -55,3 +56,5 @@ soroban contract deploy \
 
 - Keep this README aligned with API/auth/storage changes in `src/lib.rs`.
 - If this contract depends on external registries/contracts, document those dependencies before release.
+- Upgrade proposals now carry release metadata (`version`, `audit_digest`, `build_manifest`) and
+  the metadata hash must be pre-approved with `approve_artifact_metadata` before execution.

--- a/contracts/upgrade-governance/src/lib.rs
+++ b/contracts/upgrade-governance/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN,
+    Env, Vec,
 };
 
 mod test;
@@ -31,6 +32,10 @@ pub enum Error {
     Cancelled          = 11,
     /// Caller is not authorised to cancel (must be a signer).
     NotAuthorized      = 12,
+    /// Release metadata does not hash to the declared metadata hash.
+    InvalidReleaseMetadata = 13,
+    /// Release metadata hash is not in the approved artifact registry.
+    UnapprovedArtifactMetadata = 14,
 }
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
@@ -42,6 +47,7 @@ pub enum DataKey {
     Threshold,
     NextId,
     Proposal(u64),
+    ApprovedArtifactMetadata(BytesN<32>),
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -60,6 +66,8 @@ pub enum ProposalStatus {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UpgradeProposal {
     pub new_wasm_hash: BytesN<32>,
+    pub release_metadata: ReleaseMetadata,
+    pub artifact_metadata_hash: BytesN<32>,
     pub votes: Vec<Address>,
     pub proposed_at: u64,
     /// Timestamp when the threshold was first reached (starts the timelock).
@@ -68,6 +76,14 @@ pub struct UpgradeProposal {
     /// Domain tag: SHA-256(contract_address ++ "upgrade-governance" ++ proposal_id).
     /// Stored so callers can verify the binding off-chain.
     pub domain_tag: BytesN<32>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReleaseMetadata {
+    pub version: Bytes,
+    pub audit_digest: BytesN<32>,
+    pub build_manifest: BytesN<32>,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -95,10 +111,17 @@ impl UpgradeGovernance {
         env: Env,
         proposer: Address,
         new_wasm_hash: BytesN<32>,
+        release_metadata: ReleaseMetadata,
+        artifact_metadata_hash: BytesN<32>,
     ) -> Result<u64, Error> {
         Self::assert_initialized(&env)?;
         proposer.require_auth();
         Self::assert_signer(&env, &proposer)?;
+        Self::validate_release_metadata(
+            &env,
+            &release_metadata,
+            &artifact_metadata_hash,
+        )?;
 
         let proposal_id: u64 = env
             .storage()
@@ -113,6 +136,8 @@ impl UpgradeGovernance {
 
         let proposal = UpgradeProposal {
             new_wasm_hash: new_wasm_hash.clone(),
+            release_metadata,
+            artifact_metadata_hash,
             votes,
             proposed_at: env.ledger().timestamp(),
             approved_at: 0,
@@ -131,6 +156,25 @@ impl UpgradeGovernance {
             .publish((symbol_short!("proposed"), proposal_id), new_wasm_hash);
 
         Ok(proposal_id)
+    }
+
+    /// Allow signers to approve a release artifact metadata hash before execution.
+    pub fn approve_artifact_metadata(
+        env: Env,
+        caller: Address,
+        artifact_metadata_hash: BytesN<32>,
+    ) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        caller.require_auth();
+        Self::assert_signer(&env, &caller)?;
+        env.storage()
+            .persistent()
+            .set(&DataKey::ApprovedArtifactMetadata(artifact_metadata_hash.clone()), &true);
+        env.events().publish(
+            (symbol_short!("meta_appr"), caller),
+            artifact_metadata_hash,
+        );
+        Ok(())
     }
 
     pub fn vote_upgrade(env: Env, voter: Address, proposal_id: u64) -> Result<(), Error> {
@@ -198,6 +242,21 @@ impl UpgradeGovernance {
         if env.ledger().timestamp() < proposal.approved_at + TIMELOCK_DELAY {
             return Err(Error::TimelockActive);
         }
+        let approved = env
+            .storage()
+            .persistent()
+            .get::<DataKey, bool>(&DataKey::ApprovedArtifactMetadata(
+                proposal.artifact_metadata_hash.clone(),
+            ))
+            .unwrap_or(false);
+        if !approved {
+            return Err(Error::UnapprovedArtifactMetadata);
+        }
+        Self::validate_release_metadata(
+            &env,
+            &proposal.release_metadata,
+            &proposal.artifact_metadata_hash,
+        )?;
 
         proposal.status = ProposalStatus::Executed;
         env.storage()
@@ -265,6 +324,28 @@ impl UpgradeGovernance {
         data.append(&Bytes::from_slice(env, b"upgrade-governance"));
         data.append(&Bytes::from_slice(env, &proposal_id.to_le_bytes()));
         env.crypto().sha256(&data).into()
+    }
+
+    /// Canonical metadata hash = SHA-256("release-metadata-v1" ++ version ++ audit_digest ++ build_manifest)
+    fn compute_artifact_metadata_hash(env: &Env, metadata: &ReleaseMetadata) -> BytesN<32> {
+        let mut data = Bytes::new(env);
+        data.append(&Bytes::from_slice(env, b"release-metadata-v1"));
+        data.append(&metadata.version);
+        data.append(&metadata.audit_digest.clone().into());
+        data.append(&metadata.build_manifest.clone().into());
+        env.crypto().sha256(&data).into()
+    }
+
+    fn validate_release_metadata(
+        env: &Env,
+        metadata: &ReleaseMetadata,
+        declared_hash: &BytesN<32>,
+    ) -> Result<(), Error> {
+        let computed = Self::compute_artifact_metadata_hash(env, metadata);
+        if computed != *declared_hash {
+            return Err(Error::InvalidReleaseMetadata);
+        }
+        Ok(())
     }
 
     // ── guards ────────────────────────────────────────────────────────────────

--- a/contracts/upgrade-governance/src/test.rs
+++ b/contracts/upgrade-governance/src/test.rs
@@ -3,7 +3,7 @@
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
-    Address, BytesN, Env, Vec,
+    Address, Bytes, BytesN, Env, Vec,
 };
 
 fn make_signers(env: &Env, n: u32) -> Vec<Address> {
@@ -16,6 +16,23 @@ fn make_signers(env: &Env, n: u32) -> Vec<Address> {
 
 fn dummy_hash(env: &Env) -> BytesN<32> {
     BytesN::from_array(env, &[1u8; 32])
+}
+
+fn release_metadata(env: &Env) -> ReleaseMetadata {
+    ReleaseMetadata {
+        version: Bytes::from_slice(env, b"v1.2.3"),
+        audit_digest: BytesN::from_array(env, &[2u8; 32]),
+        build_manifest: BytesN::from_array(env, &[3u8; 32]),
+    }
+}
+
+fn metadata_hash(env: &Env, metadata: &ReleaseMetadata) -> BytesN<32> {
+    let mut data = Bytes::new(env);
+    data.append(&Bytes::from_slice(env, b"release-metadata-v1"));
+    data.append(&metadata.version);
+    data.append(&metadata.audit_digest.clone().into());
+    data.append(&metadata.build_manifest.clone().into());
+    env.crypto().sha256(&data).into()
 }
 
 fn setup(n: u32, threshold: u32) -> (Env, Vec<Address>, UpgradeGovernanceClient<'static>) {
@@ -56,7 +73,12 @@ fn test_propose_before_init_returns_error() {
     let client = UpgradeGovernanceClient::new(&env, &contract_id);
     let signer = Address::generate(&env);
     let err = client
-        .try_propose_upgrade(&signer, &dummy_hash(&env))
+        .try_propose_upgrade(
+            &signer,
+            &dummy_hash(&env),
+            &release_metadata(&env),
+            &metadata_hash(&env, &release_metadata(&env)),
+        )
         .unwrap_err()
         .unwrap();
     assert_eq!(err, Error::NotInitialized);
@@ -69,7 +91,12 @@ fn test_non_signer_propose_returns_error() {
     let (env, _signers, client) = setup(3, 2);
     let stranger = Address::generate(&env);
     let err = client
-        .try_propose_upgrade(&stranger, &dummy_hash(&env))
+        .try_propose_upgrade(
+            &stranger,
+            &dummy_hash(&env),
+            &release_metadata(&env),
+            &metadata_hash(&env, &release_metadata(&env)),
+        )
         .unwrap_err()
         .unwrap();
     assert_eq!(err, Error::NotASigner);
@@ -79,10 +106,30 @@ fn test_non_signer_propose_returns_error() {
 fn test_propose_returns_incrementing_ids() {
     let (env, signers, client) = setup(3, 2);
     let s0 = signers.get(0).unwrap();
-    let id0 = client.propose_upgrade(&s0, &dummy_hash(&env));
-    let id1 = client.propose_upgrade(&s0, &BytesN::from_array(&env, &[2u8; 32]));
+    let metadata = release_metadata(&env);
+    let metadata_hash = metadata_hash(&env, &metadata);
+    let id0 = client.propose_upgrade(&s0, &dummy_hash(&env), &metadata, &metadata_hash);
+    let id1 = client.propose_upgrade(
+        &s0,
+        &BytesN::from_array(&env, &[2u8; 32]),
+        &metadata,
+        &metadata_hash,
+    );
     assert_eq!(id0, 0);
     assert_eq!(id1, 1);
+}
+
+#[test]
+fn test_propose_with_invalid_release_metadata_hash_returns_error() {
+    let (env, signers, client) = setup(3, 2);
+    let s0 = signers.get(0).unwrap();
+    let metadata = release_metadata(&env);
+    let wrong_hash = BytesN::from_array(&env, &[9u8; 32]);
+    let err = client
+        .try_propose_upgrade(&s0, &dummy_hash(&env), &metadata, &wrong_hash)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::InvalidReleaseMetadata);
 }
 
 // ── domain tag ────────────────────────────────────────────────────────────────
@@ -91,8 +138,15 @@ fn test_propose_returns_incrementing_ids() {
 fn test_domain_tags_differ_per_proposal() {
     let (env, signers, client) = setup(3, 2);
     let s0 = signers.get(0).unwrap();
-    let id0 = client.propose_upgrade(&s0, &dummy_hash(&env));
-    let id1 = client.propose_upgrade(&s0, &BytesN::from_array(&env, &[2u8; 32]));
+    let metadata = release_metadata(&env);
+    let metadata_hash = metadata_hash(&env, &metadata);
+    let id0 = client.propose_upgrade(&s0, &dummy_hash(&env), &metadata, &metadata_hash);
+    let id1 = client.propose_upgrade(
+        &s0,
+        &BytesN::from_array(&env, &[2u8; 32]),
+        &metadata,
+        &metadata_hash,
+    );
     let p0 = client.get_proposal(&id0);
     let p1 = client.get_proposal(&id1);
     assert_ne!(p0.domain_tag, p1.domain_tag, "domain tags must differ per proposal");
@@ -105,7 +159,9 @@ fn test_non_signer_vote_returns_error() {
     let (env, signers, client) = setup(3, 2);
     let s0 = signers.get(0).unwrap();
     let stranger = Address::generate(&env);
-    let id = client.propose_upgrade(&s0, &dummy_hash(&env));
+    let metadata = release_metadata(&env);
+    let metadata_hash = metadata_hash(&env, &metadata);
+    let id = client.propose_upgrade(&s0, &dummy_hash(&env), &metadata, &metadata_hash);
     let err = client.try_vote_upgrade(&stranger, &id).unwrap_err().unwrap();
     assert_eq!(err, Error::NotASigner);
 }
@@ -115,7 +171,9 @@ fn test_duplicate_vote_returns_error() {
     let (env, signers, client) = setup(3, 3);
     let s0 = signers.get(0).unwrap();
     let s1 = signers.get(1).unwrap();
-    let id = client.propose_upgrade(&s0, &dummy_hash(&env));
+    let metadata = release_metadata(&env);
+    let metadata_hash = metadata_hash(&env, &metadata);
+    let id = client.propose_upgrade(&s0, &dummy_hash(&env), &metadata, &metadata_hash);
     client.vote_upgrade(&s1, &id);
     let err = client.try_vote_upgrade(&s1, &id).unwrap_err().unwrap();
     assert_eq!(err, Error::AlreadyVoted);
@@ -126,7 +184,9 @@ fn test_vote_after_expiry_returns_error() {
     let (env, signers, client) = setup(3, 3);
     let s0 = signers.get(0).unwrap();
     let s1 = signers.get(1).unwrap();
-    let id = client.propose_upgrade(&s0, &dummy_hash(&env));
+    let metadata = release_metadata(&env);
+    let metadata_hash = metadata_hash(&env, &metadata);
+    let id = client.propose_upgrade(&s0, &dummy_hash(&env), &metadata, &metadata_hash);
     env.ledger().with_mut(|li| { li.timestamp += VOTING_WINDOW + 1; });
     let err = client.try_vote_upgrade(&s1, &id).unwrap_err().unwrap();
     assert_eq!(err, Error::Expired);
@@ -139,7 +199,9 @@ fn test_execute_before_timelock_returns_error() {
     let (env, signers, client) = setup(3, 2);
     let s0 = signers.get(0).unwrap();
     let s1 = signers.get(1).unwrap();
-    let id = client.propose_upgrade(&s0, &dummy_hash(&env));
+    let metadata = release_metadata(&env);
+    let metadata_hash = metadata_hash(&env, &metadata);
+    let id = client.propose_upgrade(&s0, &dummy_hash(&env), &metadata, &metadata_hash);
     client.vote_upgrade(&s1, &id);
     // Threshold reached but timelock not elapsed.
     let err = client.try_execute_upgrade(&s0, &id).unwrap_err().unwrap();
@@ -147,12 +209,31 @@ fn test_execute_before_timelock_returns_error() {
 }
 
 #[test]
+fn test_execute_without_approved_metadata_returns_error() {
+    let (env, signers, client) = setup(3, 2);
+    let s0 = signers.get(0).unwrap();
+    let s1 = signers.get(1).unwrap();
+    let metadata = release_metadata(&env);
+    let metadata_hash = metadata_hash(&env, &metadata);
+    let id = client.propose_upgrade(&s0, &dummy_hash(&env), &metadata, &metadata_hash);
+    client.vote_upgrade(&s1, &id);
+    env.ledger().with_mut(|li| {
+        li.timestamp += TIMELOCK_DELAY + 1;
+    });
+    let err = client.try_execute_upgrade(&s0, &id).unwrap_err().unwrap();
+    assert_eq!(err, Error::UnapprovedArtifactMetadata);
+}
+
+#[test]
 fn test_execute_after_timelock_passes_governance_checks() {
     let (env, signers, client) = setup(3, 2);
     let s0 = signers.get(0).unwrap();
     let s1 = signers.get(1).unwrap();
-    let id = client.propose_upgrade(&s0, &dummy_hash(&env));
+    let metadata = release_metadata(&env);
+    let metadata_hash = metadata_hash(&env, &metadata);
+    let id = client.propose_upgrade(&s0, &dummy_hash(&env), &metadata, &metadata_hash);
     client.vote_upgrade(&s1, &id);
+    client.approve_artifact_metadata(&s0, &metadata_hash);
     // Advance past the timelock.
     env.ledger().with_mut(|li| { li.timestamp += TIMELOCK_DELAY + 1; });
     // Governance checks pass; deployer panics on dummy hash — that's expected.
@@ -180,7 +261,9 @@ fn test_cancel_active_proposal() {
     let (env, signers, client) = setup(3, 3);
     let s0 = signers.get(0).unwrap();
     let s1 = signers.get(1).unwrap();
-    let id = client.propose_upgrade(&s0, &dummy_hash(&env));
+    let metadata = release_metadata(&env);
+    let metadata_hash = metadata_hash(&env, &metadata);
+    let id = client.propose_upgrade(&s0, &dummy_hash(&env), &metadata, &metadata_hash);
     client.cancel_upgrade(&s1, &id);
     let proposal = client.get_proposal(&id);
     assert_eq!(proposal.status, ProposalStatus::Cancelled);
@@ -192,7 +275,9 @@ fn test_cancel_approved_proposal_during_timelock() {
     let s0 = signers.get(0).unwrap();
     let s1 = signers.get(1).unwrap();
     let s2 = signers.get(2).unwrap();
-    let id = client.propose_upgrade(&s0, &dummy_hash(&env));
+    let metadata = release_metadata(&env);
+    let metadata_hash = metadata_hash(&env, &metadata);
+    let id = client.propose_upgrade(&s0, &dummy_hash(&env), &metadata, &metadata_hash);
     client.vote_upgrade(&s1, &id);
     // Proposal is now Approved; cancel during timelock window.
     client.cancel_upgrade(&s2, &id);
@@ -206,7 +291,9 @@ fn test_vote_on_cancelled_proposal_returns_error() {
     let s0 = signers.get(0).unwrap();
     let s1 = signers.get(1).unwrap();
     let s2 = signers.get(2).unwrap();
-    let id = client.propose_upgrade(&s0, &dummy_hash(&env));
+    let metadata = release_metadata(&env);
+    let metadata_hash = metadata_hash(&env, &metadata);
+    let id = client.propose_upgrade(&s0, &dummy_hash(&env), &metadata, &metadata_hash);
     client.cancel_upgrade(&s1, &id);
     let err = client.try_vote_upgrade(&s2, &id).unwrap_err().unwrap();
     assert_eq!(err, Error::Cancelled);
@@ -217,7 +304,9 @@ fn test_execute_cancelled_proposal_returns_error() {
     let (env, signers, client) = setup(3, 2);
     let s0 = signers.get(0).unwrap();
     let s1 = signers.get(1).unwrap();
-    let id = client.propose_upgrade(&s0, &dummy_hash(&env));
+    let metadata = release_metadata(&env);
+    let metadata_hash = metadata_hash(&env, &metadata);
+    let id = client.propose_upgrade(&s0, &dummy_hash(&env), &metadata, &metadata_hash);
     client.vote_upgrade(&s1, &id);
     client.cancel_upgrade(&s0, &id);
     env.ledger().with_mut(|li| { li.timestamp += TIMELOCK_DELAY + 1; });
@@ -231,7 +320,9 @@ fn test_execute_cancelled_proposal_returns_error() {
 fn test_execute_under_threshold_returns_error() {
     let (env, signers, client) = setup(3, 3);
     let s0 = signers.get(0).unwrap();
-    let id = client.propose_upgrade(&s0, &dummy_hash(&env));
+    let metadata = release_metadata(&env);
+    let metadata_hash = metadata_hash(&env, &metadata);
+    let id = client.propose_upgrade(&s0, &dummy_hash(&env), &metadata, &metadata_hash);
     env.ledger().with_mut(|li| { li.timestamp += TIMELOCK_DELAY + 1; });
     let err = client.try_execute_upgrade(&s0, &id).unwrap_err().unwrap();
     assert_eq!(err, Error::ThresholdNotMet);
@@ -244,7 +335,9 @@ fn test_execute_expired_returns_error() {
     let (env, signers, client) = setup(3, 2);
     let s0 = signers.get(0).unwrap();
     let s1 = signers.get(1).unwrap();
-    let id = client.propose_upgrade(&s0, &dummy_hash(&env));
+    let metadata = release_metadata(&env);
+    let metadata_hash = metadata_hash(&env, &metadata);
+    let id = client.propose_upgrade(&s0, &dummy_hash(&env), &metadata, &metadata_hash);
     client.vote_upgrade(&s1, &id);
     env.ledger().with_mut(|li| { li.timestamp += VOTING_WINDOW + 1; });
     let err = client.try_execute_upgrade(&s0, &id).unwrap_err().unwrap();
@@ -259,7 +352,9 @@ fn test_vote_on_executed_proposal_returns_error() {
     let s0 = signers.get(0).unwrap();
     let s1 = signers.get(1).unwrap();
     let s2 = signers.get(2).unwrap();
-    let id = client.propose_upgrade(&s0, &dummy_hash(&env));
+    let metadata = release_metadata(&env);
+    let metadata_hash = metadata_hash(&env, &metadata);
+    let id = client.propose_upgrade(&s0, &dummy_hash(&env), &metadata, &metadata_hash);
     client.vote_upgrade(&s1, &id);
 
     let mut proposal: UpgradeProposal = client.get_proposal(&id);


### PR DESCRIPTION
Require approved release-artifact metadata hashes for upgrade execution and replace placeholder clinical trial eligibility with deterministic claim-hash evaluation plus explainable artifacts.

closes #234 
closes #240 