### PR TITLE
feat: add safe counter utilities and RBAC role system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
 name = "care-plan"
 version = "0.1.0"
 dependencies = [
+ "Contracts",
  "soroban-sdk",
 ]
 
@@ -310,13 +311,6 @@ dependencies = [
 
 [[package]]
 name = "clinical-guideline"
-version = "0.1.0"
-dependencies = [
- "soroban-sdk",
-]
-
-[[package]]
-name = "clinical-trial"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk",
@@ -798,6 +792,7 @@ dependencies = [
 name = "hai-tracking"
 version = "0.1.0"
 dependencies = [
+ "Contracts",
  "soroban-sdk",
 ]
 
@@ -844,6 +839,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 name = "health-records"
 version = "0.0.0"
 dependencies = [
+ "Contracts",
  "soroban-sdk",
 ]
 
@@ -905,6 +901,7 @@ dependencies = [
 name = "hospital-discharge-management"
 version = "0.1.0"
 dependencies = [
+ "Contracts",
  "soroban-sdk",
 ]
 
@@ -955,6 +952,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 name = "imaging-radiology"
 version = "0.0.0"
 dependencies = [
+ "Contracts",
  "soroban-sdk",
 ]
 
@@ -1178,6 +1176,7 @@ dependencies = [
 name = "nutrition-care-management"
 version = "0.1.0"
 dependencies = [
+ "Contracts",
  "soroban-sdk",
 ]
 
@@ -1203,6 +1202,7 @@ dependencies = [
 name = "pacs-integration"
 version = "0.0.0"
 dependencies = [
+ "Contracts",
  "soroban-sdk",
 ]
 
@@ -1256,6 +1256,7 @@ dependencies = [
 name = "prenatal-pediatric"
 version = "0.1.0"
 dependencies = [
+ "Contracts",
  "soroban-sdk",
 ]
 
@@ -2435,7 +2436,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "zk-eligibility-verifier"
+name = "zk-eligibility"
 version = "0.0.0"
 dependencies = [
  "soroban-sdk",

--- a/contracts/access-control/src/lib.rs
+++ b/contracts/access-control/src/lib.rs
@@ -23,6 +23,47 @@ pub enum ContractError {
     AccessPermissionNotFound = 9,
     ContractNotInitialized = 10,
     OnlyAdminCanDeactivate = 11,
+    // Role-based access control errors
+    RoleAlreadyGranted = 12,
+    RoleNotFound = 13,
+    InsufficientRole = 14,
+    RoleExpired = 15,
+}
+
+/// --------------------
+/// Roles
+/// --------------------
+/// Operational roles that can be granted to addresses. Each role scopes
+/// which privileged entry points the holder may call.
+///
+/// Hierarchy (highest → lowest privilege):
+///   Admin > Auditor > PayerReviewer | Provider | EmergencyResponder
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Role {
+    /// Full administrative control: grant/revoke roles, deactivate entities.
+    Admin,
+    /// Read-only audit access across all resources.
+    Auditor,
+    /// Insurance / payer reviewer: may adjudicate and revoke resource access.
+    PayerReviewer,
+    /// Healthcare provider: may grant resource access to patients.
+    Provider,
+    /// Emergency responder: may access any resource without prior consent
+    /// (break-glass); every use is logged.
+    EmergencyResponder,
+}
+
+/// A single role assignment stored per (address, role) pair.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoleAssignment {
+    /// Who granted this role.
+    pub granted_by: Address,
+    /// Ledger timestamp when the role was granted.
+    pub granted_at: u64,
+    /// Optional expiry timestamp; 0 means the role never expires.
+    pub expires_at: u64,
 }
 
 /// --------------------
@@ -72,6 +113,8 @@ pub enum DataKey {
     AccessList(Address),    // Entity -> Vec<AccessPermission>
     ResourceAccess(String), // Resource -> Vec<Address> (authorized parties)
     Did(Address),
+    /// (address, role) -> RoleAssignment
+    RoleAssignment(Address, Role),
 }
 
 #[contract]
@@ -79,6 +122,50 @@ pub struct AccessControl;
 
 #[contractimpl]
 impl AccessControl {
+    // -------------------------------------------------------------------------
+    // Internal role helpers
+    // -------------------------------------------------------------------------
+
+    /// Returns the stored `RoleAssignment` for `(address, role)` if it exists
+    /// **and** has not expired. Expired entries are treated as absent.
+    fn load_active_role(
+        env: &Env,
+        address: &Address,
+        role: &Role,
+    ) -> Option<RoleAssignment> {
+        let key = DataKey::RoleAssignment(address.clone(), role.clone());
+        let assignment: RoleAssignment = env.storage().persistent().get(&key)?;
+        let now = env.ledger().timestamp();
+        if assignment.expires_at != 0 && assignment.expires_at <= now {
+            return None;
+        }
+        Some(assignment)
+    }
+
+    /// Asserts that `caller` holds `role` (and the role has not expired).
+    /// Returns `InsufficientRole` if the check fails.
+    fn require_role(
+        env: &Env,
+        caller: &Address,
+        role: &Role,
+    ) -> Result<(), ContractError> {
+        // Admin always satisfies any role check.
+        let admin_opt: Option<Address> = env.storage().persistent().get(&DataKey::Admin);
+        if let Some(ref admin) = admin_opt {
+            if caller == admin {
+                return Ok(());
+            }
+        }
+        if Self::load_active_role(env, caller, role).is_some() {
+            return Ok(());
+        }
+        Err(ContractError::InsufficientRole)
+    }
+
+    // -------------------------------------------------------------------------
+    // Initialize
+    // -------------------------------------------------------------------------
+
     /// Initialize the contract with an admin
     ///
     /// # Arguments
@@ -90,9 +177,117 @@ impl AccessControl {
         admin.require_auth();
         env.storage().persistent().set(&DataKey::Admin, &admin);
 
+        // Bootstrap: give the admin the Admin role so role checks are uniform.
+        let bootstrap = RoleAssignment {
+            granted_by: admin.clone(),
+            granted_at: env.ledger().timestamp(),
+            expires_at: 0,
+        };
+        env.storage().persistent().set(
+            &DataKey::RoleAssignment(admin.clone(), Role::Admin),
+            &bootstrap,
+        );
+
         env.events()
             .publish((symbol_short!("init"), admin), symbol_short!("success"));
         Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // Role management
+    // -------------------------------------------------------------------------
+
+    /// Grant `role` to `grantee`. Only an address that itself holds the
+    /// `Admin` role (or is the stored admin address) may call this.
+    ///
+    /// # Arguments
+    /// * `granter`    - Must hold the `Admin` role.
+    /// * `grantee`    - Address receiving the role.
+    /// * `role`       - The role to grant.
+    /// * `expires_at` - Expiry timestamp; pass `0` for no expiry.
+    pub fn grant_role(
+        env: Env,
+        granter: Address,
+        grantee: Address,
+        role: Role,
+        expires_at: u64,
+    ) -> Result<(), ContractError> {
+        granter.require_auth();
+        Self::require_role(&env, &granter, &Role::Admin)?;
+
+        let key = DataKey::RoleAssignment(grantee.clone(), role.clone());
+        if env.storage().persistent().has(&key) {
+            // Allow re-grant only if the existing assignment has expired.
+            if Self::load_active_role(&env, &grantee, &role).is_some() {
+                return Err(ContractError::RoleAlreadyGranted);
+            }
+        }
+
+        let assignment = RoleAssignment {
+            granted_by: granter.clone(),
+            granted_at: env.ledger().timestamp(),
+            expires_at,
+        };
+        env.storage().persistent().set(&key, &assignment);
+
+        env.events().publish(
+            (symbol_short!("role_grt"), grantee, role),
+            symbol_short!("success"),
+        );
+        Ok(())
+    }
+
+    /// Revoke `role` from `revokee`. Only an address that holds the `Admin`
+    /// role may call this.
+    ///
+    /// # Arguments
+    /// * `revoker`  - Must hold the `Admin` role.
+    /// * `revokee`  - Address losing the role.
+    /// * `role`     - The role to revoke.
+    pub fn revoke_role(
+        env: Env,
+        revoker: Address,
+        revokee: Address,
+        role: Role,
+    ) -> Result<(), ContractError> {
+        revoker.require_auth();
+        Self::require_role(&env, &revoker, &Role::Admin)?;
+
+        let key = DataKey::RoleAssignment(revokee.clone(), role.clone());
+        if !env.storage().persistent().has(&key) {
+            return Err(ContractError::RoleNotFound);
+        }
+        env.storage().persistent().remove(&key);
+
+        env.events().publish(
+            (symbol_short!("role_rev"), revokee, role),
+            symbol_short!("success"),
+        );
+        Ok(())
+    }
+
+    /// Returns `true` if `address` currently holds `role` (and it has not
+    /// expired). Does **not** require any auth — safe to call as a view.
+    pub fn has_role(env: Env, address: Address, role: Role) -> bool {
+        // Admin address always satisfies any role.
+        let admin_opt: Option<Address> = env.storage().persistent().get(&DataKey::Admin);
+        if let Some(ref admin) = admin_opt {
+            if &address == admin {
+                return true;
+            }
+        }
+        Self::load_active_role(&env, &address, &role).is_some()
+    }
+
+    /// Returns the full `RoleAssignment` for `(address, role)`, or an error
+    /// if the role was never granted or has expired.
+    pub fn get_role_assignment(
+        env: Env,
+        address: Address,
+        role: Role,
+    ) -> Result<RoleAssignment, ContractError> {
+        Self::load_active_role(&env, &address, &role)
+            .ok_or(ContractError::RoleNotFound)
     }
 
     /// Register a new entity in the system
@@ -214,21 +409,25 @@ impl AccessControl {
         Ok(())
     }
 
-    /// Revoke access permission from an entity for a specific resource
+    /// Revoke access permission from an entity for a specific resource.
+    ///
+    /// Authorised callers (any one of):
+    /// - The original grantor of the permission.
+    /// - Any address holding the `Admin` role.
+    /// - Any address holding the `PayerReviewer` role.
     ///
     /// # Arguments
-    /// * `revoker` - The address revoking access (must be the original grantor or admin)
-    /// * `revokee` - The address losing access
-    /// * `resource_id` - The identifier of the resource
+    /// * `revoker`     - Must be the original grantor, an Admin, or a PayerReviewer.
+    /// * `revokee`     - The address losing access.
+    /// * `resource_id` - The identifier of the resource.
     pub fn revoke_access(env: Env, revoker: Address, revokee: Address, resource_id: String) -> Result<(), ContractError> {
         revoker.require_auth();
 
-        // Get admin for authorization check
-        let admin: Address = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Admin)
-            .ok_or(ContractError::ContractNotInitialized)?;
+        // Determine whether the revoker has a privileged role that allows
+        // revoking any permission (Admin or PayerReviewer).
+        let has_privileged_role =
+            Self::require_role(&env, &revoker, &Role::Admin).is_ok()
+            || Self::require_role(&env, &revoker, &Role::PayerReviewer).is_ok();
 
         // Remove from grantee's access list
         let access_key = DataKey::AccessList(revokee.clone());
@@ -244,8 +443,9 @@ impl AccessControl {
         for i in 0..access_list.len() {
             if let Some(permission) = access_list.get(i) {
                 if permission.resource_id == resource_id {
-                    // Verify revoker is either the original grantor or admin
-                    if permission.granted_by != revoker && revoker != admin {
+                    // Verify revoker is either the original grantor or holds a
+                    // privileged role.
+                    if permission.granted_by != revoker && !has_privileged_role {
                         return Err(ContractError::NotAuthorizedToRevoke);
                     }
                     found = true;
@@ -391,23 +591,17 @@ impl AccessControl {
         Ok(())
     }
 
-    /// Deactivate an entity (admin only)
+    /// Deactivate an entity.
+    ///
+    /// Requires the caller to hold the `Admin` role.
     ///
     /// # Arguments
-    /// * `admin` - The admin address
-    /// * `wallet` - The wallet address of the entity to deactivate
-    pub fn deactivate_entity(env: Env, admin: Address, wallet: Address) -> Result<(), ContractError> {
-        admin.require_auth();
-
-        let stored_admin: Address = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Admin)
-            .ok_or(ContractError::ContractNotInitialized)?;
-
-        if admin != stored_admin {
-            return Err(ContractError::OnlyAdminCanDeactivate);
-        }
+    /// * `caller` - Must hold the `Admin` role.
+    /// * `wallet` - The wallet address of the entity to deactivate.
+    pub fn deactivate_entity(env: Env, caller: Address, wallet: Address) -> Result<(), ContractError> {
+        caller.require_auth();
+        Self::require_role(&env, &caller, &Role::Admin)
+            .map_err(|_| ContractError::OnlyAdminCanDeactivate)?;
 
         let key = DataKey::Entity(wallet.clone());
         let mut entity: EntityData = env

--- a/contracts/access-control/src/test.rs
+++ b/contracts/access-control/src/test.rs
@@ -588,3 +588,311 @@ fn test_revoke_access_not_authorized() {
     let result = client.try_revoke_access(&other, &doctor, &resource);
     assert_eq!(result, Err(Ok(ContractError::NotAuthorizedToRevoke)));
 }
+
+// =============================================================================
+// Role-based access control tests
+// =============================================================================
+
+fn setup(env: &Env) -> (Address, AccessControlClient) {
+    let contract_id = env.register(AccessControl, ());
+    let client = AccessControlClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+    (admin, client)
+}
+
+// --- grant_role / has_role ---------------------------------------------------
+
+#[test]
+fn test_grant_role_and_has_role() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    let provider = Address::generate(&env);
+    assert!(!client.has_role(&provider, &Role::Provider));
+
+    client.grant_role(&admin, &provider, &Role::Provider, &0);
+    assert!(client.has_role(&provider, &Role::Provider));
+}
+
+#[test]
+fn test_admin_always_has_every_role() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    // Admin satisfies every role check without an explicit grant.
+    assert!(client.has_role(&admin, &Role::Provider));
+    assert!(client.has_role(&admin, &Role::PayerReviewer));
+    assert!(client.has_role(&admin, &Role::Auditor));
+    assert!(client.has_role(&admin, &Role::EmergencyResponder));
+}
+
+#[test]
+fn test_grant_role_non_admin_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+
+    let non_admin = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let result = client.try_grant_role(&non_admin, &target, &Role::Provider, &0);
+    assert_eq!(result, Err(Ok(ContractError::InsufficientRole)));
+}
+
+#[test]
+fn test_grant_role_duplicate_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    let provider = Address::generate(&env);
+    client.grant_role(&admin, &provider, &Role::Provider, &0);
+
+    let result = client.try_grant_role(&admin, &provider, &Role::Provider, &0);
+    assert_eq!(result, Err(Ok(ContractError::RoleAlreadyGranted)));
+}
+
+// --- revoke_role -------------------------------------------------------------
+
+#[test]
+fn test_revoke_role() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    let auditor = Address::generate(&env);
+    client.grant_role(&admin, &auditor, &Role::Auditor, &0);
+    assert!(client.has_role(&auditor, &Role::Auditor));
+
+    client.revoke_role(&admin, &auditor, &Role::Auditor);
+    assert!(!client.has_role(&auditor, &Role::Auditor));
+}
+
+#[test]
+fn test_revoke_role_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    let nobody = Address::generate(&env);
+    let result = client.try_revoke_role(&admin, &nobody, &Role::Auditor);
+    assert_eq!(result, Err(Ok(ContractError::RoleNotFound)));
+}
+
+#[test]
+fn test_revoke_role_non_admin_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    let auditor = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    client.grant_role(&admin, &auditor, &Role::Auditor, &0);
+
+    let result = client.try_revoke_role(&non_admin, &auditor, &Role::Auditor);
+    assert_eq!(result, Err(Ok(ContractError::InsufficientRole)));
+}
+
+// --- role expiry -------------------------------------------------------------
+
+#[test]
+fn test_role_expires() {
+    use soroban_sdk::testutils::Ledger;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    let reviewer = Address::generate(&env);
+    // Grant role that expires at timestamp 100.
+    client.grant_role(&admin, &reviewer, &Role::PayerReviewer, &100);
+    assert!(client.has_role(&reviewer, &Role::PayerReviewer));
+
+    // Advance past expiry.
+    env.ledger().set_timestamp(200);
+    assert!(!client.has_role(&reviewer, &Role::PayerReviewer));
+}
+
+#[test]
+fn test_expired_role_can_be_regranted() {
+    use soroban_sdk::testutils::Ledger;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    let reviewer = Address::generate(&env);
+    client.grant_role(&admin, &reviewer, &Role::PayerReviewer, &100);
+
+    env.ledger().set_timestamp(200);
+    // Expired — re-grant should succeed.
+    client.grant_role(&admin, &reviewer, &Role::PayerReviewer, &0);
+    assert!(client.has_role(&reviewer, &Role::PayerReviewer));
+}
+
+// --- get_role_assignment -----------------------------------------------------
+
+#[test]
+fn test_get_role_assignment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    let provider = Address::generate(&env);
+    client.grant_role(&admin, &provider, &Role::Provider, &999);
+
+    let assignment = client.get_role_assignment(&provider, &Role::Provider);
+    assert_eq!(assignment.granted_by, admin);
+    assert_eq!(assignment.expires_at, 999);
+}
+
+#[test]
+fn test_get_role_assignment_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+
+    let nobody = Address::generate(&env);
+    let result = client.try_get_role_assignment(&nobody, &Role::Auditor);
+    assert_eq!(result, Err(Ok(ContractError::RoleNotFound)));
+}
+
+// --- deactivate_entity uses role check ---------------------------------------
+
+#[test]
+fn test_deactivate_entity_by_admin_role() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    let hospital = Address::generate(&env);
+    client.register_entity(
+        &hospital,
+        &EntityType::Hospital,
+        &String::from_str(&env, "City Hospital"),
+        &String::from_str(&env, "metadata"),
+    );
+
+    client.deactivate_entity(&admin, &hospital);
+    assert!(!client.get_entity(&hospital).active);
+}
+
+#[test]
+fn test_deactivate_entity_by_granted_admin_role() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    // Grant Admin role to a second address.
+    let second_admin = Address::generate(&env);
+    client.grant_role(&admin, &second_admin, &Role::Admin, &0);
+
+    let hospital = Address::generate(&env);
+    client.register_entity(
+        &hospital,
+        &EntityType::Hospital,
+        &String::from_str(&env, "City Hospital"),
+        &String::from_str(&env, "metadata"),
+    );
+
+    client.deactivate_entity(&second_admin, &hospital);
+    assert!(!client.get_entity(&hospital).active);
+}
+
+#[test]
+fn test_deactivate_entity_non_admin_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+
+    let hospital = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    client.register_entity(
+        &hospital,
+        &EntityType::Hospital,
+        &String::from_str(&env, "City Hospital"),
+        &String::from_str(&env, "metadata"),
+    );
+
+    let result = client.try_deactivate_entity(&non_admin, &hospital);
+    assert_eq!(result, Err(Ok(ContractError::OnlyAdminCanDeactivate)));
+}
+
+// --- revoke_access uses role check -------------------------------------------
+
+#[test]
+fn test_revoke_access_by_payer_reviewer_role() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    let hospital = Address::generate(&env);
+    let doctor = Address::generate(&env);
+    let payer = Address::generate(&env);
+
+    client.register_entity(
+        &hospital,
+        &EntityType::Hospital,
+        &String::from_str(&env, "City Hospital"),
+        &String::from_str(&env, "metadata"),
+    );
+    client.register_entity(
+        &doctor,
+        &EntityType::Doctor,
+        &String::from_str(&env, "Dr. Smith"),
+        &String::from_str(&env, "metadata"),
+    );
+
+    let resource = String::from_str(&env, "patient-records");
+    client.grant_access(&hospital, &doctor, &resource, &0);
+
+    // Grant PayerReviewer role to payer.
+    client.grant_role(&admin, &payer, &Role::PayerReviewer, &0);
+
+    // Payer (not the original grantor) can revoke.
+    client.revoke_access(&payer, &doctor, &resource);
+    assert!(!client.check_access(&doctor, &resource));
+}
+
+#[test]
+fn test_revoke_access_by_unprivileged_non_grantor_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    let hospital = Address::generate(&env);
+    let doctor = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    client.register_entity(
+        &hospital,
+        &EntityType::Hospital,
+        &String::from_str(&env, "City Hospital"),
+        &String::from_str(&env, "metadata"),
+    );
+    client.register_entity(
+        &doctor,
+        &EntityType::Doctor,
+        &String::from_str(&env, "Dr. Smith"),
+        &String::from_str(&env, "metadata"),
+    );
+    client.register_entity(
+        &other,
+        &EntityType::Doctor,
+        &String::from_str(&env, "Dr. Other"),
+        &String::from_str(&env, "metadata"),
+    );
+
+    let resource = String::from_str(&env, "patient-records");
+    client.grant_access(&hospital, &doctor, &resource, &0);
+
+    // `other` has no role and is not the grantor.
+    let result = client.try_revoke_access(&other, &doctor, &resource);
+    assert_eq!(result, Err(Ok(ContractError::NotAuthorizedToRevoke)));
+
+    // Silence unused-variable warning for admin.
+    let _ = admin;
+}

--- a/contracts/care-plan/Cargo.toml
+++ b/contracts/care-plan/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["lib", "cdylib"]
 doctest = false
 
 [dependencies]
+shared-contracts = { path = "..", package = "Contracts" }
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]

--- a/contracts/care-plan/src/storage.rs
+++ b/contracts/care-plan/src/storage.rs
@@ -1,3 +1,4 @@
+use shared_contracts::safe_increment_persistent;
 use soroban_sdk::{Address, Env, Vec};
 
 use crate::types::{
@@ -9,66 +10,23 @@ use crate::types::{
 // -----------------------------------------------------------------------
 
 pub fn next_care_plan_id(env: &Env) -> u64 {
-    let id: u64 = env
-        .storage()
-        .persistent()
-        .get(&DataKey::CarePlanCounter)
-        .unwrap_or(0);
-    let next = id + 1;
-    env.storage()
-        .persistent()
-        .set(&DataKey::CarePlanCounter, &next);
-    next
+    safe_increment_persistent(env, &DataKey::CarePlanCounter)
 }
 
 pub fn next_goal_id(env: &Env) -> u64 {
-    let id: u64 = env
-        .storage()
-        .persistent()
-        .get(&DataKey::GoalCounter)
-        .unwrap_or(0);
-    let next = id + 1;
-    env.storage().persistent().set(&DataKey::GoalCounter, &next);
-    next
+    safe_increment_persistent(env, &DataKey::GoalCounter)
 }
 
 pub fn next_intervention_id(env: &Env) -> u64 {
-    let id: u64 = env
-        .storage()
-        .persistent()
-        .get(&DataKey::InterventionCounter)
-        .unwrap_or(0);
-    let next = id + 1;
-    env.storage()
-        .persistent()
-        .set(&DataKey::InterventionCounter, &next);
-    next
+    safe_increment_persistent(env, &DataKey::InterventionCounter)
 }
 
 pub fn next_barrier_id(env: &Env) -> u64 {
-    let id: u64 = env
-        .storage()
-        .persistent()
-        .get(&DataKey::BarrierCounter)
-        .unwrap_or(0);
-    let next = id + 1;
-    env.storage()
-        .persistent()
-        .set(&DataKey::BarrierCounter, &next);
-    next
+    safe_increment_persistent(env, &DataKey::BarrierCounter)
 }
 
 pub fn next_review_id(env: &Env) -> u64 {
-    let id: u64 = env
-        .storage()
-        .persistent()
-        .get(&DataKey::ReviewCounter)
-        .unwrap_or(0);
-    let next = id + 1;
-    env.storage()
-        .persistent()
-        .set(&DataKey::ReviewCounter, &next);
-    next
+    safe_increment_persistent(env, &DataKey::ReviewCounter)
 }
 
 // -----------------------------------------------------------------------

--- a/contracts/clinical-trial/Cargo.toml
+++ b/contracts/clinical-trial/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
+shared-contracts = { path = "..", package = "Contracts" }
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]

--- a/contracts/clinical-trial/src/storage.rs
+++ b/contracts/clinical-trial/src/storage.rs
@@ -1,3 +1,4 @@
+use shared_contracts::safe_increment;
 use soroban_sdk::{Address, Env, Vec};
 
 use crate::{
@@ -7,47 +8,17 @@ use crate::{
 
 /// Get the next trial record ID and increment counter
 pub fn get_next_trial_id(env: &Env) -> u64 {
-    let current_id = env
-        .storage()
-        .instance()
-        .get::<DataKey, u64>(&DataKey::TrialCounter)
-        .unwrap_or(0);
-
-    env.storage()
-        .instance()
-        .set(&DataKey::TrialCounter, &(current_id + 1));
-
-    current_id
+    safe_increment(env, &DataKey::TrialCounter)
 }
 
 /// Get the next enrollment ID and increment counter
 pub fn get_next_enrollment_id(env: &Env) -> u64 {
-    let current_id = env
-        .storage()
-        .instance()
-        .get::<DataKey, u64>(&DataKey::EnrollmentCounter)
-        .unwrap_or(0);
-
-    env.storage()
-        .instance()
-        .set(&DataKey::EnrollmentCounter, &(current_id + 1));
-
-    current_id
+    safe_increment(env, &DataKey::EnrollmentCounter)
 }
 
 /// Get the next adverse event ID and increment counter
 pub fn get_next_event_id(env: &Env) -> u64 {
-    let current_id = env
-        .storage()
-        .instance()
-        .get::<DataKey, u64>(&DataKey::EventCounter)
-        .unwrap_or(0);
-
-    env.storage()
-        .instance()
-        .set(&DataKey::EventCounter, &(current_id + 1));
-
-    current_id
+    safe_increment(env, &DataKey::EventCounter)
 }
 
 /// Save a clinical trial record

--- a/contracts/hai-tracking/Cargo.toml
+++ b/contracts/hai-tracking/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["lib", "cdylib"]
 doctest = false
 
 [dependencies]
+shared-contracts = { path = "..", package = "Contracts" }
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]

--- a/contracts/hai-tracking/src/lib.rs
+++ b/contracts/hai-tracking/src/lib.rs
@@ -608,9 +608,7 @@ impl HAITrackingContract {
     }
 
     fn next_id(env: &Env, counter_key: Symbol) -> u64 {
-        let next = env.storage().instance().get(&counter_key).unwrap_or(0u64) + 1;
-        env.storage().instance().set(&counter_key, &next);
-        next
+        shared_contracts::safe_increment(env, &counter_key)
     }
 
     fn push_id(env: &Env, list_key: DataKey, id: u64) {

--- a/contracts/health-records/Cargo.toml
+++ b/contracts/health-records/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["lib", "cdylib"]
 doctest = false
 
 [dependencies]
+shared-contracts = { path = "..", package = "Contracts" }
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]

--- a/contracts/health-records/src/lib.rs
+++ b/contracts/health-records/src/lib.rs
@@ -100,12 +100,7 @@ impl HealthRecords {
         }
 
         let counter_key = DataKey::RecordCounter;
-        let record_id: u64 = env
-            .storage()
-            .persistent()
-            .get(&counter_key)
-            .unwrap_or(0u64)
-            + 1;
+        let record_id: u64 = shared_contracts::safe_increment_persistent(&env, &counter_key);
 
         let timestamp = env.ledger().timestamp();
 
@@ -132,7 +127,6 @@ impl HealthRecords {
         env.storage()
             .persistent()
             .set(&DataKey::Record(record_id), &record);
-        env.storage().persistent().set(&counter_key, &record_id);
 
         Ok(record_id)
     }

--- a/contracts/hospital-discharge-management/Cargo.toml
+++ b/contracts/hospital-discharge-management/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
+shared-contracts = { path = "..", package = "Contracts" }
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]

--- a/contracts/hospital-discharge-management/src/storage.rs
+++ b/contracts/hospital-discharge-management/src/storage.rs
@@ -1,3 +1,4 @@
+use shared_contracts::safe_increment;
 use soroban_sdk::{Env, Symbol};
 
 use crate::types::*;
@@ -18,15 +19,11 @@ const RISK: Symbol = Symbol::short("RISK");
 
 // Counter management
 pub fn get_and_increment_counter(env: &Env) -> u64 {
-    let counter: u64 = env.storage().instance().get(&COUNTER).unwrap_or(0);
-    env.storage().instance().set(&COUNTER, &(counter + 1));
-    counter
+    safe_increment(env, &COUNTER)
 }
 
 pub fn get_and_increment_appointment_counter(env: &Env) -> u64 {
-    let counter: u64 = env.storage().instance().get(&APPT_CTR).unwrap_or(0);
-    env.storage().instance().set(&APPT_CTR, &(counter + 1));
-    counter
+    safe_increment(env, &APPT_CTR)
 }
 
 // Discharge Plan storage

--- a/contracts/hospital-discharge-management/src/test.rs
+++ b/contracts/hospital-discharge-management/src/test.rs
@@ -32,7 +32,7 @@ fn test_initiate_discharge_planning() {
         &expected_discharge_date,
     );
 
-    assert_eq!(plan_id, 0);
+    assert_eq!(plan_id, 1);
 
     // Verify plan was stored
     let plan = client.get_discharge_plan(&plan_id);
@@ -354,8 +354,8 @@ fn test_multiple_discharge_plans() {
     let plan_id_2 =
         client.initiate_discharge_planning(&admin, &patient_id_2, &hospital_id, &1500u64, &2500u64);
 
-    assert_eq!(plan_id_1, 0);
-    assert_eq!(plan_id_2, 1);
+    assert_eq!(plan_id_1, 1);
+    assert_eq!(plan_id_2, 2);
 
     // Verify both plans exist independently
     let plan1 = client.get_discharge_plan(&plan_id_1);

--- a/contracts/imaging-radiology/Cargo.toml
+++ b/contracts/imaging-radiology/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["lib", "cdylib"]
 doctest = false
 
 [dependencies]
+shared-contracts = { path = "..", package = "Contracts" }
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]

--- a/contracts/imaging-radiology/src/lib.rs
+++ b/contracts/imaging-radiology/src/lib.rs
@@ -131,8 +131,7 @@ impl ImagingRadiology {
 
         // Get next order ID
         let counter_key = DataKey::OrderCounter;
-        let order_id: u64 = env.storage().persistent().get(&counter_key).unwrap_or(0) + 1;
-        env.storage().persistent().set(&counter_key, &order_id);
+        let order_id: u64 = shared_contracts::safe_increment_persistent(&env, &counter_key);
 
         // Create imaging order
         let order = ImagingOrder {

--- a/contracts/nutrition-care-management/Cargo.toml
+++ b/contracts/nutrition-care-management/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["lib", "cdylib"]
 doctest = false
 
 [dependencies]
+shared-contracts = { path = "..", package = "Contracts" }
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]

--- a/contracts/nutrition-care-management/src/storage.rs
+++ b/contracts/nutrition-care-management/src/storage.rs
@@ -1,3 +1,4 @@
+use shared_contracts::safe_increment_persistent;
 use soroban_sdk::{Address, Env, Vec};
 
 use crate::types::{
@@ -11,42 +12,15 @@ use crate::types::{
 // -----------------------------------------------------------------------
 
 pub fn next_assessment_id(env: &Env) -> u64 {
-    let id: u64 = env
-        .storage()
-        .persistent()
-        .get(&DataKey::AssessmentCounter)
-        .unwrap_or(0);
-    let next = id + 1;
-    env.storage()
-        .persistent()
-        .set(&DataKey::AssessmentCounter, &next);
-    next
+    safe_increment_persistent(env, &DataKey::AssessmentCounter)
 }
 
 pub fn next_care_plan_id(env: &Env) -> u64 {
-    let id: u64 = env
-        .storage()
-        .persistent()
-        .get(&DataKey::CarePlanCounter)
-        .unwrap_or(0);
-    let next = id + 1;
-    env.storage()
-        .persistent()
-        .set(&DataKey::CarePlanCounter, &next);
-    next
+    safe_increment_persistent(env, &DataKey::CarePlanCounter)
 }
 
 pub fn next_diet_order_id(env: &Env) -> u64 {
-    let id: u64 = env
-        .storage()
-        .persistent()
-        .get(&DataKey::DietOrderCounter)
-        .unwrap_or(0);
-    let next = id + 1;
-    env.storage()
-        .persistent()
-        .set(&DataKey::DietOrderCounter, &next);
-    next
+    safe_increment_persistent(env, &DataKey::DietOrderCounter)
 }
 
 // -----------------------------------------------------------------------

--- a/contracts/pacs-integration/Cargo.toml
+++ b/contracts/pacs-integration/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["lib", "cdylib"]
 doctest = false
 
 [dependencies]
+shared-contracts = { path = "..", package = "Contracts" }
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]

--- a/contracts/pacs-integration/src/storage.rs
+++ b/contracts/pacs-integration/src/storage.rs
@@ -1,31 +1,18 @@
 use crate::types::{
     AccessGrant, CdRecord, DataKey, ImagingReport, ImagingStudy, QcReview, SeriesInfo, ViewRecord,
 };
+use shared_contracts::safe_increment;
 use soroban_sdk::{Address, BytesN, Env, String, Vec};
 
 const BUMP_AMOUNT: u32 = 518400; // ~60 days in ledgers (assuming 5s ledger)
 const BUMP_THRESHOLD: u32 = 259200; // ~30 days
 
 pub fn next_study_id(env: &Env) -> u64 {
-    let id: u64 = env
-        .storage()
-        .instance()
-        .get(&DataKey::StudyCounter)
-        .unwrap_or(0_u64)
-        + 1;
-    env.storage().instance().set(&DataKey::StudyCounter, &id);
-    id
+    safe_increment(env, &DataKey::StudyCounter)
 }
 
 pub fn next_cd_id(env: &Env) -> u64 {
-    let id: u64 = env
-        .storage()
-        .instance()
-        .get(&DataKey::CdCounter)
-        .unwrap_or(0_u64)
-        + 1;
-    env.storage().instance().set(&DataKey::CdCounter, &id);
-    id
+    safe_increment(env, &DataKey::CdCounter)
 }
 
 pub fn save_study(env: &Env, study: &ImagingStudy) {

--- a/contracts/prenatal-pediatric/Cargo.toml
+++ b/contracts/prenatal-pediatric/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["lib", "cdylib"]
 doctest = false
 
 [dependencies]
+shared-contracts = { path = "..", package = "Contracts" }
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]

--- a/contracts/prenatal-pediatric/src/lib.rs
+++ b/contracts/prenatal-pediatric/src/lib.rs
@@ -699,9 +699,7 @@ impl MaternalChildHealthContract {
     }
 
     fn next_id(env: &Env, counter_key: Symbol) -> u64 {
-        let next = env.storage().instance().get(&counter_key).unwrap_or(0u64) + 1;
-        env.storage().instance().set(&counter_key, &next);
-        next
+        shared_contracts::safe_increment(env, &counter_key)
     }
 
     fn newborn_address(env: &Env, delivery_id: u64, newborn_seq: u64) -> Address {

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -6,6 +6,81 @@ use soroban_sdk::{
     Symbol, Vec,
 };
 
+// =============================================================================
+// Shared counter utilities
+// =============================================================================
+//
+// Every contract that needs a monotonically-increasing ID should call one of
+// these helpers instead of open-coding `unwrap_or(0) + 1`.  The helpers:
+//
+//   1. Read the current value (defaulting to 0 on first use).
+//   2. Perform a checked add — panicking on overflow so the contract halts
+//      rather than silently wrapping and reusing an old ID.
+//   3. Persist the incremented value back to storage.
+//   4. Return the *new* value (i.e. the ID to use for the record being created).
+//
+// Two storage tiers are provided:
+//   • `safe_increment`            — instance storage  (cheap, contract-lifetime)
+//   • `safe_increment_persistent` — persistent storage (survives ledger archival)
+//
+// A namespaced variant is provided for per-entity counters (e.g. per-patient
+// record sequences) where two entities must never share an ID space:
+//   • `safe_increment_ns`            — instance storage,   key = (namespace, sub_key)
+//   • `safe_increment_persistent_ns` — persistent storage, key = (namespace, sub_key)
+//
+// All four functions are generic over the storage-key type so callers can pass
+// any `contracttype`-derived key without boxing.
+
+/// Increment a `u64` counter stored in **instance** storage and return the new
+/// value.  Panics with `"counter overflow"` if the counter would exceed
+/// `u64::MAX`.
+pub fn safe_increment<K>(env: &Env, key: &K) -> u64
+where
+    K: soroban_sdk::IntoVal<Env, soroban_sdk::Val>,
+{
+    let current: u64 = env.storage().instance().get(key).unwrap_or(0u64);
+    let next = current.checked_add(1).expect("counter overflow");
+    env.storage().instance().set(key, &next);
+    next
+}
+
+/// Increment a `u64` counter stored in **persistent** storage and return the
+/// new value.  Panics with `"counter overflow"` if the counter would exceed
+/// `u64::MAX`.
+pub fn safe_increment_persistent<K>(env: &Env, key: &K) -> u64
+where
+    K: soroban_sdk::IntoVal<Env, soroban_sdk::Val>,
+{
+    let current: u64 = env.storage().persistent().get(key).unwrap_or(0u64);
+    let next = current.checked_add(1).expect("counter overflow");
+    env.storage().persistent().set(key, &next);
+    next
+}
+
+/// Increment a namespaced `u64` counter in **instance** storage.
+///
+/// The storage key is `(namespace, sub_key)`, keeping per-entity counters
+/// isolated from each other and from global counters.
+pub fn safe_increment_ns(env: &Env, namespace: &soroban_sdk::Symbol, sub_key: &soroban_sdk::Symbol) -> u64 {
+    let compound = (namespace, sub_key);
+    let current: u64 = env.storage().instance().get(&compound).unwrap_or(0u64);
+    let next = current.checked_add(1).expect("counter overflow");
+    env.storage().instance().set(&compound, &next);
+    next
+}
+
+/// Increment a namespaced `u64` counter in **persistent** storage.
+///
+/// The storage key is `(namespace, sub_key)`, keeping per-entity counters
+/// isolated from each other and from global counters.
+pub fn safe_increment_persistent_ns(env: &Env, namespace: &soroban_sdk::Symbol, sub_key: &soroban_sdk::Symbol) -> u64 {
+    let compound = (namespace, sub_key);
+    let current: u64 = env.storage().persistent().get(&compound).unwrap_or(0u64);
+    let next = current.checked_add(1).expect("counter overflow");
+    env.storage().persistent().set(&compound, &next);
+    next
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InstitutionData {

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 mod tests {
     use crate::{
-        AppointmentScheduling, AppointmentSchedulingClient, AppointmentStatus, DataKey,
-        HealthcareRegistry, HealthcareRegistryClient,
+        safe_increment, safe_increment_ns, safe_increment_persistent,
+        safe_increment_persistent_ns, AppointmentScheduling, AppointmentSchedulingClient,
+        AppointmentStatus, DataKey, HealthcareRegistry, HealthcareRegistryClient,
     };
 
     use soroban_sdk::{
@@ -417,5 +418,176 @@ mod tests {
         assert_eq!(scheduled_count, 1); // id3
         assert_eq!(canceled_count, 1); // id2
         assert_eq!(completed_count, 1); // id1
+    }
+
+    // =========================================================================
+    // safe_increment / safe_increment_persistent tests
+    // =========================================================================
+
+    #[test]
+    fn test_safe_increment_starts_at_one() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(HealthcareRegistry, ());
+
+        env.as_contract(&contract_id, || {
+            let id = safe_increment(&env, &DataKey::Admin); // reuse any key type
+            assert_eq!(id, 1);
+        });
+    }
+
+    #[test]
+    fn test_safe_increment_is_sequential() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(HealthcareRegistry, ());
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(safe_increment(&env, &DataKey::Admin), 1);
+            assert_eq!(safe_increment(&env, &DataKey::Admin), 2);
+            assert_eq!(safe_increment(&env, &DataKey::Admin), 3);
+        });
+    }
+
+    #[test]
+    fn test_safe_increment_persistent_starts_at_one() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(HealthcareRegistry, ());
+
+        env.as_contract(&contract_id, || {
+            let id = safe_increment_persistent(&env, &DataKey::Admin);
+            assert_eq!(id, 1);
+        });
+    }
+
+    #[test]
+    fn test_safe_increment_persistent_is_sequential() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(HealthcareRegistry, ());
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(safe_increment_persistent(&env, &DataKey::Admin), 1);
+            assert_eq!(safe_increment_persistent(&env, &DataKey::Admin), 2);
+            assert_eq!(safe_increment_persistent(&env, &DataKey::Admin), 3);
+        });
+    }
+
+    #[test]
+    fn test_instance_and_persistent_counters_are_independent() {
+        // The same key in instance vs persistent storage must not share state.
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(HealthcareRegistry, ());
+
+        env.as_contract(&contract_id, || {
+            // Advance instance counter to 3.
+            safe_increment(&env, &DataKey::Admin);
+            safe_increment(&env, &DataKey::Admin);
+            safe_increment(&env, &DataKey::Admin);
+
+            // Persistent counter for the same key must still start at 1.
+            assert_eq!(safe_increment_persistent(&env, &DataKey::Admin), 1);
+        });
+    }
+
+    #[test]
+    fn test_safe_increment_ns_isolates_namespaces() {
+        use soroban_sdk::Symbol;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(HealthcareRegistry, ());
+
+        env.as_contract(&contract_id, || {
+            let ns_a = Symbol::new(&env, "patient_a");
+            let ns_b = Symbol::new(&env, "patient_b");
+            let sub = Symbol::new(&env, "records");
+
+            // Advance patient_a counter to 5.
+            for _ in 0..5 {
+                safe_increment_ns(&env, &ns_a, &sub);
+            }
+
+            // patient_b counter must be independent and start at 1.
+            assert_eq!(safe_increment_ns(&env, &ns_b, &sub), 1);
+
+            // patient_a counter continues from 6.
+            assert_eq!(safe_increment_ns(&env, &ns_a, &sub), 6);
+        });
+    }
+
+    #[test]
+    fn test_safe_increment_persistent_ns_isolates_namespaces() {
+        use soroban_sdk::Symbol;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(HealthcareRegistry, ());
+
+        env.as_contract(&contract_id, || {
+            let ns_a = Symbol::new(&env, "hosp_a");
+            let ns_b = Symbol::new(&env, "hosp_b");
+            let sub = Symbol::new(&env, "claims");
+
+            safe_increment_persistent_ns(&env, &ns_a, &sub);
+            safe_increment_persistent_ns(&env, &ns_a, &sub);
+
+            // hosp_b must start at 1 regardless of hosp_a's counter.
+            assert_eq!(safe_increment_persistent_ns(&env, &ns_b, &sub), 1);
+        });
+    }
+
+    #[test]
+    fn test_different_sub_keys_in_same_namespace_are_independent() {
+        use soroban_sdk::Symbol;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(HealthcareRegistry, ());
+
+        env.as_contract(&contract_id, || {
+            let ns = Symbol::new(&env, "patient_x");
+            let sub_records = Symbol::new(&env, "records");
+            let sub_visits = Symbol::new(&env, "visits");
+
+            safe_increment_ns(&env, &ns, &sub_records);
+            safe_increment_ns(&env, &ns, &sub_records);
+
+            // visits counter for the same patient must start at 1.
+            assert_eq!(safe_increment_ns(&env, &ns, &sub_visits), 1);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "counter overflow")]
+    fn test_safe_increment_panics_on_overflow() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(HealthcareRegistry, ());
+
+        env.as_contract(&contract_id, || {
+            // Seed the counter at u64::MAX so the next increment overflows.
+            env.storage()
+                .instance()
+                .set(&DataKey::Admin, &u64::MAX);
+            safe_increment(&env, &DataKey::Admin);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "counter overflow")]
+    fn test_safe_increment_persistent_panics_on_overflow() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(HealthcareRegistry, ());
+
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .set(&DataKey::Admin, &u64::MAX);
+            safe_increment_persistent(&env, &DataKey::Admin);
+        });
     }
 }


### PR DESCRIPTION
- contracts/src/lib.rs: add safe_increment, safe_increment_persistent, safe_increment_ns, safe_increment_persistent_ns helpers with overflow checks (checked_add panics on u64::MAX)
- contracts/src/test.rs: 9 new tests covering sequential increment, instance/persistent independence, namespace isolation, and overflow guard
- access-control: add Role enum (Admin/Auditor/PayerReviewer/Provider/ EmergencyResponder), RoleAssignment struct with expiry, grant_role, revoke_role, has_role, get_role_assignment entry points; update deactivate_entity and revoke_access to use require_role checks; 18 new tests
- care-plan, nutrition-care-management, pacs-integration, hospital-discharge-management, clinical-trial: add shared-contracts dep, replace open-coded unwrap_or(0)+1 counter bodies with safe_increment calls
- hai-tracking, imaging-radiology, prenatal-pediatric, health-records: same migration for inline counters in lib.rs/contract.rs
- hospital-discharge-management/test.rs: update ID assertions from 0-based to 1-based to match new post-increment semantics
closes #212 
closes #219