### PR TITLE
fix: enforce proposal TTL, record-level access, share link replay pro…

### DIFF
--- a/contracts/financial-records/src/lib.rs
+++ b/contracts/financial-records/src/lib.rs
@@ -135,8 +135,11 @@ impl FinancialRecordContract {
             if let Some(record) = e
                 .storage()
                 .persistent()
-                .get(&DataKey::Record(owner.clone(), i))
+                .get::<DataKey, FinancialRecord>(&DataKey::Record(owner.clone(), i))
             {
+                if record.owner != owner {
+                    return Err(ContractError::AccessDenied);
+                }
                 records.push_back(record);
             }
         }
@@ -181,6 +184,9 @@ impl FinancialRecordContract {
                 Some(r) => r,
                 None => continue,
             };
+            if record.owner != owner {
+                return Err(ContractError::AccessDenied);
+            }
             if record.timestamp >= start && record.timestamp <= end {
                 if skipped < offset {
                     skipped += 1;
@@ -229,8 +235,11 @@ impl FinancialRecordContract {
             if let Some(record) = e
                 .storage()
                 .persistent()
-                .get(&DataKey::Record(owner.clone(), record_idx))
+                .get::<DataKey, FinancialRecord>(&DataKey::Record(owner.clone(), record_idx))
             {
+                if record.owner != owner {
+                    return Err(ContractError::AccessDenied);
+                }
                 records.push_back(record);
             }
         }

--- a/contracts/lab-management/src/lib.rs
+++ b/contracts/lab-management/src/lib.rs
@@ -59,11 +59,13 @@ impl LabManagementContract {
         req: OrderRequest,
     ) -> u64 {
         provider_id.require_auth();
-        let id = env
+        let counter_key = Symbol::new(&env, "LAB_ID");
+        let id: u64 = env
             .storage()
             .instance()
-            .get::<_, u64>(&Symbol::new(&env, "LAB_ID"))
+            .get::<_, u64>(&counter_key)
             .unwrap_or(0);
+        env.storage().instance().set(&counter_key, &(id + 1));
 
         let order = LabOrder {
             provider_id,
@@ -76,9 +78,6 @@ impl LabManagementContract {
         };
 
         env.storage().persistent().set(&id, &order);
-        env.storage()
-            .instance()
-            .set(&Symbol::new(&env, "LAB_ID"), &(id + 1));
         id
     }
 

--- a/contracts/patient-registry/src/lib.rs
+++ b/contracts/patient-registry/src/lib.rs
@@ -1750,6 +1750,16 @@ impl MedicalRegistry {
 
         let token: BytesN<32> = env.crypto().sha256(&preimage).into();
 
+        // Reject duplicate tokens — prevents a nonce collision from silently
+        // overwriting an active link and granting unintended access.
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::ShareLink(token.clone()))
+        {
+            return Err(ContractError::AlreadyExists);
+        }
+
         let link = ShareLinkData {
             patient: patient.clone(),
             record_id,

--- a/contracts/upgrade-governance/src/lib.rs
+++ b/contracts/upgrade-governance/src/lib.rs
@@ -576,6 +576,9 @@ impl UpgradeGovernance {
             _ => {}
         }
         if env.ledger().timestamp() > proposal.proposed_at + VOTING_WINDOW {
+            env.storage()
+                .persistent()
+                .remove(&DataKey::Proposal(proposal_id));
             return Err(Error::Expired);
         }
         Ok(proposal)


### PR DESCRIPTION
…tection, and lab counter atomicity

TTL expiration not enforced in upgrade-governance proposal loading Fixes #303

Overly broad record access in financial-records check_access Fixes #309

Missing replay protection for share link tokens in patient-registry Fixes #310

Double counter increment in lab-management order_lab_test skips every other ID Fixes #313