### PR TITLE
fix(medical-claims): validate submitted claim line amounts

### DIFF
--- a/contracts/medical-claims/src/lib.rs
+++ b/contracts/medical-claims/src/lib.rs
@@ -40,11 +40,7 @@ impl MedicalClaimsSystem {
     /// `access_control_id` must be the address of the deployed access-control
     /// contract.  Every `submit_claim` call will cross-contract-call its
     /// `check_consent` function before creating a claim record (#300).
-    pub fn initialize(
-        env: Env,
-        admin: Address,
-        access_control_id: Address,
-    ) -> Result<(), Error> {
+    pub fn initialize(env: Env, admin: Address, access_control_id: Address) -> Result<(), Error> {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(Error::AlreadyInitialized);
         }
@@ -102,6 +98,7 @@ impl MedicalClaimsSystem {
         provider_id.require_auth();
         Self::require_insurer(&env, &insurer_id)?;
         validate_policy_metadata(&policy).map_err(|_| Error::InvalidPolicyMetadata)?;
+        Self::validate_claim_amounts(&service_codes, total_amount)?;
 
         // #300: Verify that the patient has granted consent to this provider
         // before creating a claim record (HIPAA compliance).
@@ -425,7 +422,7 @@ impl MedicalClaimsSystem {
 
         let mut computed_total = 0_i128;
         for line in service_codes.iter() {
-            if line.quantity == 0 || line.charge_amount < 0 {
+            if line.quantity == 0 || line.charge_amount <= 0 {
                 return Err(Error::InvalidAmount);
             }
             computed_total = Self::checked_add(computed_total, line.charge_amount)?;

--- a/contracts/medical-claims/src/test.rs
+++ b/contracts/medical-claims/src/test.rs
@@ -3,7 +3,9 @@
 
 use super::*;
 use shared::privacy::PolicyMetadata;
-use soroban_sdk::{contract, contractimpl, testutils::Address as _, BytesN, Env, String, Symbol, Vec};
+use soroban_sdk::{
+    contract, contractimpl, testutils::Address as _, BytesN, Env, String, Symbol, Vec,
+};
 
 // ── Mock access-control contract for tests (#300) ────────────────────────────
 //
@@ -151,7 +153,7 @@ fn test_unregistered_insurer_cannot_adjudicate() {
         &Vec::new(&env),
         &BytesN::from_array(&env, &[0; 32]),
         &policy(&env),
-        &5000,
+        &15000,
     );
 
     let result =
@@ -177,7 +179,7 @@ fn test_wrong_insurer_cannot_adjudicate() {
         &Vec::new(&env),
         &BytesN::from_array(&env, &[0; 32]),
         &policy(&env),
-        &5000,
+        &15000,
     );
 
     let result = client.try_adjudicate_claim(
@@ -208,7 +210,7 @@ fn test_unregistered_insurer_cannot_process_payment() {
         &Vec::new(&env),
         &BytesN::from_array(&env, &[0; 32]),
         &policy(&env),
-        &5000,
+        &15000,
     );
 
     client.adjudicate_claim(
@@ -242,9 +244,55 @@ fn test_submit_claim_with_unregistered_insurer_fails() {
         &Vec::new(&env),
         &BytesN::from_array(&env, &[0; 32]),
         &policy(&env),
-        &5000,
+        &15000,
     );
     assert_eq!(result, Err(Ok(Error::InsurerNotRegistered)));
+}
+
+#[test]
+fn test_submit_claim_rejects_negative_charge_service_line() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, provider, patient, insurer) = setup(&env);
+
+    let services = build_services(&env, -100);
+    let result = client.try_submit_claim(
+        &provider,
+        &patient,
+        &insurer,
+        &1,
+        &100,
+        &services,
+        &Vec::new(&env),
+        &BytesN::from_array(&env, &[0; 32]),
+        &policy(&env),
+        &-100,
+    );
+
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}
+
+#[test]
+fn test_submit_claim_rejects_zero_charge_service_line() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, provider, patient, insurer) = setup(&env);
+
+    let services = build_services(&env, 0);
+    let result = client.try_submit_claim(
+        &provider,
+        &patient,
+        &insurer,
+        &1,
+        &100,
+        &services,
+        &Vec::new(&env),
+        &BytesN::from_array(&env, &[0; 32]),
+        &policy(&env),
+        &0,
+    );
+
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
 }
 
 #[test]
@@ -263,7 +311,7 @@ fn test_appeal_workflow() {
         &Vec::new(&env),
         &BytesN::from_array(&env, &[1; 32]),
         &policy(&env),
-        &25000,
+        &15000,
     );
 
     let mut denials = Vec::new(&env);


### PR DESCRIPTION
## Summary
- run claim amount validation during `submit_claim` before persisting a claim
- reject zero and negative service-line charges by requiring each `charge_amount` to be strictly positive
- align existing medical-claims tests with service-line totals and add non-positive charge regression tests

Closes #315

## Verification
- `cargo fmt -p medical-claims -- --check`
- `cargo test -p medical-claims`
- `git diff --check`

## Stellar Wave
This PR addresses Stellar Wave issue #315. Please assign/credit @JacKane21 for the issue if this fix is accepted.
