### PR TITLE
Fix: storage bloat, access control, timestamp edge cases, and concurrent redemption 

### DIFF
--- a/contracts/doctor-registry/src/lib.rs
+++ b/contracts/doctor-registry/src/lib.rs
@@ -10,6 +10,8 @@ use soroban_sdk::{contract, contractimpl, contracterror, contracttype, symbol_sh
 pub enum Error {
     DuplicateProfile = 1,
     ProfileNotFound = 2,
+    Unauthorized = 3,
+    AlreadyInitialized = 4,
 }
 
 /// --------------------
@@ -29,6 +31,7 @@ pub struct DoctorProfileData {
 /// --------------------
 #[contracttype]
 pub enum DataKey {
+    Admin,
     Doctor(Address),
 }
 
@@ -37,21 +40,35 @@ pub struct DoctorRegistry;
 
 #[contractimpl]
 impl DoctorRegistry {
-    /// Create a new doctor profile with basic information and institution association
+    /// Set the contract admin. Must be called once before any profile operations.
+    /// Only the admin (or an authorized registrar) may create or modify doctor profiles.
+    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+        admin.require_auth();
+        if env.storage().persistent().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized);
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    /// Create a new doctor profile with basic information and institution association.
+    /// Requires the admin (registrar) to authorize, preventing arbitrary self-registration.
     ///
     /// # Arguments
-    /// * `wallet` - The wallet address of the doctor
+    /// * `registrar` - The admin address that authorizes this profile creation
+    /// * `wallet` - The wallet address of the doctor being registered
     /// * `name` - The name of the doctor
     /// * `specialization` - The area of specialization
     /// * `institution_wallet` - The wallet address of the associated hospital/clinic
     pub fn create_doctor_profile(
         env: Env,
+        registrar: Address,
         wallet: Address,
         name: String,
         specialization: String,
         institution_wallet: Address,
     ) -> Result<(), Error> {
-        wallet.require_auth();
+        require_admin(&env, &registrar)?;
 
         let key = DataKey::Doctor(wallet.clone());
         if env.storage().persistent().has(&key) {
@@ -73,19 +90,22 @@ impl DoctorRegistry {
         Ok(())
     }
 
-    /// Update doctor profile specialization and metadata
+    /// Update doctor profile specialization and metadata.
+    /// Requires the admin (registrar) to authorize, consistent with creation policy.
     ///
     /// # Arguments
-    /// * `wallet` - The wallet address of the doctor
+    /// * `registrar` - The admin address that authorizes this profile update
+    /// * `wallet` - The wallet address of the doctor whose profile is being updated
     /// * `specialization` - Updated area of specialization
     /// * `metadata` - Additional information (credentials, certifications, etc.)
     pub fn update_doctor_profile(
         env: Env,
+        registrar: Address,
         wallet: Address,
         specialization: String,
         metadata: String,
     ) -> Result<(), Error> {
-        wallet.require_auth();
+        require_admin(&env, &registrar)?;
 
         let key = DataKey::Doctor(wallet.clone());
         let mut doctor_profile: DoctorProfileData = env
@@ -111,6 +131,19 @@ impl DoctorRegistry {
             .get(&key)
             .ok_or(Error::ProfileNotFound)
     }
+}
+
+fn require_admin(env: &Env, admin: &Address) -> Result<(), Error> {
+    admin.require_auth();
+    let configured: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Admin)
+        .ok_or(Error::Unauthorized)?;
+    if configured != *admin {
+        return Err(Error::Unauthorized);
+    }
+    Ok(())
 }
 
 mod test;

--- a/contracts/doctor-registry/src/test.rs
+++ b/contracts/doctor-registry/src/test.rs
@@ -8,12 +8,16 @@ fn test_create_doctor_profile() {
     let contract_id = env.register_contract(None, DoctorRegistry);
     let client = DoctorRegistryClient::new(&env, &contract_id);
 
+    let admin = Address::generate(&env);
     let doctor_wallet = Address::generate(&env);
     let institution_wallet = Address::generate(&env);
 
     env.mock_all_auths();
 
+    client.initialize(&admin);
+
     client.create_doctor_profile(
+        &admin,
         &doctor_wallet,
         &String::from_str(&env, "Dr. John Smith"),
         &String::from_str(&env, "Cardiology"),
@@ -34,12 +38,16 @@ fn test_update_doctor_profile() {
     let contract_id = env.register_contract(None, DoctorRegistry);
     let client = DoctorRegistryClient::new(&env, &contract_id);
 
+    let admin = Address::generate(&env);
     let doctor_wallet = Address::generate(&env);
     let institution_wallet = Address::generate(&env);
 
     env.mock_all_auths();
 
+    client.initialize(&admin);
+
     client.create_doctor_profile(
+        &admin,
         &doctor_wallet,
         &String::from_str(&env, "Dr. Jane Doe"),
         &String::from_str(&env, "Neurology"),
@@ -47,6 +55,7 @@ fn test_update_doctor_profile() {
     );
 
     client.update_doctor_profile(
+        &admin,
         &doctor_wallet,
         &String::from_str(&env, "Pediatric Neurology"),
         &String::from_str(&env, "Board Certified, 15 years experience"),
@@ -71,12 +80,16 @@ fn test_duplicate_profile_creation() {
     let contract_id = env.register_contract(None, DoctorRegistry);
     let client = DoctorRegistryClient::new(&env, &contract_id);
 
+    let admin = Address::generate(&env);
     let doctor_wallet = Address::generate(&env);
     let institution_wallet = Address::generate(&env);
 
     env.mock_all_auths();
 
+    client.initialize(&admin);
+
     client.create_doctor_profile(
+        &admin,
         &doctor_wallet,
         &String::from_str(&env, "Dr. Test"),
         &String::from_str(&env, "General Medicine"),
@@ -85,6 +98,7 @@ fn test_duplicate_profile_creation() {
 
     // Attempt to create again — must return DuplicateProfile typed error
     let result = client.try_create_doctor_profile(
+        &admin,
         &doctor_wallet,
         &String::from_str(&env, "Dr. Test"),
         &String::from_str(&env, "General Medicine"),
@@ -112,11 +126,15 @@ fn test_update_nonexistent_profile() {
     let contract_id = env.register_contract(None, DoctorRegistry);
     let client = DoctorRegistryClient::new(&env, &contract_id);
 
+    let admin = Address::generate(&env);
     let doctor_wallet = Address::generate(&env);
 
     env.mock_all_auths();
 
+    client.initialize(&admin);
+
     let result = client.try_update_doctor_profile(
+        &admin,
         &doctor_wallet,
         &String::from_str(&env, "Cardiology"),
         &String::from_str(&env, "Updated info"),
@@ -131,13 +149,17 @@ fn test_multiple_doctors() {
     let contract_id = env.register_contract(None, DoctorRegistry);
     let client = DoctorRegistryClient::new(&env, &contract_id);
 
+    let admin = Address::generate(&env);
     let doctor1_wallet = Address::generate(&env);
     let doctor2_wallet = Address::generate(&env);
     let institution_wallet = Address::generate(&env);
 
     env.mock_all_auths();
 
+    client.initialize(&admin);
+
     client.create_doctor_profile(
+        &admin,
         &doctor1_wallet,
         &String::from_str(&env, "Dr. Alice"),
         &String::from_str(&env, "Oncology"),
@@ -145,6 +167,7 @@ fn test_multiple_doctors() {
     );
 
     client.create_doctor_profile(
+        &admin,
         &doctor2_wallet,
         &String::from_str(&env, "Dr. Bob"),
         &String::from_str(&env, "Orthopedics"),
@@ -162,4 +185,71 @@ fn test_multiple_doctors() {
         profile2.specialization,
         String::from_str(&env, "Orthopedics")
     );
+}
+
+#[test]
+fn test_double_initialize_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, DoctorRegistry);
+    let client = DoctorRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    let result = client.try_initialize(&admin);
+    assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
+}
+
+#[test]
+fn test_create_without_initialize_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, DoctorRegistry);
+    let client = DoctorRegistryClient::new(&env, &contract_id);
+
+    let non_admin = Address::generate(&env);
+    let doctor_wallet = Address::generate(&env);
+    let institution_wallet = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    // Contract not initialized — no admin stored, so require_admin returns Unauthorized
+    let result = client.try_create_doctor_profile(
+        &non_admin,
+        &doctor_wallet,
+        &String::from_str(&env, "Dr. Impostor"),
+        &String::from_str(&env, "Fake Specialty"),
+        &institution_wallet,
+    );
+
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_non_admin_cannot_create_profile() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, DoctorRegistry);
+    let client = DoctorRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let doctor_wallet = Address::generate(&env);
+    let institution_wallet = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    // Attacker passes their own address as registrar — stored admin is different
+    let result = client.try_create_doctor_profile(
+        &attacker,
+        &doctor_wallet,
+        &String::from_str(&env, "Dr. Impostor"),
+        &String::from_str(&env, "Fake Specialty"),
+        &institution_wallet,
+    );
+
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
 }

--- a/contracts/doctor-registry/test_snapshots/test/test_create_doctor_profile.1.json
+++ b/contracts/doctor-registry/test_snapshots/test/test_create_doctor_profile.1.json
@@ -1,11 +1,30 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0,
     "mux_id": 0
   },
   "auth": [
     [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
@@ -19,13 +38,16 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
                   "string": "Dr. John Smith"
                 },
                 {
                   "string": "Cardiology"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -53,10 +75,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "Admin"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Admin"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "Doctor"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -76,7 +137,7 @@
                       "symbol": "Doctor"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -88,7 +149,7 @@
                         "symbol": "institution_wallet"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
                     },
                     {
@@ -178,6 +239,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
                   }
                 },
                 "durability": "temporary",

--- a/contracts/doctor-registry/test_snapshots/test/test_duplicate_profile_creation.1.json
+++ b/contracts/doctor-registry/test_snapshots/test/test_duplicate_profile_creation.1.json
@@ -1,11 +1,30 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0,
     "mux_id": 0
   },
   "auth": [
     [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
@@ -19,13 +38,16 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
                   "string": "Dr. Test"
                 },
                 {
                   "string": "General Medicine"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -53,10 +75,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "Admin"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Admin"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "Doctor"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -76,7 +137,7 @@
                       "symbol": "Doctor"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -88,7 +149,7 @@
                         "symbol": "institution_wallet"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
                     },
                     {
@@ -178,6 +239,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
                   }
                 },
                 "durability": "temporary",

--- a/contracts/doctor-registry/test_snapshots/test/test_multiple_doctors.1.json
+++ b/contracts/doctor-registry/test_snapshots/test/test_multiple_doctors.1.json
@@ -1,11 +1,30 @@
 {
   "generators": {
-    "address": 4,
+    "address": 5,
     "nonce": 0,
     "mux_id": 0
   },
   "auth": [
     [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
@@ -19,13 +38,16 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
                   "string": "Dr. Alice"
                 },
                 {
                   "string": "Oncology"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 }
               ]
             }
@@ -36,7 +58,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -44,7 +66,10 @@
               "function_name": "create_doctor_profile",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
                   "string": "Dr. Bob"
@@ -53,7 +78,7 @@
                   "string": "Orthopedics"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                 }
               ]
             }
@@ -82,10 +107,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "Doctor"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "symbol": "Admin"
                 }
               ]
             },
@@ -102,49 +124,13 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "Doctor"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "symbol": "Admin"
                     }
                   ]
                 },
                 "durability": "persistent",
                 "val": {
-                  "map": [
-                    {
-                      "key": {
-                        "symbol": "institution_wallet"
-                      },
-                      "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "metadata"
-                      },
-                      "val": {
-                        "string": ""
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "name"
-                      },
-                      "val": {
-                        "string": "Dr. Alice"
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "specialization"
-                      },
-                      "val": {
-                        "string": "Oncology"
-                      }
-                    }
-                  ]
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               }
             },
@@ -195,7 +181,85 @@
                         "symbol": "institution_wallet"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "metadata"
+                      },
+                      "val": {
+                        "string": ""
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "name"
+                      },
+                      "val": {
+                        "string": "Dr. Alice"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "specialization"
+                      },
+                      "val": {
+                        "string": "Oncology"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Doctor"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Doctor"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "institution_wallet"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                       }
                     },
                     {
@@ -299,7 +363,40 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "1033654523790656264"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
                 "nonce": "5541220902715666415"
@@ -314,7 +411,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "5541220902715666415"

--- a/contracts/doctor-registry/test_snapshots/test/test_update_doctor_profile.1.json
+++ b/contracts/doctor-registry/test_snapshots/test/test_update_doctor_profile.1.json
@@ -1,11 +1,30 @@
 {
   "generators": {
-    "address": 3,
+    "address": 4,
     "nonce": 0,
     "mux_id": 0
   },
   "auth": [
     [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
@@ -19,13 +38,16 @@
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 },
                 {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
                   "string": "Dr. Jane Doe"
                 },
                 {
                   "string": "Neurology"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -45,6 +67,9 @@
               "args": [
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 },
                 {
                   "string": "Pediatric Neurology"
@@ -78,10 +103,49 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "Admin"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Admin"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
                   "symbol": "Doctor"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                 }
               ]
             },
@@ -101,7 +165,7 @@
                       "symbol": "Doctor"
                     },
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   ]
                 },
@@ -113,7 +177,7 @@
                         "symbol": "institution_wallet"
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                       }
                     },
                     {
@@ -203,6 +267,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "1033654523790656264"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
                   }
                 },
                 "durability": "temporary",

--- a/contracts/doctor-registry/test_snapshots/test/test_update_nonexistent_profile.1.json
+++ b/contracts/doctor-registry/test_snapshots/test/test_update_nonexistent_profile.1.json
@@ -1,11 +1,30 @@
 {
   "generators": {
-    "address": 2,
+    "address": 3,
     "nonce": 0,
     "mux_id": 0
   },
   "auth": [
     [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     []
   ],
   "ledger": {
@@ -18,6 +37,45 @@
     "min_temp_entry_ttl": 16,
     "max_entry_ttl": 6312000,
     "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Admin"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Admin"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
       [
         {
           "contract_data": {
@@ -48,6 +106,39 @@
             "ext": "v0"
           },
           4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
         ]
       ],
       [

--- a/contracts/patient-registry/src/test.rs
+++ b/contracts/patient-registry/src/test.rs
@@ -1969,6 +1969,10 @@ fn test_get_records_by_type_missing_doctor_history_returns_not_found() {
     });
 
     let result = client.try_get_records_by_type(&patient, &patient, &Symbol::new(&env, "VISIT"));
+    assert_eq!(result, Err(Ok(ContractError::NotFound)));
+}
+
+#[test]
 fn test_get_record_history_missing_record_returns_not_found() {
     let env = Env::default();
     let (client, patient, _doctor) = setup_for_filter(&env);
@@ -3023,6 +3027,68 @@ fn test_only_patient_can_create_share_link() {
         .try_create_share_link(&patient, &0u64, &1u32, &2000u64);
 
     assert!(result.is_err());
+}
+
+// -----------------------------------------------------------------------
+// #325 – Concurrent share link redemption
+// -----------------------------------------------------------------------
+
+/// Two callers attempt to redeem the same single-use link "simultaneously".
+///
+/// In Soroban, transactions within a ledger round are serialized at the
+/// contract level — only one can execute at a time. The first call succeeds
+/// and atomically removes the token; the second call finds it gone and must
+/// return InvalidToken. This ensures uses_remaining = 1 is honored even under
+/// concurrent submission pressure.
+#[test]
+fn test_concurrent_single_use_link_only_one_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1000);
+
+    let (_admin, patient, _doctor, client) = setup_with_record(&env);
+
+    // Create a single-use link (uses_remaining = 1).
+    let token = client.create_share_link(&patient, &0u64, &1u32, &2000u64);
+
+    // First redemption — represents the winning transaction in the race.
+    let record = client.use_share_link(&token);
+    assert_eq!(record.record_type, Symbol::new(&env, "LAB"));
+
+    // Second redemption — represents the losing transaction; the token was
+    // removed atomically after the first use so this must fail.
+    let result = client.try_use_share_link(&token);
+    assert!(
+        matches!(result, Err(Ok(ContractError::InvalidToken))),
+        "second redemption must fail with InvalidToken after single-use link is exhausted"
+    );
+}
+
+/// Concurrent redemptions against a two-use link: both succeed, the third fails.
+/// Verifies the counter decrements correctly under sequential ordering.
+#[test]
+fn test_concurrent_two_use_link_third_call_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1000);
+
+    let (_admin, patient, _doctor, client) = setup_with_record(&env);
+
+    let token = client.create_share_link(&patient, &0u64, &2u32, &5000u64);
+
+    // First and second callers both succeed.
+    let record1 = client.use_share_link(&token);
+    assert_eq!(record1.record_type, Symbol::new(&env, "LAB"));
+
+    let record2 = client.use_share_link(&token);
+    assert_eq!(record2.record_type, Symbol::new(&env, "LAB"));
+
+    // Third caller loses — link is exhausted.
+    let result = client.try_use_share_link(&token);
+    assert!(
+        matches!(result, Err(Ok(ContractError::InvalidToken))),
+        "third redemption must fail after two-use link is exhausted"
+    );
 }
 
 #[test]

--- a/contracts/prescription-management/src/lib.rs
+++ b/contracts/prescription-management/src/lib.rs
@@ -5,6 +5,10 @@ use soroban_sdk::{
 };
 use shared::temporal;
 
+/// Maximum number of transfer records retained per prescription.
+/// Attempting to exceed this returns `Error::TransferHistoryFull`.
+pub const MAX_TRANSFER_HISTORY: u32 = 100;
+
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -31,6 +35,8 @@ pub enum Error {
     ProposalAlreadyFinalized = 20,
     /// valid_until must be in the future and within MAX_VALIDITY_WINDOW_SECS of issue time
     InvalidValidityWindow = 21,
+    /// transfer_history has reached MAX_TRANSFER_HISTORY entries
+    TransferHistoryFull = 22,
 }
 
 #[contracttype]
@@ -382,6 +388,11 @@ impl PrescriptionContract {
         // Transfer limits for controlled substances
         if p.is_controlled && p.transfer_count >= 1 {
             return Err(Error::ControlledSubstanceViolation);
+        }
+
+        // Enforce the transfer-history storage cap before appending.
+        if p.transfer_history.len() >= MAX_TRANSFER_HISTORY {
+            return Err(Error::TransferHistoryFull);
         }
 
         // Create transfer record
@@ -972,8 +983,13 @@ impl PrescriptionContract {
         p.status = PrescriptionStatus::Active;
         p.last_dispensed = None;
 
-        // Extend validity if needed (30 days from refill)
-        let new_valid_until = env.ledger().timestamp() + (30 * 24 * 60 * 60); // 30 days in seconds
+        // Extend validity if needed (30 days from refill). Use checked_add to
+        // guard against overflow when ledger timestamp is near u64::MAX.
+        let new_valid_until = env
+            .ledger()
+            .timestamp()
+            .checked_add(30u64 * 24 * 60 * 60)
+            .ok_or(Error::InvalidValidityWindow)?;
         if new_valid_until > p.valid_until {
             p.valid_until = new_valid_until;
         }

--- a/contracts/prescription-management/src/test_enhanced.rs
+++ b/contracts/prescription-management/src/test_enhanced.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use soroban_sdk::{Address, BytesN, Env, String, Symbol};
+use soroban_sdk::testutils::Ledger as _;
 
 #[test]
 fn test_prescription_lifecycle_invariants() {
@@ -294,4 +295,182 @@ fn test_prescription_cancellation_safety() {
         env.storage().persistent().get(&prescription_id).unwrap()
     });
     assert!(matches!(prescription.status, PrescriptionStatus::Cancelled));
+}
+
+// -----------------------------------------------------------------------
+// #324 – Edge-case timestamp tests
+// -----------------------------------------------------------------------
+
+/// valid_until = 0 when ledger timestamp = 0 must be rejected immediately.
+/// must_be_future requires valid_until > current_timestamp, so 0 > 0 is false.
+#[test]
+fn test_valid_until_zero_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Default ledger timestamp is 0.
+    let contract_id = env.register_contract(None, PrescriptionContract);
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+
+    let req = IssueRequest {
+        medication_name: String::from_str(&env, "TestMed"),
+        ndc_code: String::from_str(&env, "00000-0001"),
+        dosage: String::from_str(&env, "10mg"),
+        quantity: 10,
+        days_supply: 10,
+        refills_allowed: 0,
+        instructions_hash: BytesN::from_array(&env, &[0; 32]),
+        is_controlled: false,
+        schedule: None,
+        valid_until: 0, // same as ledger timestamp — not in the future
+        substitution_allowed: true,
+        pharmacy_id: None,
+    };
+
+    let result = client.try_issue_prescription(&provider, &patient, &req);
+    assert_eq!(result, Err(Ok(Error::InvalidValidityWindow)));
+}
+
+/// valid_until = u64::MAX is outside the 1-year validity window and must be rejected.
+#[test]
+fn test_valid_until_max_u64_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PrescriptionContract);
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+
+    let req = IssueRequest {
+        medication_name: String::from_str(&env, "TestMed"),
+        ndc_code: String::from_str(&env, "00000-0002"),
+        dosage: String::from_str(&env, "10mg"),
+        quantity: 10,
+        days_supply: 10,
+        refills_allowed: 0,
+        instructions_hash: BytesN::from_array(&env, &[0; 32]),
+        is_controlled: false,
+        schedule: None,
+        valid_until: u64::MAX, // far exceeds MAX_VALIDITY_WINDOW_SECS (1 year)
+        substitution_allowed: true,
+        pharmacy_id: None,
+    };
+
+    let result = client.try_issue_prescription(&provider, &patient, &req);
+    assert_eq!(result, Err(Ok(Error::InvalidValidityWindow)));
+}
+
+/// valid_until exactly at MAX_VALIDITY_WINDOW_SECS (1 year from timestamp = 0) is accepted.
+/// valid_until one second beyond is rejected.
+#[test]
+fn test_valid_until_at_and_beyond_window_limit() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, PrescriptionContract);
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+
+    // Exactly 1 year — within_validity_window checks end - start > max_secs,
+    // so equality is accepted.
+    let at_limit = shared::temporal::MAX_VALIDITY_WINDOW_SECS; // 31_536_000
+    let req_ok = IssueRequest {
+        medication_name: String::from_str(&env, "TestMedA"),
+        ndc_code: String::from_str(&env, "00000-0003"),
+        dosage: String::from_str(&env, "10mg"),
+        quantity: 10,
+        days_supply: 10,
+        refills_allowed: 0,
+        instructions_hash: BytesN::from_array(&env, &[0; 32]),
+        is_controlled: false,
+        schedule: None,
+        valid_until: at_limit,
+        substitution_allowed: true,
+        pharmacy_id: None,
+    };
+    let id = client.issue_prescription(&provider, &patient, &req_ok);
+    // Prescription was created successfully — fetch it and verify
+    let p: Prescription = env.as_contract(&contract_id, || {
+        env.storage().persistent().get(&id).unwrap()
+    });
+    assert_eq!(p.valid_until, at_limit);
+
+    // One second beyond the limit must be rejected.
+    let req_over = IssueRequest {
+        medication_name: String::from_str(&env, "TestMedB"),
+        ndc_code: String::from_str(&env, "00000-0004"),
+        dosage: String::from_str(&env, "10mg"),
+        quantity: 10,
+        days_supply: 10,
+        refills_allowed: 0,
+        instructions_hash: BytesN::from_array(&env, &[0; 32]),
+        is_controlled: false,
+        schedule: None,
+        valid_until: at_limit + 1,
+        substitution_allowed: true,
+        pharmacy_id: None,
+    };
+    let result = client.try_issue_prescription(&provider, &patient, &req_over);
+    assert_eq!(result, Err(Ok(Error::InvalidValidityWindow)));
+}
+
+/// When the ledger timestamp is within 30 days of u64::MAX, the refill
+/// validity extension (timestamp + 30 days) would overflow. The checked_add
+/// guard must return InvalidValidityWindow instead of panicking.
+#[test]
+fn test_refill_timestamp_near_max_u64_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Place the ledger 100 seconds before u64::MAX so that adding 30 days overflows.
+    let near_max: u64 = u64::MAX - 100;
+    env.ledger().set_timestamp(near_max);
+
+    let contract_id = env.register_contract(None, PrescriptionContract);
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+    let pharmacy = Address::generate(&env);
+
+    // valid_until = near_max + 50 (50 s ahead, well within the 1-year window)
+    let valid_until = near_max + 50;
+    let req = IssueRequest {
+        medication_name: String::from_str(&env, "TestMed"),
+        ndc_code: String::from_str(&env, "00000-0005"),
+        dosage: String::from_str(&env, "5mg"),
+        quantity: 30,
+        days_supply: 30,
+        refills_allowed: 3,
+        instructions_hash: BytesN::from_array(&env, &[0; 32]),
+        is_controlled: false,
+        schedule: None,
+        valid_until,
+        substitution_allowed: true,
+        pharmacy_id: Some(pharmacy.clone()),
+    };
+
+    let prescription_id = client.issue_prescription(&provider, &patient, &req);
+
+    // Fully dispense to reach Dispensed state (required for refill).
+    let dispense_req = DispenseRequest {
+        prescription_id,
+        quantity: 30,
+        lot: String::from_str(&env, "LOT001"),
+        expires_at: valid_until,
+        ndc_code: String::from_str(&env, "00000-0005"),
+    };
+    client.dispense_prescription(&dispense_req, &pharmacy);
+
+    // Refill triggers: timestamp + 30_days which overflows u64::MAX.
+    // The checked_add guard must surface InvalidValidityWindow.
+    let result = client.try_refill_prescription(&prescription_id, &pharmacy, &provider);
+    assert_eq!(result, Err(Ok(Error::InvalidValidityWindow)));
 }

--- a/contracts/prescription-management/test_snapshots/test/test_prescription_lifecycle.1.json
+++ b/contracts/prescription-management/test_snapshots/test/test_prescription_lifecycle.1.json
@@ -664,9 +664,6 @@
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "string": "patient_request"
                 }
               ]
             }


### PR DESCRIPTION

closes #322— Enforce MAX_TRANSFER_HISTORY = 100 on prescription transfer records to prevent unbounded Vec storage growth; fix u64 overflow in refill validity extension using checked_add
closes #323 — Add admin role initialization to doctor-registry; only the admin/registrar may now create or modify doctor profiles, blocking arbitrary self-registration and impersonation
closes #324 — Add timestamp edge-case tests to prescription-management covering valid_until = 0, valid_until = u64::MAX, the exact 1-year validity boundary, and refill overflow near u64::MAX
closes #325 — Add concurrent share-link redemption tests to patient-registry verifying that a single-use token is atomically exhausted after the first redemption and a second concurrent call is rejected
Changes
contracts/prescription-management/src/lib.rs
Added MAX_TRANSFER_HISTORY: u32 = 100 constant
Added Error::TransferHistoryFull = 22
transfer_prescription() — returns TransferHistoryFull before appending when the history Vec already holds 100 records
refill_prescription() — replaces timestamp + 30_days with checked_add, returning InvalidValidityWindow on overflow
contracts/doctor-registry/src/lib.rs
Added Error::Unauthorized = 3 and Error::AlreadyInitialized = 4
Added DataKey::Admin storage key
New initialize(admin) function — must be called once to set the contract admin
create_doctor_profile and update_doctor_profile now require a registrar: Address parameter validated against the stored admin, replacing unrestricted self-registration
contracts/doctor-registry/src/test.rs
Updated all existing tests to call initialize and pass the admin as registrar
New tests: test_double_initialize_fails, test_create_without_initialize_fails, test_non_admin_cannot_create_profile
contracts/prescription-management/src/test_enhanced.rs
test_valid_until_zero_is_rejected — valid_until = 0 returns InvalidValidityWindow
test_valid_until_max_u64_is_rejected — valid_until = u64::MAX exceeds the 1-year window
test_valid_until_at_and_beyond_window_limit — exactly 1 year is accepted; 1 second over is rejected
test_refill_timestamp_near_max_u64_returns_error — ledger near u64::MAX, refill overflow returns InvalidValidityWindow
contracts/patient-registry/src/test.rs
test_concurrent_single_use_link_only_one_succeeds — first redemption of a uses_remaining = 1 link succeeds; second fails with InvalidToken
test_concurrent_two_use_link_third_call_fails — counter decrements correctly; third call on a 2-use link fails
Fixed pre-existing unclosed function body in test_get_records_by_type_missing_doctor_history_returns_not_found that blocked compilation
