### PR TITLE
fix: resolve issues #342 #343 #344 #345

### DIFF
--- a/contracts/access-control/src/lib.rs
+++ b/contracts/access-control/src/lib.rs
@@ -36,6 +36,7 @@ pub enum ContractError {
     InsufficientRole = 20,
     RoleAlreadyGranted = 21,
     RoleNotFound = 22,
+    RateLimitExceeded = 23,
 }
 
 /// --------------------
@@ -176,6 +177,8 @@ pub enum DataKey {
     SubjectConsents(Address),
     // RBAC: (address, role) -> RoleAssignment
     RoleAssignment(Address, Role),
+    // Rate limiting: (address, ledger_sequence) -> u32 count
+    RateLimit(Address, u32),
 }
 
 #[contract]
@@ -183,6 +186,28 @@ pub struct AccessControl;
 
 #[contractimpl]
 impl AccessControl {
+    // -------------------------------------------------------------------------
+    // Rate limiting
+    // -------------------------------------------------------------------------
+
+    const MAX_CONSENT_OPS_PER_BLOCK: u32 = 10;
+
+    /// Increment the per-caller per-block consent operation counter and return
+    /// `RateLimitExceeded` if the limit is breached.
+    fn check_rate_limit(env: &Env, caller: &Address) -> Result<(), ContractError> {
+        let seq = env.ledger().sequence();
+        let key = DataKey::RateLimit(caller.clone(), seq);
+        let count: u32 = env.storage().temporary().get(&key).unwrap_or(0);
+        if count >= Self::MAX_CONSENT_OPS_PER_BLOCK {
+            return Err(ContractError::RateLimitExceeded);
+        }
+        // TTL of 1 ledger is enough — the entry is only meaningful for the
+        // current sequence number.
+        env.storage().temporary().set(&key, &(count + 1));
+        env.storage().temporary().extend_ttl(&key, 1, 1);
+        Ok(())
+    }
+
     // -------------------------------------------------------------------------
     // Internal role helpers
     // -------------------------------------------------------------------------
@@ -779,6 +804,8 @@ impl AccessControl {
     ) -> Result<u64, ContractError> {
         subject.require_auth();
 
+        Self::check_rate_limit(&env, &subject)?;
+
         if scope_mask == 0 {
             return Err(ContractError::InvalidScopeMask);
         }
@@ -847,6 +874,8 @@ impl AccessControl {
         purpose_code: String,
     ) -> Result<u64, ContractError> {
         subject.require_auth();
+
+        Self::check_rate_limit(&env, &subject)?;
 
         let key = DataKey::Consent(subject.clone(), grantee.clone(), purpose_code.clone());
         let mut record: ConsentRecord = env

--- a/contracts/hospital-registry/src/lib.rs
+++ b/contracts/hospital-registry/src/lib.rs
@@ -120,6 +120,17 @@ pub struct HospitalConfig {
     pub emergency_protocols: Vec<EmergencyProtocol>,
 }
 
+/// Audit event payload emitted by every admin mutation.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuditEvent {
+    pub caller: Address,
+    pub timestamp: u64,
+    pub field: String,
+    pub old_value: HospitalConfig,
+    pub new_value: HospitalConfig,
+}
+
 #[contracttype]
 pub enum DataKey {
     Hospital(Address),
@@ -169,6 +180,25 @@ impl HospitalRegistry {
             },
             emergency_protocols: Vec::new(env),
         }
+    }
+
+    /// Emit a before/after audit event for a config mutation.
+    fn emit_audit(
+        env: &Env,
+        caller: &Address,
+        field: &str,
+        old: HospitalConfig,
+        new: HospitalConfig,
+    ) {
+        let event = AuditEvent {
+            caller: caller.clone(),
+            timestamp: env.ledger().timestamp(),
+            field: String::from_str(env, field),
+            old_value: old,
+            new_value: new,
+        };
+        env.events()
+            .publish((symbol_short!("audit"), caller.clone()), event);
     }
 
     pub fn register_hospital(
@@ -253,12 +283,17 @@ impl HospitalRegistry {
         wallet.require_auth();
         Self::assert_active_hospital(&env, &wallet)?;
 
+        let old: HospitalConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::HospitalConfig(wallet.clone()))
+            .unwrap_or_else(|| Self::default_config(&env));
+
         env.storage()
             .persistent()
             .set(&DataKey::HospitalConfig(wallet.clone()), &config);
 
-        env.events()
-            .publish((symbol_short!("cfg_set"), wallet), symbol_short!("success"));
+        Self::emit_audit(&env, &wallet, "config", old, config);
         Ok(())
     }
 
@@ -280,12 +315,12 @@ impl HospitalRegistry {
         if departments.is_empty() && !config.departments.is_empty() {
             return Err(ContractError::EmptyFieldUpdate);
         }
+        let old = config.clone();
         config.departments = departments;
         env.storage()
             .persistent()
             .set(&DataKey::HospitalConfig(wallet.clone()), &config);
-        env.events()
-            .publish((symbol_short!("upd_dept"), wallet), symbol_short!("success"));
+        Self::emit_audit(&env, &wallet, "departments", old, config);
         Ok(())
     }
 
@@ -300,12 +335,12 @@ impl HospitalRegistry {
         if locations.is_empty() && !config.locations.is_empty() {
             return Err(ContractError::EmptyFieldUpdate);
         }
+        let old = config.clone();
         config.locations = locations;
         env.storage()
             .persistent()
             .set(&DataKey::HospitalConfig(wallet.clone()), &config);
-        env.events()
-            .publish((symbol_short!("upd_loc"), wallet), symbol_short!("success"));
+        Self::emit_audit(&env, &wallet, "locations", old, config);
         Ok(())
     }
 
@@ -320,12 +355,12 @@ impl HospitalRegistry {
         if equipment.is_empty() && !config.equipment.is_empty() {
             return Err(ContractError::EmptyFieldUpdate);
         }
+        let old = config.clone();
         config.equipment = equipment;
         env.storage()
             .persistent()
             .set(&DataKey::HospitalConfig(wallet.clone()), &config);
-        env.events()
-            .publish((symbol_short!("upd_eq"), wallet), symbol_short!("success"));
+        Self::emit_audit(&env, &wallet, "equipment", old, config);
         Ok(())
     }
 
@@ -337,12 +372,12 @@ impl HospitalRegistry {
         wallet.require_auth();
         Self::assert_active_hospital(&env, &wallet)?;
         let mut config = Self::get_hospital_config(env.clone(), wallet.clone())?;
+        let old = config.clone();
         config.policies = policies;
         env.storage()
             .persistent()
             .set(&DataKey::HospitalConfig(wallet.clone()), &config);
-        env.events()
-            .publish((symbol_short!("upd_pol"), wallet), symbol_short!("success"));
+        Self::emit_audit(&env, &wallet, "policies", old, config);
         Ok(())
     }
 
@@ -354,12 +389,12 @@ impl HospitalRegistry {
         wallet.require_auth();
         Self::assert_active_hospital(&env, &wallet)?;
         let mut config = Self::get_hospital_config(env.clone(), wallet.clone())?;
+        let old = config.clone();
         config.alerts = alerts;
         env.storage()
             .persistent()
             .set(&DataKey::HospitalConfig(wallet.clone()), &config);
-        env.events()
-            .publish((symbol_short!("upd_alrt"), wallet), symbol_short!("success"));
+        Self::emit_audit(&env, &wallet, "alerts", old, config);
         Ok(())
     }
 
@@ -371,12 +406,12 @@ impl HospitalRegistry {
         wallet.require_auth();
         Self::assert_active_hospital(&env, &wallet)?;
         let mut config = Self::get_hospital_config(env.clone(), wallet.clone())?;
+        let old = config.clone();
         config.insurance_providers = insurance_providers;
         env.storage()
             .persistent()
             .set(&DataKey::HospitalConfig(wallet.clone()), &config);
-        env.events()
-            .publish((symbol_short!("upd_ins"), wallet), symbol_short!("success"));
+        Self::emit_audit(&env, &wallet, "insurance", old, config);
         Ok(())
     }
 
@@ -388,12 +423,12 @@ impl HospitalRegistry {
         wallet.require_auth();
         Self::assert_active_hospital(&env, &wallet)?;
         let mut config = Self::get_hospital_config(env.clone(), wallet.clone())?;
+        let old = config.clone();
         config.billing = billing;
         env.storage()
             .persistent()
             .set(&DataKey::HospitalConfig(wallet.clone()), &config);
-        env.events()
-            .publish((symbol_short!("upd_bill"), wallet), symbol_short!("success"));
+        Self::emit_audit(&env, &wallet, "billing", old, config);
         Ok(())
     }
 
@@ -405,12 +440,12 @@ impl HospitalRegistry {
         wallet.require_auth();
         Self::assert_active_hospital(&env, &wallet)?;
         let mut config = Self::get_hospital_config(env.clone(), wallet.clone())?;
+        let old = config.clone();
         config.emergency_protocols = protocols;
         env.storage()
             .persistent()
             .set(&DataKey::HospitalConfig(wallet.clone()), &config);
-        env.events()
-            .publish((symbol_short!("upd_emg"), wallet), symbol_short!("success"));
+        Self::emit_audit(&env, &wallet, "emergency", old, config);
         Ok(())
     }
 }

--- a/contracts/multisig-governance/src/lib.rs
+++ b/contracts/multisig-governance/src/lib.rs
@@ -45,6 +45,8 @@ pub enum DataKey {
     Proposal(Symbol),
     /// Pending signer-change proposal (only one active at a time).
     SignerProposal,
+    /// Catalog of all proposal IDs for enumeration / cleanup.
+    ProposalIds,
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -164,9 +166,64 @@ impl MultisigGovernance {
         };
 
         env.storage().persistent().set(&key, &proposal);
+
+        // Track proposal ID for cleanup enumeration.
+        let mut ids: Vec<Symbol> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ProposalIds)
+            .unwrap_or(Vec::new(&env));
+        ids.push_back(action_id.clone());
+        env.storage().persistent().set(&DataKey::ProposalIds, &ids);
+
         env.events()
             .publish((symbol_short!("proposed"), action_id), signer);
         Ok(())
+    }
+
+    /// Delete all proposals whose TTL has elapsed. Callable by anyone.
+    pub fn cleanup_expired_proposals(env: Env) -> Result<u32, Error> {
+        let ttl: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Ttl)
+            .ok_or(Error::NotInitialized)?;
+
+        let now = env.ledger().timestamp();
+
+        let ids: Vec<Symbol> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ProposalIds)
+            .unwrap_or(Vec::new(&env));
+
+        let mut remaining: Vec<Symbol> = Vec::new(&env);
+        let mut removed: u32 = 0;
+
+        for id in ids.iter() {
+            let key = DataKey::Proposal(id.clone());
+            if let Some(proposal) = env
+                .storage()
+                .persistent()
+                .get::<_, Proposal>(&key)
+            {
+                if now > proposal.proposed_at + ttl {
+                    env.storage().persistent().remove(&key);
+                    removed += 1;
+                } else {
+                    remaining.push_back(id);
+                }
+            }
+            // If the entry is already gone, drop it from the catalog too.
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::ProposalIds, &remaining);
+
+        env.events()
+            .publish((symbol_short!("cleanup"),), removed);
+        Ok(removed)
     }
 
     /// An admin signer approves an existing proposal. Once the approval count

--- a/contracts/prescription-management/src/lib.rs
+++ b/contracts/prescription-management/src/lib.rs
@@ -1,9 +1,17 @@
 #![no_std]
 
 use soroban_sdk::{
-    Address, BytesN, Env, String, Symbol, Vec, contract, contracterror, contractimpl, contracttype,
+    Address, BytesN, Env, String, Symbol, Vec, contract, contracterror, contractimpl,
+    contracttype, contractclient,
 };
 use shared::temporal;
+
+// ── Provider-registry client ──────────────────────────────────────────────────
+
+#[contractclient(name = "ProviderRegistryClient")]
+pub trait ProviderRegistryInterface {
+    fn is_provider(env: Env, provider: Address) -> bool;
+}
 
 /// Maximum number of transfer records retained per prescription.
 /// Attempting to exceed this returns `Error::TransferHistoryFull`.
@@ -37,6 +45,10 @@ pub enum Error {
     InvalidValidityWindow = 21,
     /// Timestamp arithmetic would overflow u64
     TimestampOverflow = 22,
+    /// Provider is not registered or active in the provider-registry
+    ProviderNotRegistered = 23,
+    /// Transfer history has reached the maximum allowed entries
+    TransferHistoryFull = 24,
 }
 
 #[contracttype]
@@ -129,6 +141,8 @@ pub enum DataKey {
     RegistryProposal(u64),
     SnapshotCounter,
     CatalogSnapshot(u64),
+    /// Address of the provider-registry contract used for cross-contract verification.
+    ProviderRegistry,
 }
 
 #[contracttype]
@@ -216,6 +230,18 @@ pub struct PrescriptionContract;
 
 #[contractimpl]
 impl PrescriptionContract {
+    /// Store the provider-registry contract address for cross-contract verification.
+    /// Must be called once before issue_prescription is used.
+    pub fn initialize(env: Env, provider_registry: Address) -> Result<(), Error> {
+        if env.storage().persistent().has(&DataKey::ProviderRegistry) {
+            return Err(Error::AlreadyExists);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::ProviderRegistry, &provider_registry);
+        Ok(())
+    }
+
     pub fn issue_prescription(
         env: Env,
         provider_id: Address,
@@ -223,6 +249,18 @@ impl PrescriptionContract {
         req: IssueRequest,
     ) -> Result<u64, Error> {
         provider_id.require_auth();
+
+        // #345: verify provider is registered and active in the provider-registry.
+        if let Some(registry_addr) = env
+            .storage()
+            .persistent()
+            .get::<_, Address>(&DataKey::ProviderRegistry)
+        {
+            let client = ProviderRegistryClient::new(&env, &registry_addr);
+            if !client.is_provider(&provider_id) {
+                return Err(Error::ProviderNotRegistered);
+            }
+        }
 
         // #215 – valid_until must be in the future and within a 1-year window
         temporal::must_be_future(&env, req.valid_until)


### PR DESCRIPTION
close #342  
close #343  
close #344 
close #345 
#369

## Summary

This PR fixes four issues across four contracts.

---

### #342 — hospital-registry: before/after audit events on admin functions

**Problem:** Admin mutation functions emitted only a generic success event with no record of what changed.

**Fix:**
- Added `AuditEvent` struct containing `caller`, `timestamp`, `field`, `old_value`, `new_value`.
- Added `emit_audit()` helper that publishes the event under the `audit` topic.
- Wired into all nine admin functions: `set_hospital_config`, `update_departments`, `update_locations`, `update_equipment`, `update_policies`, `update_alerts`, `update_insurance_providers`, `update_billing`, `update_emergency_protocols`.

---

### #343 — multisig-governance: clean up expired proposals from storage

**Problem:** Expired proposals were never deleted, causing unbounded storage growth.

**Fix:**
- Added `ProposalIds` DataKey storing a `Vec<Symbol>` catalog of all proposal IDs.
- `propose_multisig_action` now appends each new ID to the catalog.
- Added `cleanup_expired_proposals(env)` callable by anyone: iterates the catalog, removes proposals past their TTL from persistent storage, prunes the catalog, emits a `cleanup` event, and returns the count of removed entries.

---

### #344 — access-control: rate limiting for consent grant/revoke

**Problem:** A single caller could spam thousands of consent records in one block.

**Fix:**
- Added `RateLimitExceeded` error (code 23).
- Added `RateLimit(Address, u32)` DataKey keyed by `(caller, ledger_sequence)`.
- Added `check_rate_limit()` helper that reads/increments the per-block counter and returns `RateLimitExceeded` once it exceeds 10.
- Wired into `grant_consent` and `revoke_consent` immediately after `require_auth`.

---

### #345 — prescription-management: cross-contract provider verification

**Problem:** `issue_prescription` accepted any `provider_id` without verifying it against the provider-registry.

**Fix:**
- Added `#[contractclient]` trait `ProviderRegistryInterface` exposing `is_provider()`.
- Added `ProviderRegistry` DataKey to store the registry contract address.
- Added `ProviderNotRegistered` error (code 23).
- Added `initialize(env, provider_registry: Address)` to store the registry address once.
- In `issue_prescription`, when the registry address is set, calls `ProviderRegistryClient::is_provider()` and returns `ProviderNotRegistered` if the check fails.

---

## Testing

Cargo is not available in this environment. All changes follow existing patterns in the codebase (e.g., `contractclient` usage mirrors `contracts/medical-claims`). Tests should be run in a Rust-enabled CI environment.
