### PR TITLE
test: add missing tests for issues

### DIFF
--- a/contracts/allergy-management/src/test.rs
+++ b/contracts/allergy-management/src/test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env, String, Symbol, Vec};
+use soroban_sdk::{symbol_short, testutils::{Address as _, Ledger}, Address, Env, String, Symbol, Vec};
 
 use crate::{
     AllergyManagement, AllergyManagementClient, AllergyStatus, Error, RecordAllergyRequest,
@@ -15,6 +15,8 @@ fn create_test_env() -> (
 ) {
     let env = Env::default();
     env.mock_all_auths();
+    // Set a baseline timestamp so onset_date values like 1000 or 500 are in the past.
+    env.ledger().set_timestamp(10_000);
 
     let admin = Address::generate(&env);
     let patient = Address::generate(&env);
@@ -23,7 +25,17 @@ fn create_test_env() -> (
     let contract_id = env.register(AllergyManagement, ());
     let client = AllergyManagementClient::new(&env, &contract_id);
 
-    client.initialize(&admin);
+    let patient_registry = Address::generate(&env);
+    let provider_registry = Address::generate(&env);
+    let hospital_registry = Address::generate(&env);
+    let insurer_registry = Address::generate(&env);
+    client.initialize(
+        &admin,
+        &patient_registry,
+        &provider_registry,
+        &hospital_registry,
+        &insurer_registry,
+    );
 
     (env, admin, patient, provider, client)
 }
@@ -57,10 +69,15 @@ fn test_initialize() {
 
 #[test]
 fn test_double_initialize() {
-    let (_, admin, _, _, client) = create_test_env();
+    let (env, admin, _, _, client) = create_test_env();
+
+    let p_reg = Address::generate(&env);
+    let prov_reg = Address::generate(&env);
+    let hosp_reg = Address::generate(&env);
+    let ins_reg = Address::generate(&env);
 
     // Try to initialize again
-    let result = client.try_initialize(&admin);
+    let result = client.try_initialize(&admin, &p_reg, &prov_reg, &hosp_reg, &ins_reg);
     assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
 }
 
@@ -687,4 +704,110 @@ fn test_food_allergy() {
     assert_eq!(allergy.allergen_type, symbol_short!("food"));
     assert_eq!(allergy.severity, symbol_short!("critical"));
     assert_eq!(allergy.onset_date, Some(500u64));
+}
+
+// ─── Issue #327 ── Guardian authorization scope ───────────────────────────
+
+#[test]
+fn test_guardian_a_cannot_write_allergy_for_patient_b() {
+    let (env, _, patient_a, guardian_a, client) = create_test_env();
+    let patient_b = Address::generate(&env);
+    let guardian_b = Address::generate(&env);
+
+    // Guardian A is authorized only for Patient A.
+    client.grant_access(&patient_a, &guardian_a);
+    // Guardian B is authorized only for Patient B.
+    client.grant_access(&patient_b, &guardian_b);
+
+    let mut reactions = Vec::new(&env);
+    reactions.push_back(String::from_str(&env, "rash"));
+
+    let request = create_allergy_request(
+        &env,
+        "Penicillin",
+        symbol_short!("med"),
+        reactions,
+        symbol_short!("mild"),
+        None,
+        true,
+    );
+
+    // Guardian A must not be able to record an allergy for Patient B.
+    let result = client.try_record_allergy(&patient_b, &guardian_a, &request);
+    assert!(
+        result.is_err(),
+        "Guardian A must not be able to record allergy for Patient B"
+    );
+}
+
+#[test]
+fn test_guardian_a_cannot_update_severity_for_patient_b_allergy() {
+    let (env, _, patient_a, guardian_a, client) = create_test_env();
+    let patient_b = Address::generate(&env);
+    let guardian_b = Address::generate(&env);
+
+    client.grant_access(&patient_a, &guardian_a);
+    client.grant_access(&patient_b, &guardian_b);
+
+    // Guardian B records an allergy for Patient B.
+    let mut reactions = Vec::new(&env);
+    reactions.push_back(String::from_str(&env, "hives"));
+    let request_b = create_allergy_request(
+        &env,
+        "Peanuts",
+        symbol_short!("food"),
+        reactions,
+        symbol_short!("severe"),
+        None,
+        true,
+    );
+    let allergy_id = client.record_allergy(&patient_b, &guardian_b, &request_b);
+
+    // Guardian A must not be able to update the severity of Patient B's allergy.
+    let result = client.try_update_allergy_severity(
+        &allergy_id,
+        &guardian_a,
+        &symbol_short!("mild"),
+        &String::from_str(&env, "unauthorized update attempt"),
+    );
+    assert!(
+        result.is_err(),
+        "Guardian A must not be able to update allergy severity for Patient B"
+    );
+}
+
+#[test]
+fn test_guardian_a_cannot_resolve_patient_b_allergy() {
+    let (env, _, patient_a, guardian_a, client) = create_test_env();
+    let patient_b = Address::generate(&env);
+    let guardian_b = Address::generate(&env);
+
+    client.grant_access(&patient_a, &guardian_a);
+    client.grant_access(&patient_b, &guardian_b);
+
+    // Guardian B records an allergy for Patient B.
+    let mut reactions = Vec::new(&env);
+    reactions.push_back(String::from_str(&env, "swelling"));
+    let request_b = create_allergy_request(
+        &env,
+        "Aspirin",
+        symbol_short!("med"),
+        reactions,
+        symbol_short!("moderate"),
+        None,
+        true,
+    );
+    let allergy_id = client.record_allergy(&patient_b, &guardian_b, &request_b);
+
+    // Guardian A must not be able to resolve Patient B's allergy.
+    let result = client.try_resolve_allergy(
+        &allergy_id,
+        &guardian_a,
+        &env.ledger().timestamp(),
+        &String::from_str(&env, "unauthorized resolution attempt"),
+    );
+    assert!(
+        result.is_err(),
+        "Guardian A must not be able to resolve allergy for Patient B"
+    );
 }

--- a/contracts/medical-claims/src/test.rs
+++ b/contracts/medical-claims/src/test.rs
@@ -329,3 +329,90 @@ fn test_non_admin_cannot_register_insurer() {
     let result = client.try_register_insurer(&fake_admin, &new_insurer);
     assert_eq!(result, Err(Ok(Error::NotAuthorized)));
 }
+
+// ─── Issue #329 ── Appeal level boundary validation ───────────────────────
+
+fn setup_adjudicated_claim(env: &Env) -> (MedicalClaimsSystemClient<'static>, Address, u64) {
+    let (client, _, provider, patient, insurer) = setup(env);
+
+    let claim_id = client.submit_claim(
+        &provider,
+        &patient,
+        &insurer,
+        &1,
+        &1000,
+        &make_services(env),
+        &Vec::new(env),
+        &BytesN::from_array(env, &[0u8; 32]),
+        &policy(env),
+        &15000,
+    );
+
+    // Adjudicate with zero approved/responsibility so amounts validate.
+    client.adjudicate_claim(
+        &claim_id,
+        &insurer,
+        &Vec::new(env),
+        &Vec::new(env),
+        &0,
+        &0,
+    );
+
+    (client, provider, claim_id)
+}
+
+#[test]
+fn test_appeal_level_3_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, provider, claim_id) = setup_adjudicated_claim(&env);
+
+    // appeal_level = 3 is the maximum valid level and must be accepted.
+    let result = client.try_appeal_denial(
+        &claim_id,
+        &provider,
+        &3,
+        &BytesN::from_array(&env, &[1u8; 32]),
+    );
+    assert!(result.is_ok(), "appeal_level = 3 must be accepted");
+}
+
+#[test]
+fn test_appeal_level_4_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, provider, claim_id) = setup_adjudicated_claim(&env);
+
+    // appeal_level = 4 exceeds the maximum of 3 and must be rejected.
+    let result = client.try_appeal_denial(
+        &claim_id,
+        &provider,
+        &4,
+        &BytesN::from_array(&env, &[2u8; 32]),
+    );
+    assert_eq!(
+        result,
+        Err(Ok(Error::InvalidAppealLevel)),
+        "appeal_level = 4 must be rejected with InvalidAppealLevel"
+    );
+}
+
+#[test]
+fn test_appeal_level_0_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, provider, claim_id) = setup_adjudicated_claim(&env);
+
+    // appeal_level = 0 is not above the initial claim.appeal_level (0) and must be rejected.
+    let result = client.try_appeal_denial(
+        &claim_id,
+        &provider,
+        &0,
+        &BytesN::from_array(&env, &[3u8; 32]),
+    );
+    assert_eq!(
+        result,
+        Err(Ok(Error::InvalidAppealLevel)),
+        "appeal_level = 0 must be rejected with InvalidAppealLevel"
+    );
+}

--- a/contracts/patient-registry/src/test.rs
+++ b/contracts/patient-registry/src/test.rs
@@ -3571,3 +3571,158 @@ fn test_verify_membership_patient_with_no_records_returns_false() {
     let proof: Vec<BytesN<32>> = Vec::new(&env);
     assert!(!client.verify_record_membership(&patient, &1, &proof));
 }
+
+// ─── Issue #326 ── Type-index consistency after multiple soft deletes ──────
+
+#[test]
+fn test_type_index_consistency_after_multiple_soft_deletes() {
+    let env = Env::default();
+    let (client, _admin, patient, doctor, _v1) = setup_for_ttl(&env);
+
+    // Create 5 records of the same type.
+    let mut ids: Vec<u64> = Vec::new(&env);
+    for i in 0u8..5 {
+        let id = client.add_medical_record(
+            &patient,
+            &doctor,
+            &encrypted_ref(&env, i + 30),
+            &Symbol::new(&env, "LAB"),
+            &policy(&env),
+        );
+        ids.push_back(id);
+    }
+
+    // Soft-delete the first 3.
+    for i in 0u32..3 {
+        let record_id = ids.get(i).unwrap();
+        client.soft_delete_record(&record_id, &patient);
+    }
+
+    // The type index must contain exactly 2 surviving entries.
+    let entries = client.get_global_records_by_type(&Symbol::new(&env, "LAB"));
+    assert_eq!(entries.len(), 2, "type index should have 2 entries after 3 soft deletes");
+
+    let count = client.get_global_type_count(&Symbol::new(&env, "LAB"));
+    assert_eq!(count, 2, "get_global_type_count should return 2");
+
+    // The three deleted IDs must not appear in the index.
+    let del_id0 = ids.get(0).unwrap();
+    let del_id1 = ids.get(1).unwrap();
+    let del_id2 = ids.get(2).unwrap();
+    for entry in entries.iter() {
+        let rid = entry.record_id;
+        assert_ne!(rid, del_id0, "deleted record 1 must not appear in type index");
+        assert_ne!(rid, del_id1, "deleted record 2 must not appear in type index");
+        assert_ne!(rid, del_id2, "deleted record 3 must not appear in type index");
+    }
+
+    // The two surviving IDs must be present.
+    let keep_id0 = ids.get(3).unwrap();
+    let keep_id1 = ids.get(4).unwrap();
+    let mut found0 = false;
+    let mut found1 = false;
+    for entry in entries.iter() {
+        if entry.record_id == keep_id0 {
+            found0 = true;
+        }
+        if entry.record_id == keep_id1 {
+            found1 = true;
+        }
+    }
+    assert!(found0, "surviving record 4 must be present in type index");
+    assert!(found1, "surviving record 5 must be present in type index");
+}
+
+#[test]
+fn test_deleted_records_not_returned_by_type_query() {
+    let env = Env::default();
+    let (client, _admin, patient, doctor, _v1) = setup_for_ttl(&env);
+
+    // Add 5 records of a distinct type and soft-delete 3.
+    let mut ids: Vec<u64> = Vec::new(&env);
+    for i in 0u8..5 {
+        let id = client.add_medical_record(
+            &patient,
+            &doctor,
+            &encrypted_ref(&env, i + 40),
+            &Symbol::new(&env, "VISIT"),
+            &policy(&env),
+        );
+        ids.push_back(id);
+    }
+
+    let del_id0 = ids.get(0).unwrap();
+    let del_id1 = ids.get(1).unwrap();
+    let del_id2 = ids.get(2).unwrap();
+    client.soft_delete_record(&del_id0, &patient);
+    client.soft_delete_record(&del_id1, &patient);
+    client.soft_delete_record(&del_id2, &patient);
+
+    let entries = client.get_global_records_by_type(&Symbol::new(&env, "VISIT"));
+    for entry in entries.iter() {
+        let rid = entry.record_id;
+        assert_ne!(rid, del_id0, "deleted record 1 must not be in type query results");
+        assert_ne!(rid, del_id1, "deleted record 2 must not be in type query results");
+        assert_ne!(rid, del_id2, "deleted record 3 must not be in type query results");
+    }
+}
+
+// ─── Issue #328 ── Merkle proof edge cases ────────────────────────────────
+
+#[test]
+fn test_merkle_empty_tree_proof_returns_false() {
+    let env = Env::default();
+    let contract_id = env.register(MedicalRegistry, ());
+    let client = MedicalRegistryClient::new(&env, &contract_id);
+    let patient = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    // Empty tree: root is the sha256("") sentinel.
+    // An empty proof for any record_id must return false.
+    let empty_proof: Vec<BytesN<32>> = Vec::new(&env);
+    assert!(
+        !client.verify_record_membership(&patient, &1, &empty_proof),
+        "empty-tree empty-proof must return false"
+    );
+
+    // A non-empty proof against an empty tree must also return false.
+    let mut non_empty_proof: Vec<BytesN<32>> = Vec::new(&env);
+    non_empty_proof.push_back(BytesN::from_array(&env, &[0xabu8; 32]));
+    assert!(
+        !client.verify_record_membership(&patient, &1, &non_empty_proof),
+        "empty-tree non-empty-proof must return false"
+    );
+}
+
+#[test]
+fn test_merkle_single_record_valid_proof_verified() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, patient, ids) = setup_with_records(&env, 1);
+
+    let id = ids.get(0).unwrap();
+    // Single-leaf tree: root = hash_leaf(id). The correct proof is empty.
+    let proof: Vec<BytesN<32>> = Vec::new(&env);
+    assert!(
+        client.verify_record_membership(&patient, &id, &proof),
+        "single-record valid proof must be accepted"
+    );
+}
+
+#[test]
+fn test_merkle_wrong_depth_proof_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, patient, ids) = setup_with_records(&env, 1);
+
+    let id = ids.get(0).unwrap();
+    // Correct proof for a single-leaf tree is empty (depth 0).
+    // Supplying an extra sibling (depth 1) computes a different root → rejected.
+    let mut wrong_depth_proof: Vec<BytesN<32>> = Vec::new(&env);
+    wrong_depth_proof.push_back(BytesN::from_array(&env, &[0xffu8; 32]));
+    assert!(
+        !client.verify_record_membership(&patient, &id, &wrong_depth_proof),
+        "proof with wrong depth must be rejected"
+    );
+}


### PR DESCRIPTION
No test for type index consistency after multiple soft deletes in patient-registry Fixes #326

Missing test for guardian authorization scope in allergy-management Fixes #327

Missing Merkle proof edge-case tests in patient-registry Fixes #328

No boundary test for claim appeal level validation in medical-claims Fixes #329