### PR TITLE
feat: cross-contract incident correlation (#384)

### DIFF
--- a/contracts/allergy-management/src/lib.rs
+++ b/contracts/allergy-management/src/lib.rs
@@ -207,6 +207,7 @@ impl AllergyManagement {
             error_code,
             description,
             reporter.clone(),
+            None,
         );
 
         let severity_symbol = match severity {

--- a/contracts/health-records/Cargo.toml
+++ b/contracts/health-records/Cargo.toml
@@ -14,4 +14,5 @@ shared-contracts = { path = "..", package = "Contracts" }
 soroban-sdk = { workspace = true }
 
 [dev-dependencies]
+patient-registry = { path = "../patient-registry" }
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/health-records/src/lib.rs
+++ b/contracts/health-records/src/lib.rs
@@ -1,11 +1,14 @@
 #![no_std]
 
+use shared::incident_tracking::{
+    capture_incident, get_incidents_by_correlation_id as shared_get_by_corr, IncidentSeverity,
+};
 use shared::privacy::{
     validate_encrypted_ref, validate_policy_metadata, EncryptedEnvelopeRef, PolicyMetadata,
 };
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, xdr::ToXdr, Address, Bytes, BytesN, Env,
-    String,
+    String, Vec,
 };
 
 #[contracttype]
@@ -192,6 +195,35 @@ impl HealthRecords {
 
         let recomputed_bytes: Bytes = recomputed.into();
         Ok(recomputed_bytes == expected_hash)
+    }
+
+    /// Capture an incident for this contract, optionally linking it to a
+    /// cross-contract correlation ID.  Returns the new incident ID.
+    pub fn report_incident(
+        env: Env,
+        reporter: Address,
+        error_code: u32,
+        description: String,
+        correlation_id: Option<BytesN<32>>,
+    ) -> u64 {
+        reporter.require_auth();
+        capture_incident(
+            &env,
+            IncidentSeverity::High,
+            String::from_str(&env, "health-records"),
+            error_code,
+            description,
+            reporter,
+            correlation_id,
+        )
+    }
+
+    /// Return all incident IDs that share the given correlation ID.
+    pub fn get_incidents_by_correlation_id(
+        env: Env,
+        correlation_id: BytesN<32>,
+    ) -> Vec<u64> {
+        shared_get_by_corr(&env, correlation_id)
     }
 }
 

--- a/contracts/health-records/src/test.rs
+++ b/contracts/health-records/src/test.rs
@@ -207,3 +207,148 @@ mod tests {
         assert!(!client.verify_record_integrity(&patient, &record_id, &short_hash));
     }
 }
+
+#[cfg(test)]
+mod cross_contract_correlation_tests {
+    use crate::{HealthRecords, HealthRecordsClient};
+    use patient_registry::{MedicalRegistry, MedicalRegistryClient};
+    use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String};
+
+    fn corr_id(env: &Env, seed: u8) -> BytesN<32> {
+        BytesN::from_array(env, &[seed; 32])
+    }
+
+    fn setup_both(
+        env: &Env,
+    ) -> (
+        HealthRecordsClient<'static>,
+        MedicalRegistryClient<'static>,
+    ) {
+        let hr_id = env.register(HealthRecords, ());
+        let pr_id = env.register(MedicalRegistry, ());
+        (
+            HealthRecordsClient::new(env, &hr_id),
+            MedicalRegistryClient::new(env, &pr_id),
+        )
+    }
+
+    /// Scenario 1: same correlation ID links one incident in each contract.
+    #[test]
+    fn test_correlated_incidents_appear_in_both_contracts() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (hr, pr) = setup_both(&env);
+        let reporter = Address::generate(&env);
+        let cid = corr_id(&env, 0xAA);
+
+        let hr_incident = hr.report_incident(
+            &reporter,
+            &1u32,
+            &String::from_str(&env, "hr: unauthorized access"),
+            &Some(cid.clone()),
+        );
+        let pr_incident = pr.report_incident(
+            &reporter,
+            &1u32,
+            &String::from_str(&env, "pr: patient not found"),
+            &Some(cid.clone()),
+        );
+
+        // Each contract's own storage holds the incident under the correlation index.
+        let hr_ids = hr.get_incidents_by_correlation_id(&cid);
+        let pr_ids = pr.get_incidents_by_correlation_id(&cid);
+
+        assert_eq!(hr_ids.len(), 1);
+        assert_eq!(hr_ids.get(0).unwrap(), hr_incident);
+
+        assert_eq!(pr_ids.len(), 1);
+        assert_eq!(pr_ids.get(0).unwrap(), pr_incident);
+    }
+
+    /// Scenario 2: multiple incidents across both contracts share one correlation ID.
+    #[test]
+    fn test_multiple_incidents_same_correlation_id() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (hr, pr) = setup_both(&env);
+        let reporter = Address::generate(&env);
+        let cid = corr_id(&env, 0xBB);
+
+        hr.report_incident(
+            &reporter,
+            &2u32,
+            &String::from_str(&env, "hr: consent revoked"),
+            &Some(cid.clone()),
+        );
+        hr.report_incident(
+            &reporter,
+            &3u32,
+            &String::from_str(&env, "hr: integrity check failed"),
+            &Some(cid.clone()),
+        );
+        pr.report_incident(
+            &reporter,
+            &2u32,
+            &String::from_str(&env, "pr: duplicate registration"),
+            &Some(cid.clone()),
+        );
+
+        assert_eq!(hr.get_incidents_by_correlation_id(&cid).len(), 2);
+        assert_eq!(pr.get_incidents_by_correlation_id(&cid).len(), 1);
+    }
+
+    /// Scenario 3: incidents without a correlation ID are not returned by the query.
+    #[test]
+    fn test_uncorrelated_incidents_not_returned() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (hr, pr) = setup_both(&env);
+        let reporter = Address::generate(&env);
+        let cid = corr_id(&env, 0xCC);
+
+        // Fire incidents with no correlation ID.
+        hr.report_incident(
+            &reporter,
+            &9u32,
+            &String::from_str(&env, "hr: unrelated error"),
+            &None,
+        );
+        pr.report_incident(
+            &reporter,
+            &9u32,
+            &String::from_str(&env, "pr: unrelated error"),
+            &None,
+        );
+
+        // The correlation index for `cid` must be empty.
+        assert_eq!(hr.get_incidents_by_correlation_id(&cid).len(), 0);
+        assert_eq!(pr.get_incidents_by_correlation_id(&cid).len(), 0);
+    }
+
+    /// Scenario 4: different correlation IDs are kept isolated from each other.
+    #[test]
+    fn test_different_correlation_ids_are_isolated() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (hr, _pr) = setup_both(&env);
+        let reporter = Address::generate(&env);
+        let cid_a = corr_id(&env, 0x01);
+        let cid_b = corr_id(&env, 0x02);
+
+        hr.report_incident(
+            &reporter,
+            &1u32,
+            &String::from_str(&env, "incident for A"),
+            &Some(cid_a.clone()),
+        );
+        hr.report_incident(
+            &reporter,
+            &2u32,
+            &String::from_str(&env, "incident for B"),
+            &Some(cid_b.clone()),
+        );
+
+        assert_eq!(hr.get_incidents_by_correlation_id(&cid_a).len(), 1);
+        assert_eq!(hr.get_incidents_by_correlation_id(&cid_b).len(), 1);
+    }
+}

--- a/contracts/healthcare-analytics/src/lib.rs
+++ b/contracts/healthcare-analytics/src/lib.rs
@@ -123,6 +123,7 @@ impl HealthcareAnalytics {
                 5, // Throttling error code
                 String::from_str(&env, "Report job throttled due to resource constraints"),
                 requester.clone(),
+                None,
             );
             // Attach evidence: current resource usage
             let cpu_used: u64 = env.storage().instance().get(&ResourceKey::TotalCpuUsed).unwrap_or(0);
@@ -181,6 +182,7 @@ impl HealthcareAnalytics {
                 8, // Resource overrun error code
                 String::from_str(&env, "Job exceeded resource quota"),
                 job.requested_by.clone(),
+                None,
             );
             let hash: Bytes = env.crypto().sha256(
                 &Bytes::from_slice(&env, b"resource_usage_exceeded_quota")
@@ -228,6 +230,7 @@ impl HealthcareAnalytics {
             9, // Job failure error code
             String::from_str(&env, "Report job failed"),
             requester.clone(),
+            None,
         );
         let hash: Bytes = env.crypto().sha256(
             &Bytes::from_slice(&env, b"report_job_error_log")

--- a/contracts/patient-registry/src/lib.rs
+++ b/contracts/patient-registry/src/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 #![allow(deprecated)]
 
+use shared::incident_tracking::{
+    capture_incident, get_incidents_by_correlation_id as shared_get_by_corr, IncidentSeverity,
+};
 use shared::privacy::{
     validate_encrypted_ref, validate_policy_metadata, EncryptedEnvelopeRef, PolicyMetadata,
 };
@@ -2093,6 +2096,39 @@ impl MedicalRegistry {
             .unwrap_or(Vec::new(&env));
 
         Ok(index.len() as u64)
+    }
+
+    // =====================================================
+    //              INCIDENT TRACKING
+    // =====================================================
+
+    /// Capture an incident for this contract, optionally linking it to a
+    /// cross-contract correlation ID.  Returns the new incident ID.
+    pub fn report_incident(
+        env: Env,
+        reporter: Address,
+        error_code: u32,
+        description: String,
+        correlation_id: Option<BytesN<32>>,
+    ) -> u64 {
+        reporter.require_auth();
+        capture_incident(
+            &env,
+            IncidentSeverity::High,
+            String::from_str(&env, "patient-registry"),
+            error_code,
+            description,
+            reporter,
+            correlation_id,
+        )
+    }
+
+    /// Return all incident IDs that share the given correlation ID.
+    pub fn get_incidents_by_correlation_id(
+        env: Env,
+        correlation_id: BytesN<32>,
+    ) -> Vec<u64> {
+        shared_get_by_corr(&env, correlation_id)
     }
 
     // =====================================================

--- a/contracts/shared/src/incident_tracking.rs
+++ b/contracts/shared/src/incident_tracking.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contracttype, Address, Bytes, Env, String, Symbol, Vec};
+use soroban_sdk::{contracttype, Address, Bytes, BytesN, Env, String, Symbol, Vec};
 
 /// Severity levels for incidents
 #[contracttype]
@@ -47,6 +47,7 @@ pub struct Incident {
     pub evidence_count: u32,
     pub resolved: bool,
     pub resolution_note: Option<String>,
+    pub correlation_id: Option<BytesN<32>>,
 }
 
 /// Evidence attachment to incident
@@ -56,6 +57,7 @@ pub struct IncidentEvidence {
     pub incident_id: u64,
     pub evidence_index: u32,
     pub evidence: Evidence,
+    pub correlation_id: Option<BytesN<32>>,
 }
 
 /// Storage keys for incident tracking
@@ -67,6 +69,7 @@ pub enum IncidentKey {
     IncidentEvidence(u64, u32),
     OpenIncidents,             // Vec<u64> - IDs of unresolved incidents
     ContractIncidents(String), // Contract-specific incident list
+    CorrelationIndex(BytesN<32>), // correlation_id -> Vec<u64> incident IDs
 }
 
 /// Constants for incident tracking
@@ -81,6 +84,7 @@ pub fn capture_incident(
     error_code: u32,
     description: String,
     reporter: Address,
+    correlation_id: Option<BytesN<32>>,
 ) -> u64 {
     let incident_id: u64 = env
         .storage()
@@ -103,6 +107,7 @@ pub fn capture_incident(
         evidence_count: 0,
         resolved: false,
         resolution_note: None,
+        correlation_id: correlation_id.clone(),
     };
 
     env.storage()
@@ -130,6 +135,26 @@ pub fn capture_incident(
     env.storage().persistent().set(
         &IncidentKey::ContractIncidents(contract),
         &contract_incidents,
+    );
+
+    // Index by correlation_id if provided
+    if let Some(ref cid) = correlation_id {
+        let mut correlated: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&IncidentKey::CorrelationIndex(cid.clone()))
+            .unwrap_or(Vec::new(env));
+        correlated.push_back(incident_id);
+        env.storage().persistent().set(
+            &IncidentKey::CorrelationIndex(cid.clone()),
+            &correlated,
+        );
+    }
+
+    // Emit event with correlation_id for off-chain aggregation
+    env.events().publish(
+        (Symbol::new(env, "incident"), Symbol::new(env, "captured")),
+        (incident_id, correlation_id),
     );
 
     incident_id
@@ -165,6 +190,7 @@ pub fn attach_evidence(
         incident_id,
         evidence_index,
         evidence,
+        correlation_id: incident.correlation_id.clone(),
     };
 
     env.storage().persistent().set(
@@ -233,4 +259,12 @@ pub fn get_evidence(env: &Env, incident_id: u64, evidence_index: u32) -> Result<
         .get(&IncidentKey::IncidentEvidence(incident_id, evidence_index))
         .ok_or(())?;
     Ok(incident_evidence.evidence)
+}
+
+/// Get all incident IDs linked to a correlation ID
+pub fn get_incidents_by_correlation_id(env: &Env, correlation_id: BytesN<32>) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&IncidentKey::CorrelationIndex(correlation_id))
+        .unwrap_or(Vec::new(env))
 }


### PR DESCRIPTION
## Summary

Implements cross-contract incident correlation between `patient-registry` and `health-records` as specified in #384.

## Changes

**`shared/src/incident_tracking.rs`**
- Added `correlation_id: Option<BytesN<32>>` to `Incident` and `IncidentEvidence` structs
- Added `CorrelationIndex(BytesN<32>)` variant to `IncidentKey` for indexed lookups
- Updated `capture_incident` to accept and persist `correlation_id`, indexing it under `CorrelationIndex`
- Added `get_incidents_by_correlation_id` query function
- Incident events now include `correlation_id` for off-chain aggregation

**`patient-registry/src/lib.rs`**
- Added `report_incident(reporter, error_code, description, correlation_id) -> u64`
- Added `get_incidents_by_correlation_id(correlation_id) -> Vec<u64>`

**`health-records/src/lib.rs`**
- Added `report_incident(reporter, error_code, description, correlation_id) -> u64`
- Added `get_incidents_by_correlation_id(correlation_id) -> Vec<u64>`

**Existing callers updated** (`healthcare-analytics`, `allergy-management`) to pass `None` — fully backward-compatible.

## Tests

4 cross-contract scenarios in `health-records/src/test.rs`:
1. Same correlation ID links one incident in each contract
2. Multiple incidents across both contracts share one correlation ID
3. Incidents without a correlation ID are not returned by the query
4. Different correlation IDs are isolated from each other

## Acceptance Criteria

- [x] `IncidentEvidence` includes `correlation_id: Option<BytesN<32>>`
- [x] Incident creation accepts an optional correlation ID
- [x] Cross-contract incident linkage tested with 4 scenarios (≥3 required)
- [x] Events include `correlation_id` for off-chain aggregation

Closes #384