### PR TITLE
fix: exclusive valid_until boundary for prescription expiry (#381)

### DIFF
--- a/contracts/prescription-management/src/lib.rs
+++ b/contracts/prescription-management/src/lib.rs
@@ -330,8 +330,12 @@ impl PrescriptionContract {
             return Err(Error::InvalidStatusTransition);
         }
 
-        // Check expiration
-        if env.ledger().timestamp() > p.valid_until {
+        // Check expiration.
+        // Semantics: valid_until is an EXCLUSIVE upper bound — a prescription
+        // is considered expired when ledger timestamp >= valid_until.
+        // This ensures consistent behaviour at UTC midnight boundaries
+        // regardless of sub-second ledger close timing.
+        if env.ledger().timestamp() >= p.valid_until {
             return Err(Error::Expired);
         }
 
@@ -418,8 +422,12 @@ impl PrescriptionContract {
             return Err(Error::InvalidStatusTransition);
         }
 
-        // Check expiration
-        if env.ledger().timestamp() > p.valid_until {
+        // Check expiration.
+        // Semantics: valid_until is an EXCLUSIVE upper bound — a prescription
+        // is considered expired when ledger timestamp >= valid_until.
+        // This ensures consistent behaviour at UTC midnight boundaries
+        // regardless of sub-second ledger close timing.
+        if env.ledger().timestamp() >= p.valid_until {
             return Err(Error::Expired);
         }
 
@@ -995,8 +1003,12 @@ impl PrescriptionContract {
             return Err(Error::InvalidStatusTransition);
         }
 
-        // Check expiration
-        if env.ledger().timestamp() > p.valid_until {
+        // Check expiration.
+        // Semantics: valid_until is an EXCLUSIVE upper bound — a prescription
+        // is considered expired when ledger timestamp >= valid_until.
+        // This ensures consistent behaviour at UTC midnight boundaries
+        // regardless of sub-second ledger close timing.
+        if env.ledger().timestamp() >= p.valid_until {
             return Err(Error::Expired);
         }
 

--- a/contracts/prescription-management/src/test.rs
+++ b/contracts/prescription-management/src/test.rs
@@ -423,3 +423,150 @@ fn test_high_impact_interaction_requires_proposal_and_snapshot_is_versioned() {
     let duplicate_approval = client.try_approve_registry_proposal(&admin, &proposal_id);
     assert_eq!(duplicate_approval, Err(Ok(Error::ProposalAlreadyFinalized)));
 }
+
+// ── UTC midnight boundary tests (#381) ───────────────────────────────────────
+//
+// valid_until is an EXCLUSIVE upper bound:
+//   timestamp <  valid_until  → prescription is valid
+//   timestamp == valid_until  → prescription is expired
+//   timestamp >  valid_until  → prescription is expired
+//
+// Midnight boundaries used below are real UTC epoch values:
+//   2024-01-01 00:00:00 UTC = 1_704_067_200
+//   2024-06-15 00:00:00 UTC = 1_718_409_600
+
+const MIDNIGHT_JAN1: u64 = 1_704_067_200;
+const MIDNIGHT_JUN15: u64 = 1_718_409_600;
+
+fn make_client(env: &Env) -> (PrescriptionContractClient<'static>, Address, Address, Address) {
+    let contract_id = env.register(PrescriptionContract, ());
+    let client = PrescriptionContractClient::new(env, &contract_id);
+    let provider = Address::generate(env);
+    let patient = Address::generate(env);
+    let pharmacy = Address::generate(env);
+    (client, provider, patient, pharmacy)
+}
+
+fn issue_at(
+    env: &Env,
+    client: &PrescriptionContractClient,
+    provider: &Address,
+    patient: &Address,
+    pharmacy: &Address,
+    valid_until: u64,
+) -> u64 {
+    // Set ledger to 1 second before valid_until so must_be_future and
+    // within_validity_window (1-year cap) both pass during issuance.
+    env.ledger().with_mut(|li| li.timestamp = valid_until - 1);
+    let req = IssueRequest {
+        medication_name: String::from_str(env, "TestDrug"),
+        ndc_code: String::from_str(env, "00000-0001"),
+        dosage: String::from_str(env, "10mg"),
+        quantity: 10,
+        days_supply: 30,
+        refills_allowed: 0,
+        instructions_hash: BytesN::from_array(env, &[0u8; 32]),
+        is_controlled: false,
+        schedule: None,
+        valid_until,
+        substitution_allowed: true,
+        pharmacy_id: Some(pharmacy.clone()),
+    };
+    client.issue_prescription(provider, patient, &req)
+}
+
+/// One second before midnight: prescription must be valid.
+#[test]
+fn test_dispense_one_second_before_midnight_is_valid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, provider, patient, pharmacy) = make_client(&env);
+    let id = issue_at(&env, &client, &provider, &patient, &pharmacy, MIDNIGHT_JAN1);
+
+    env.ledger().with_mut(|li| li.timestamp = MIDNIGHT_JAN1 - 1);
+    let req = DispenseRequest {
+        prescription_id: id,
+        quantity: 1,
+        lot: String::from_str(&env, "LOT1"),
+        expires_at: MIDNIGHT_JAN1 + 86400,
+        ndc_code: String::from_str(&env, "00000-0001"),
+    };
+    client.dispense_prescription(&req, &pharmacy); // must not panic
+}
+
+/// Exactly at midnight (timestamp == valid_until): prescription must be expired.
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_dispense_exactly_at_midnight_is_expired() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, provider, patient, pharmacy) = make_client(&env);
+    let id = issue_at(&env, &client, &provider, &patient, &pharmacy, MIDNIGHT_JAN1);
+
+    env.ledger().with_mut(|li| li.timestamp = MIDNIGHT_JAN1);
+    let req = DispenseRequest {
+        prescription_id: id,
+        quantity: 1,
+        lot: String::from_str(&env, "LOT1"),
+        expires_at: MIDNIGHT_JAN1 + 86400,
+        ndc_code: String::from_str(&env, "00000-0001"),
+    };
+    client.dispense_prescription(&req, &pharmacy);
+}
+
+/// One second after midnight: prescription must be expired.
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_dispense_one_second_after_midnight_is_expired() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, provider, patient, pharmacy) = make_client(&env);
+    let id = issue_at(&env, &client, &provider, &patient, &pharmacy, MIDNIGHT_JAN1);
+
+    env.ledger().with_mut(|li| li.timestamp = MIDNIGHT_JAN1 + 1);
+    let req = DispenseRequest {
+        prescription_id: id,
+        quantity: 1,
+        lot: String::from_str(&env, "LOT1"),
+        expires_at: MIDNIGHT_JAN1 + 86400,
+        ndc_code: String::from_str(&env, "00000-0001"),
+    };
+    client.dispense_prescription(&req, &pharmacy);
+}
+
+/// Transfer: exactly at midnight is expired.
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_transfer_exactly_at_midnight_is_expired() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, provider, patient, pharmacy) = make_client(&env);
+    let id = issue_at(&env, &client, &provider, &patient, &pharmacy, MIDNIGHT_JUN15);
+
+    env.ledger().with_mut(|li| li.timestamp = MIDNIGHT_JUN15);
+    let req = TransferRequest {
+        prescription_id: id,
+        to_pharmacy: Address::generate(&env),
+        transfer_reason: String::from_str(&env, "patient_request"),
+        urgency: Symbol::new(&env, "routine"),
+    };
+    client.transfer_prescription(&req, &pharmacy);
+}
+
+/// Transfer: one second before midnight is valid.
+#[test]
+fn test_transfer_one_second_before_midnight_is_valid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, provider, patient, pharmacy) = make_client(&env);
+    let id = issue_at(&env, &client, &provider, &patient, &pharmacy, MIDNIGHT_JUN15);
+
+    env.ledger().with_mut(|li| li.timestamp = MIDNIGHT_JUN15 - 1);
+    let req = TransferRequest {
+        prescription_id: id,
+        to_pharmacy: Address::generate(&env),
+        transfer_reason: String::from_str(&env, "patient_request"),
+        urgency: Symbol::new(&env, "routine"),
+    };
+    client.transfer_prescription(&req, &pharmacy); // must not panic
+}


### PR DESCRIPTION
## Summary

Fixes the UTC midnight boundary inconsistency in prescription expiration checks.

## Root Cause

All three expiration checks used `timestamp > valid_until` (strict greater-than), making `valid_until` an **inclusive** upper bound. A prescription with `valid_until = T` was accepted at `timestamp = T` and only rejected at `timestamp = T+1`. At UTC midnight boundaries this creates a one-second window where an expired prescription is still dispensable.

## Fix

Changed all three checks to `timestamp >= valid_until` (exclusive upper bound):

| Function | Line |
|---|---|
| `dispense_prescription` | ~338 |
| `transfer_prescription` | ~430 |
| `refill_prescription` | ~1011 |

Each check now has a documentation comment explaining the semantics.

## Tests Added

5 targeted midnight boundary tests using real UTC epoch values:

| Test | Timestamp vs valid_until | Expected |
|---|---|---|
| `test_dispense_one_second_before_midnight_is_valid` | T-1 | ✅ valid |
| `test_dispense_exactly_at_midnight_is_expired` | T | ❌ Expired |
| `test_dispense_one_second_after_midnight_is_expired` | T+1 | ❌ Expired |
| `test_transfer_exactly_at_midnight_is_expired` | T | ❌ Expired |
| `test_transfer_one_second_before_midnight_is_valid` | T-1 | ✅ valid |

Closes #381