### PR TITLE
fix(patient-registry): complete record versioning — update_record & get_record_history

### DIFF
--- a/contracts/patient-registry/src/lib.rs
+++ b/contracts/patient-registry/src/lib.rs
@@ -1553,13 +1553,13 @@ impl MedicalRegistry {
 
         let timestamp = env.ledger().timestamp();
 
-        // Append old current to history
-        let old_version = RecordVersion {
-            encrypted_ref: record_data.current_ref.clone(),
+        // Append new version to history, then update current_ref
+        let new_version = RecordVersion {
+            encrypted_ref: new_encrypted_ref.clone(),
             updated_by: caller.clone(),
             updated_at: timestamp,
         };
-        record_data.history.push_back(old_version);
+        record_data.history.push_back(new_version);
         record_data.current_ref = new_encrypted_ref;
         record_data.policy = policy;
         record_data.latest_version += 1;

--- a/contracts/patient-registry/src/test.rs
+++ b/contracts/patient-registry/src/test.rs
@@ -3726,3 +3726,234 @@ fn test_merkle_wrong_depth_proof_rejected() {
         "proof with wrong depth must be rejected"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  RECORD VERSIONING TESTS  (#383)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// create → update×3 → get_history must return 4 entries (1 initial + 3 updates).
+#[test]
+fn test_record_history_four_entries_after_three_updates() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, patient, doctor, _v1) = setup_for_ttl(&env);
+
+    let record_id = client.add_medical_record(
+        &patient,
+        &doctor,
+        &encrypted_ref(&env, 1),
+        &Symbol::new(&env, "LAB"),
+        &policy(&env),
+    );
+
+    client.update_record(&doctor, &record_id, &encrypted_ref(&env, 2), &policy(&env));
+    client.update_record(&doctor, &record_id, &encrypted_ref(&env, 3), &policy(&env));
+    client.update_record(&doctor, &record_id, &encrypted_ref(&env, 4), &policy(&env));
+
+    let history = client.get_record_history(&record_id, &patient);
+    assert_eq!(history.len(), 4, "expected 4 history entries (1 initial + 3 updates)");
+}
+
+/// Version IDs (latest_version) must be monotonically increasing and immutable.
+#[test]
+fn test_version_ids_are_monotonically_increasing() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, patient, doctor, _v1) = setup_for_ttl(&env);
+
+    let record_id = client.add_medical_record(
+        &patient,
+        &doctor,
+        &encrypted_ref(&env, 10),
+        &Symbol::new(&env, "LAB"),
+        &policy(&env),
+    );
+
+    // Read latest_version via the contract's internal storage through as_contract
+    let v1: u64 = env.as_contract(&client.address, || {
+        let rd: RecordData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MedicalRecord(record_id))
+            .unwrap();
+        rd.latest_version
+    });
+    assert_eq!(v1, 1);
+
+    client.update_record(&doctor, &record_id, &encrypted_ref(&env, 11), &policy(&env));
+    let v2: u64 = env.as_contract(&client.address, || {
+        let rd: RecordData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MedicalRecord(record_id))
+            .unwrap();
+        rd.latest_version
+    });
+    assert_eq!(v2, 2);
+
+    client.update_record(&doctor, &record_id, &encrypted_ref(&env, 12), &policy(&env));
+    let v3: u64 = env.as_contract(&client.address, || {
+        let rd: RecordData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MedicalRecord(record_id))
+            .unwrap();
+        rd.latest_version
+    });
+    assert_eq!(v3, 3);
+
+    assert!(v1 < v2 && v2 < v3, "version IDs must be strictly increasing");
+}
+
+/// History entries must record the correct encrypted_ref for each version.
+#[test]
+fn test_history_entries_contain_correct_refs() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, patient, doctor, _v1) = setup_for_ttl(&env);
+
+    let record_id = client.add_medical_record(
+        &patient,
+        &doctor,
+        &encrypted_ref(&env, 1),
+        &Symbol::new(&env, "LAB"),
+        &policy(&env),
+    );
+    client.update_record(&doctor, &record_id, &encrypted_ref(&env, 2), &policy(&env));
+    client.update_record(&doctor, &record_id, &encrypted_ref(&env, 3), &policy(&env));
+
+    let history = client.get_record_history(&record_id, &patient);
+    assert_eq!(history.len(), 3);
+
+    assert_eq!(history.get(0).unwrap().encrypted_ref, encrypted_ref(&env, 1));
+    assert_eq!(history.get(1).unwrap().encrypted_ref, encrypted_ref(&env, 2));
+    assert_eq!(history.get(2).unwrap().encrypted_ref, encrypted_ref(&env, 3));
+}
+
+/// current_ref must always reflect the latest update.
+#[test]
+fn test_current_ref_reflects_latest_update() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, patient, doctor, _v1) = setup_for_ttl(&env);
+
+    let record_id = client.add_medical_record(
+        &patient,
+        &doctor,
+        &encrypted_ref(&env, 1),
+        &Symbol::new(&env, "LAB"),
+        &policy(&env),
+    );
+    client.update_record(&doctor, &record_id, &encrypted_ref(&env, 2), &policy(&env));
+    client.update_record(&doctor, &record_id, &encrypted_ref(&env, 3), &policy(&env));
+
+    let current: EncryptedEnvelopeRef = env.as_contract(&client.address, || {
+        let rd: RecordData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MedicalRecord(record_id))
+            .unwrap();
+        rd.current_ref
+    });
+    assert_eq!(current, encrypted_ref(&env, 3));
+}
+
+/// Concurrent updates from multiple authorized providers — each update is
+/// serialized; history must contain all versions in order.
+#[test]
+fn test_concurrent_updates_from_multiple_providers() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, patient, doctor1, _v1) = setup_for_ttl(&env);
+
+    // Register and authorize a second provider.
+    let doctor2 = Address::generate(&env);
+    client.register_doctor(
+        &doctor2,
+        &String::from_str(&env, "Dr. Carol"),
+        &String::from_str(&env, "Neurology"),
+        &Bytes::from_array(&env, &[4, 5, 6]),
+    );
+    client.grant_access(&patient, &patient, &doctor2);
+
+    let record_id = client.add_medical_record(
+        &patient,
+        &doctor1,
+        &encrypted_ref(&env, 1),
+        &Symbol::new(&env, "LAB"),
+        &policy(&env),
+    );
+
+    // doctor1 updates, then doctor2 updates, then doctor1 again.
+    env.ledger().set_timestamp(1000);
+    client.update_record(&doctor1, &record_id, &encrypted_ref(&env, 2), &policy(&env));
+    env.ledger().set_timestamp(2000);
+    client.update_record(&doctor2, &record_id, &encrypted_ref(&env, 3), &policy(&env));
+    env.ledger().set_timestamp(3000);
+    client.update_record(&doctor1, &record_id, &encrypted_ref(&env, 4), &policy(&env));
+
+    let history = client.get_record_history(&record_id, &patient);
+    assert_eq!(history.len(), 4, "all 4 versions must be in history");
+
+    // Verify updated_by attribution.
+    assert_eq!(history.get(1).unwrap().updated_by, doctor1);
+    assert_eq!(history.get(2).unwrap().updated_by, doctor2);
+    assert_eq!(history.get(3).unwrap().updated_by, doctor1);
+
+    // Verify timestamps are non-decreasing.
+    for i in 1..history.len() {
+        assert!(
+            history.get(i).unwrap().updated_at >= history.get(i - 1).unwrap().updated_at,
+            "timestamps must be non-decreasing"
+        );
+    }
+}
+
+/// Unauthorized caller must not be able to update a record.
+#[test]
+fn test_unauthorized_caller_cannot_update_record() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, patient, doctor, _v1) = setup_for_ttl(&env);
+    let stranger = Address::generate(&env);
+
+    let record_id = client.add_medical_record(
+        &patient,
+        &doctor,
+        &encrypted_ref(&env, 1),
+        &Symbol::new(&env, "LAB"),
+        &policy(&env),
+    );
+
+    let result =
+        client.try_update_record(&stranger, &record_id, &encrypted_ref(&env, 2), &policy(&env));
+    assert!(result.is_err(), "unauthorized caller must be rejected");
+}
+
+/// get_record_history is readable by any address with read permission.
+#[test]
+fn test_get_record_history_readable_by_authorized_doctor() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _admin, patient, doctor, _v1) = setup_for_ttl(&env);
+
+    let record_id = client.add_medical_record(
+        &patient,
+        &doctor,
+        &encrypted_ref(&env, 1),
+        &Symbol::new(&env, "LAB"),
+        &policy(&env),
+    );
+    client.update_record(&doctor, &record_id, &encrypted_ref(&env, 2), &policy(&env));
+
+    // Doctor (authorized) can read history.
+    let history = client.get_record_history(&record_id, &doctor);
+    assert_eq!(history.len(), 2);
+}


### PR DESCRIPTION
## Summary

Closes #383

Completes the record versioning implementation in `patient-registry` as tracked in TODO.md.

## Changes

### `contracts/patient-registry/src/lib.rs`
- **Fix `update_record`**: The history append logic was saving the *old* `current_ref` attributed to the caller. Corrected to append a new `RecordVersion { encrypted_ref: new_encrypted_ref, updated_by: caller, updated_at: timestamp }` so history is an accurate, append-only log of every version written. `current_ref` is then set to `new_encrypted_ref` so it always mirrors the latest entry.

### `contracts/patient-registry/src/test.rs`
Added 7 versioning tests:

| Test | Covers |
|---|---|
| `test_record_history_four_entries_after_three_updates` | create→update×3 yields 4 history entries (acceptance criterion) |
| `test_version_ids_are_monotonically_increasing` | `latest_version` increments strictly after each update |
| `test_history_entries_contain_correct_refs` | each history entry carries the correct `encrypted_ref` |
| `test_current_ref_reflects_latest_update` | `current_ref` always mirrors the most recent version |
| `test_concurrent_updates_from_multiple_providers` | two authorized providers can update the same record; all versions are serialized in order with correct attribution |
| `test_unauthorized_caller_cannot_update_record` | stranger is rejected by `update_record` |
| `test_get_record_history_readable_by_authorized_doctor` | authorized doctor can read history via `get_record_history` |

## Acceptance Criteria

- [x] A record updated 3 times returns a history of 4 entries (original + 3 updates)
- [x] Version IDs are monotonically increasing and immutable
- [x] History is readable by anyone with read permission on the record
- [x] Concurrent updates from multiple authorized providers are handled correctly