### PR TITLE
fix: resolve issues #373 #374 #375 #376

### DIFF
--- a/contracts/imaging-radiology/src/lib.rs
+++ b/contracts/imaging-radiology/src/lib.rs
@@ -127,6 +127,8 @@ pub enum Error {
     InvalidScheduledTime = 9,
     /// study_date must not be in the future
     InvalidStudyDate = 10,
+    /// A required counter entry was missing from storage
+    CounterUnavailable = 11,
 }
 
 /// --------------------
@@ -571,7 +573,11 @@ impl ImagingRadiology {
         }
         let p = patient_id.clone();
         let total_key = DataKey::PatientOrdersTotal(patient_id.clone());
-        let total: u32 = env.storage().persistent().get(&total_key).unwrap_or(0);
+        let total: u32 = env
+            .storage()
+            .persistent()
+            .get(&total_key)
+            .ok_or(Error::CounterUnavailable)?;
         Ok(pagination::get_paged(
             &env,
             |pg| DataKey::PatientOrdersPage(p.clone(), pg),
@@ -596,7 +602,11 @@ impl ImagingRadiology {
         }
         let prov = provider_id.clone();
         let total_key = DataKey::ProviderOrdersTotal(provider_id.clone());
-        let total: u32 = env.storage().persistent().get(&total_key).unwrap_or(0);
+        let total: u32 = env
+            .storage()
+            .persistent()
+            .get(&total_key)
+            .ok_or(Error::CounterUnavailable)?;
         Ok(pagination::get_paged(
             &env,
             |pg| DataKey::ProviderOrdersPage(prov.clone(), pg),

--- a/contracts/lab-management/src/lib.rs
+++ b/contracts/lab-management/src/lib.rs
@@ -3,7 +3,6 @@
 
 use soroban_sdk::{
     Address, BytesN, Env, String, Symbol, Vec, contract, contracterror, contractimpl, contracttype,
-    panic_with_error,
 };
 
 #[contracterror]
@@ -85,7 +84,7 @@ impl LabManagementContract {
         provider_id: Address,
         patient_id: Address,
         req: OrderRequest,
-    ) -> u64 {
+    ) -> Result<u64, Error> {
         provider_id.require_auth();
 
         // Read the current counter (u64 throughout — no cast to u32).
@@ -96,9 +95,7 @@ impl LabManagementContract {
             .unwrap_or(0);
 
         // Guard against u64 overflow before incrementing.
-        let next_id = id
-            .checked_add(1)
-            .unwrap_or_else(|| panic_with_error!(&env, Error::OrderIdOverflow));
+        let next_id = id.checked_add(1).ok_or(Error::OrderIdOverflow)?;
 
         env.storage()
             .instance()
@@ -118,20 +115,21 @@ impl LabManagementContract {
         env.storage()
             .persistent()
             .set(&DataKey::LabOrder(id), &order);
-        id
+        Ok(id)
     }
 
-    pub fn assign_lab(env: Env, order_id: u64, lab_id: Address, _eta: u64) {
+    pub fn assign_lab(env: Env, order_id: u64, lab_id: Address, _eta: u64) -> Result<(), Error> {
         let mut order: LabOrder = env
             .storage()
             .persistent()
             .get(&DataKey::LabOrder(order_id))
-            .unwrap_or_else(|| panic_with_error!(&env, Error::NotFound));
+            .ok_or(Error::NotFound)?;
         order.lab_id = Some(lab_id);
         order.status = Symbol::new(&env, "Assigned");
         env.storage()
             .persistent()
             .set(&DataKey::LabOrder(order_id), &order);
+        Ok(())
     }
 
     pub fn submit_results(
@@ -141,7 +139,7 @@ impl LabManagementContract {
         results_hash: BytesN<32>,
         results_summary: Vec<TestResult>,
         qc_passed: bool,
-    ) {
+    ) -> Result<(), Error> {
         lab_id.require_auth();
 
         // VALIDATION PHASE: All validations must pass before any storage writes.
@@ -151,11 +149,10 @@ impl LabManagementContract {
             .storage()
             .persistent()
             .get(&DataKey::LabOrder(order_id))
-            .unwrap_or_else(|| panic_with_error!(&env, Error::NotFound));
+            .ok_or(Error::NotFound)?;
 
         // 2. Perform QC validation (BEFORE any mutations).
-        Self::validate_qc_results(qc_passed, &results_summary)
-            .unwrap_or_else(|e| panic_with_error!(&env, e));
+        Self::validate_qc_results(qc_passed, &results_summary)?;
 
         // MUTATION PHASE: All state changes after validations have passed.
 
@@ -175,6 +172,7 @@ impl LabManagementContract {
         env.storage()
             .persistent()
             .set(&DataKey::LabOrder(order_id), &order);
+        Ok(())
     }
 
     pub fn flag_critical_value(

--- a/contracts/shared/src/actor_verification.rs
+++ b/contracts/shared/src/actor_verification.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contracttype, Address, Env};
+use soroban_sdk::{contracttype, vec, Address, Env, IntoVal, Symbol};
 
 /// Actor types for verification
 #[contracttype]
@@ -24,13 +24,21 @@ pub struct VerificationCache {
 #[contracttype]
 pub enum VerificationKey {
     Cache(ActorType, Address),
+    /// Registry contract addresses stored by the host contract during initialization.
+    PatientRegistry,
+    ProviderRegistry,
+    HospitalRegistry,
+    InsurerRegistry,
 }
 
 /// Cache duration in ledger seconds (e.g., 24 hours)
 pub const CACHE_DURATION: u64 = 86400;
 
-/// Verify if an address is a registered actor of the given type
-/// Uses caching to reduce cross-contract calls
+/// Verify if an address is a registered actor of the given type.
+/// Uses caching to reduce cross-contract calls.
+/// Registry addresses must be stored in instance storage under the
+/// `VerificationKey::{Patient,Provider,Hospital,Insurer}Registry` keys
+/// before this function is called.
 pub fn verify_actor(env: &Env, actor_type: ActorType, address: &Address) -> bool {
     // Check cache first
     let cache_key = VerificationKey::Cache(actor_type.clone(), address.clone());
@@ -62,26 +70,54 @@ pub fn verify_actor(env: &Env, actor_type: ActorType, address: &Address) -> bool
     verified
 }
 
-fn verify_patient(_env: &Env, _address: &Address) -> bool {
-    // Cross-contract call to patient-registry
-    // For now, we'll assume the contract addresses are known or passed
-    // In a real implementation, this would use contract.invoke()
-    // Since we can't do cross-contract calls easily here, we'll return true for demo
-    // In practice, this would check patient-registry.is_patient_registered()
-    true // TODO: Implement actual cross-contract call
+fn verify_patient(env: &Env, address: &Address) -> bool {
+    let registry: Address = match env
+        .storage()
+        .instance()
+        .get::<VerificationKey, Address>(&VerificationKey::PatientRegistry)
+    {
+        Some(r) => r,
+        None => return false,
+    };
+    let args = vec![env, address.clone().into_val(env)];
+    env.invoke_contract(&registry, &Symbol::new(env, "is_patient_registered"), args)
 }
 
-fn verify_provider(_env: &Env, _address: &Address) -> bool {
-    // Cross-contract call to provider-registry
-    true // TODO: Implement actual cross-contract call
+fn verify_provider(env: &Env, address: &Address) -> bool {
+    let registry: Address = match env
+        .storage()
+        .instance()
+        .get::<VerificationKey, Address>(&VerificationKey::ProviderRegistry)
+    {
+        Some(r) => r,
+        None => return false,
+    };
+    let args = vec![env, address.clone().into_val(env)];
+    env.invoke_contract(&registry, &Symbol::new(env, "is_provider"), args)
 }
 
-fn verify_hospital(_env: &Env, _address: &Address) -> bool {
-    // Cross-contract call to hospital-registry
-    true // TODO: Implement actual cross-contract call
+fn verify_hospital(env: &Env, address: &Address) -> bool {
+    let registry: Address = match env
+        .storage()
+        .instance()
+        .get::<VerificationKey, Address>(&VerificationKey::HospitalRegistry)
+    {
+        Some(r) => r,
+        None => return false,
+    };
+    let args = vec![env, address.clone().into_val(env)];
+    env.invoke_contract(&registry, &Symbol::new(env, "is_hospital_active"), args)
 }
 
-fn verify_insurer(_env: &Env, _address: &Address) -> bool {
-    // Cross-contract call to insurer-registry
-    true // TODO: Implement actual cross-contract call
+fn verify_insurer(env: &Env, address: &Address) -> bool {
+    let registry: Address = match env
+        .storage()
+        .instance()
+        .get::<VerificationKey, Address>(&VerificationKey::InsurerRegistry)
+    {
+        Some(r) => r,
+        None => return false,
+    };
+    let args = vec![env, address.clone().into_val(env)];
+    env.invoke_contract(&registry, &Symbol::new(env, "is_insurer_active"), args)
 }

--- a/contracts/upgrade-governance/src/lib.rs
+++ b/contracts/upgrade-governance/src/lib.rs
@@ -277,7 +277,7 @@ impl UpgradeGovernance {
             .get::<DataKey, bool>(&DataKey::ApprovedArtifactMetadata(
                 proposal.artifact_metadata_hash.clone(),
             ))
-            .unwrap_or(false);
+            .ok_or(Error::UnapprovedArtifactMetadata)?;
         if !approved {
             return Err(Error::UnapprovedArtifactMetadata);
         }


### PR DESCRIPTION
closes #373 - Replace true stubs in actor_verification.rs with real cross-contract calls to patient/provider/hospital/insurer registries. Registry addresses are read from instance storage (VerificationKey::{Patient,Provider,Hospital, Insurer}Registry). Returns false when registry address is not configured.

closes #374 - Replace panic_with_error! macro with Result error returns in lab-management. order_lab_test, assign_lab, and submit_results now return Result<_, Error> so callers can handle failures programmatically.

closes #375 - Replace .unwrap_or(false) with .ok_or(Error::UnapprovedArtifactMetadata) in upgrade-governance execute_upgrade. Missing approval record now halts execution with a typed error instead of silently treating it as unapproved.

closes #376 - Add CounterUnavailable error variant to imaging-radiology and replace .unwrap_or(0) in get_patient_orders/get_provider_orders total reads with .ok_or(Error::CounterUnavailable) so callers receive an explicit error when counter storage is unavailable.