### PR TITLE
fix(multisig-governance): extract is_signer helper to remove duplicated membership check

### DIFF
--- a/contracts/multisig-governance/src/lib.rs
+++ b/contracts/multisig-governance/src/lib.rs
@@ -281,10 +281,8 @@ impl MultisigGovernance {
         // Validate the change is meaningful.
         match kind {
             SignerChangeKind::Add => {
-                for s in signers.iter() {
-                    if s == target {
-                        return Err(Error::AlreadySigner);
-                    }
+                if is_signer(&env, &signers, &target) {
+                    return Err(Error::AlreadySigner);
                 }
             }
             SignerChangeKind::Remove => {
@@ -298,14 +296,7 @@ impl MultisigGovernance {
                     return Err(Error::ThresholdBreached);
                 }
                 // Target must be a current signer.
-                let mut found = false;
-                for s in signers.iter() {
-                    if s == target {
-                        found = true;
-                        break;
-                    }
-                }
-                if !found {
+                if !is_signer(&env, &signers, &target) {
                     return Err(Error::NotASigner);
                 }
             }
@@ -475,11 +466,19 @@ impl MultisigGovernance {
             .persistent()
             .get(&DataKey::Signers)
             .ok_or(Error::NotInitialized)?;
-        for i in 0..signers.len() {
-            if signers.get(i).ok_or(Error::NotASigner)? == *caller {
-                return Ok(());
-            }
+        if is_signer(env, &signers, caller) {
+            return Ok(());
         }
         Err(Error::NotASigner)
     }
+}
+
+/// Returns `true` if `addr` is present in `signers`.
+fn is_signer(_env: &Env, signers: &Vec<Address>, addr: &Address) -> bool {
+    for s in signers.iter() {
+        if s == *addr {
+            return true;
+        }
+    }
+    false
 }


### PR DESCRIPTION
Closes #335

## Summary

- Extract a private `is_signer(_env: &Env, signers: &Vec<Address>, addr: &Address) -> bool` helper at module level
- Replace the three inline signer-membership loops in `assert_signer` and both branches of `propose_signer_change` with calls to the helper
- No behaviour change; purely a DRY refactor

## Test plan

- [ ] `cargo build -p multisig-governance` passes with no new errors
- [ ] All existing tests that compile continue to pass (pre-existing test failures for `abstain_multisig_action` / `finalize_expired` are unrelated to this change and existed on `main` before this PR)