### PR TITLE
fix(hospital-registry): cap department, location and equipment Vec sizes

### DIFF
--- a/contracts/hospital-registry/src/lib.rs
+++ b/contracts/hospital-registry/src/lib.rs
@@ -6,6 +6,13 @@ use soroban_sdk::{
     String, Vec,
 };
 
+/// Maximum number of departments a hospital configuration may contain.
+pub const MAX_DEPARTMENTS: u32 = 200;
+/// Maximum number of locations a hospital configuration may contain.
+pub const MAX_LOCATIONS: u32 = 50;
+/// Maximum number of equipment resources a hospital configuration may contain.
+pub const MAX_EQUIPMENT: u32 = 100;
+
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
@@ -17,6 +24,8 @@ pub enum ContractError {
     CredentialRevoked = 5,
     /// An empty vector was passed for a field that previously had values
     EmptyFieldUpdate = 6,
+    /// A config vector exceeds its maximum allowed length
+    ConfigLimitExceeded = 7,
 }
 
 #[contracttype]
@@ -283,6 +292,16 @@ impl HospitalRegistry {
         wallet.require_auth();
         Self::assert_active_hospital(&env, &wallet)?;
 
+        if config.departments.len() > MAX_DEPARTMENTS {
+            return Err(ContractError::ConfigLimitExceeded);
+        }
+        if config.locations.len() > MAX_LOCATIONS {
+            return Err(ContractError::ConfigLimitExceeded);
+        }
+        if config.equipment.len() > MAX_EQUIPMENT {
+            return Err(ContractError::ConfigLimitExceeded);
+        }
+
         let old: HospitalConfig = env
             .storage()
             .persistent()
@@ -315,6 +334,9 @@ impl HospitalRegistry {
         if departments.is_empty() && !config.departments.is_empty() {
             return Err(ContractError::EmptyFieldUpdate);
         }
+        if departments.len() > MAX_DEPARTMENTS {
+            return Err(ContractError::ConfigLimitExceeded);
+        }
         let old = config.clone();
         config.departments = departments;
         env.storage()
@@ -335,6 +357,9 @@ impl HospitalRegistry {
         if locations.is_empty() && !config.locations.is_empty() {
             return Err(ContractError::EmptyFieldUpdate);
         }
+        if locations.len() > MAX_LOCATIONS {
+            return Err(ContractError::ConfigLimitExceeded);
+        }
         let old = config.clone();
         config.locations = locations;
         env.storage()
@@ -354,6 +379,9 @@ impl HospitalRegistry {
         let mut config = Self::get_hospital_config(env.clone(), wallet.clone())?;
         if equipment.is_empty() && !config.equipment.is_empty() {
             return Err(ContractError::EmptyFieldUpdate);
+        }
+        if equipment.len() > MAX_EQUIPMENT {
+            return Err(ContractError::ConfigLimitExceeded);
         }
         let old = config.clone();
         config.equipment = equipment;

--- a/contracts/hospital-registry/src/test.rs
+++ b/contracts/hospital-registry/src/test.rs
@@ -275,3 +275,163 @@ fn test_hospital_config_flow() {
     let stored_after = client.get_hospital_config(&hospital_wallet);
     assert_eq!(stored_after.departments, updated_departments);
 }
+
+#[test]
+fn test_update_departments_exceeds_limit() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, HospitalRegistry);
+    let client = HospitalRegistryClient::new(&env, &contract_id);
+
+    let hospital_wallet = Address::generate(&env);
+    env.mock_all_auths();
+
+    register_hospital_with_anchor(&env, &client, &hospital_wallet);
+
+    // Initialise an empty config so get_hospital_config succeeds inside update_departments
+    client.set_hospital_config(&hospital_wallet, &HospitalConfig {
+        departments: Vec::new(&env),
+        locations: Vec::new(&env),
+        equipment: Vec::new(&env),
+        policies: Vec::new(&env),
+        alerts: Vec::new(&env),
+        insurance_providers: Vec::new(&env),
+        billing: BillingConfig {
+            currency: String::from_str(&env, "USD"),
+            payment_terms: String::from_str(&env, "Net 30"),
+            tax_id: String::from_str(&env, "TAX-001"),
+        },
+        emergency_protocols: Vec::new(&env),
+    });
+
+    let mut departments: Vec<Department> = Vec::new(&env);
+    for i in 0..=MAX_DEPARTMENTS {
+        departments.push_back(Department {
+            name: String::from_str(&env, "Dept"),
+            head: String::from_str(&env, "Head"),
+            contact: String::from_str(&env, "contact@hospital.org"),
+        });
+        let _ = i;
+    }
+
+    let result = client.try_update_departments(&hospital_wallet, &departments);
+    assert_eq!(result, Err(Ok(ContractError::ConfigLimitExceeded)));
+}
+
+#[test]
+fn test_update_locations_exceeds_limit() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, HospitalRegistry);
+    let client = HospitalRegistryClient::new(&env, &contract_id);
+
+    let hospital_wallet = Address::generate(&env);
+    env.mock_all_auths();
+
+    register_hospital_with_anchor(&env, &client, &hospital_wallet);
+
+    client.set_hospital_config(&hospital_wallet, &HospitalConfig {
+        departments: Vec::new(&env),
+        locations: Vec::new(&env),
+        equipment: Vec::new(&env),
+        policies: Vec::new(&env),
+        alerts: Vec::new(&env),
+        insurance_providers: Vec::new(&env),
+        billing: BillingConfig {
+            currency: String::from_str(&env, "USD"),
+            payment_terms: String::from_str(&env, "Net 30"),
+            tax_id: String::from_str(&env, "TAX-001"),
+        },
+        emergency_protocols: Vec::new(&env),
+    });
+
+    let mut locations: Vec<Location> = Vec::new(&env);
+    for i in 0..=MAX_LOCATIONS {
+        locations.push_back(Location {
+            name: String::from_str(&env, "Loc"),
+            address: String::from_str(&env, "Addr"),
+            metadata: String::from_str(&env, ""),
+        });
+        let _ = i;
+    }
+
+    let result = client.try_update_locations(&hospital_wallet, &locations);
+    assert_eq!(result, Err(Ok(ContractError::ConfigLimitExceeded)));
+}
+
+#[test]
+fn test_update_equipment_exceeds_limit() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, HospitalRegistry);
+    let client = HospitalRegistryClient::new(&env, &contract_id);
+
+    let hospital_wallet = Address::generate(&env);
+    env.mock_all_auths();
+
+    register_hospital_with_anchor(&env, &client, &hospital_wallet);
+
+    client.set_hospital_config(&hospital_wallet, &HospitalConfig {
+        departments: Vec::new(&env),
+        locations: Vec::new(&env),
+        equipment: Vec::new(&env),
+        policies: Vec::new(&env),
+        alerts: Vec::new(&env),
+        insurance_providers: Vec::new(&env),
+        billing: BillingConfig {
+            currency: String::from_str(&env, "USD"),
+            payment_terms: String::from_str(&env, "Net 30"),
+            tax_id: String::from_str(&env, "TAX-001"),
+        },
+        emergency_protocols: Vec::new(&env),
+    });
+
+    let mut equipment: Vec<EquipmentResource> = Vec::new(&env);
+    for i in 0..=MAX_EQUIPMENT {
+        equipment.push_back(EquipmentResource {
+            name: String::from_str(&env, "Item"),
+            quantity: 1,
+            status: String::from_str(&env, "operational"),
+            metadata: String::from_str(&env, ""),
+        });
+        let _ = i;
+    }
+
+    let result = client.try_update_equipment(&hospital_wallet, &equipment);
+    assert_eq!(result, Err(Ok(ContractError::ConfigLimitExceeded)));
+}
+
+#[test]
+fn test_set_hospital_config_exceeds_limits() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, HospitalRegistry);
+    let client = HospitalRegistryClient::new(&env, &contract_id);
+
+    let hospital_wallet = Address::generate(&env);
+    env.mock_all_auths();
+
+    register_hospital_with_anchor(&env, &client, &hospital_wallet);
+
+    let mut locations: Vec<Location> = Vec::new(&env);
+    for i in 0..=MAX_LOCATIONS {
+        locations.push_back(Location {
+            name: String::from_str(&env, "Loc"),
+            address: String::from_str(&env, "Addr"),
+            metadata: String::from_str(&env, ""),
+        });
+        let _ = i;
+    }
+
+    let result = client.try_set_hospital_config(&hospital_wallet, &HospitalConfig {
+        departments: Vec::new(&env),
+        locations,
+        equipment: Vec::new(&env),
+        policies: Vec::new(&env),
+        alerts: Vec::new(&env),
+        insurance_providers: Vec::new(&env),
+        billing: BillingConfig {
+            currency: String::from_str(&env, "USD"),
+            payment_terms: String::from_str(&env, "Net 30"),
+            tax_id: String::from_str(&env, "TAX-001"),
+        },
+        emergency_protocols: Vec::new(&env),
+    });
+    assert_eq!(result, Err(Ok(ContractError::ConfigLimitExceeded)));
+}


### PR DESCRIPTION
Closes #337

## Summary

- Add three named constants at module level:
  - `MAX_DEPARTMENTS: u32 = 200`
  - `MAX_LOCATIONS: u32 = 50`
  - `MAX_EQUIPMENT: u32 = 100`
- Add `ContractError::ConfigLimitExceeded = 7` error variant
- Enforce limits in `set_hospital_config` (departments, locations, and equipment checked before write)
- Enforce limits in `update_departments`, `update_locations`, and `update_equipment` individually
- Add four new tests covering the limit-exceeded path for each vector and for `set_hospital_config`

## Test plan

- [x] `cargo build -p hospital-registry` passes with no errors
- [x] All 11 tests pass: `cargo test -p hospital-registry`
  - `test_update_departments_exceeds_limit`
  - `test_update_locations_exceeds_limit`
  - `test_update_equipment_exceeds_limit`
  - `test_set_hospital_config_exceeds_limits`
  - All 7 pre-existing tests continue to pass