### PR TITLE
test(access-control): add expired consent enforcement test

### DIFF
--- a/contracts/access-control/src/test.rs
+++ b/contracts/access-control/src/test.rs
@@ -641,7 +641,7 @@ fn test_role_expires() {
 
     let env = Env::default();
     env.mock_all_auths();
-    let (admin, client) = setup(&env);
+    let (admin, client) = setup_rbac(&env);
 
     let reviewer = Address::generate(&env);
     // Grant role that expires at timestamp 100.
@@ -659,7 +659,7 @@ fn test_expired_role_can_be_regranted() {
 
     let env = Env::default();
     env.mock_all_auths();
-    let (admin, client) = setup(&env);
+    let (admin, client) = setup_rbac(&env);
 
     let reviewer = Address::generate(&env);
     client.grant_role(&admin, &reviewer, &Role::PayerReviewer, &100);
@@ -676,7 +676,7 @@ fn test_expired_role_can_be_regranted() {
 fn test_get_role_assignment() {
     let env = Env::default();
     env.mock_all_auths();
-    let (admin, client) = setup(&env);
+    let (admin, client) = setup_rbac(&env);
 
     let provider = Address::generate(&env);
     client.grant_role(&admin, &provider, &Role::Provider, &999);
@@ -690,7 +690,7 @@ fn test_get_role_assignment() {
 fn test_get_role_assignment_not_found() {
     let env = Env::default();
     env.mock_all_auths();
-    let (_admin, client) = setup(&env);
+    let (_admin, client) = setup_rbac(&env);
 
     let nobody = Address::generate(&env);
     let result = client.try_get_role_assignment(&nobody, &Role::Auditor);
@@ -703,7 +703,7 @@ fn test_get_role_assignment_not_found() {
 fn test_deactivate_entity_by_admin_role() {
     let env = Env::default();
     env.mock_all_auths();
-    let (admin, client) = setup(&env);
+    let (admin, client) = setup_rbac(&env);
 
     let hospital = Address::generate(&env);
     client.register_entity(
@@ -721,7 +721,7 @@ fn test_deactivate_entity_by_admin_role() {
 fn test_deactivate_entity_by_granted_admin_role() {
     let env = Env::default();
     env.mock_all_auths();
-    let (admin, client) = setup(&env);
+    let (admin, client) = setup_rbac(&env);
 
     // Grant Admin role to a second address.
     let second_admin = Address::generate(&env);
@@ -743,7 +743,7 @@ fn test_deactivate_entity_by_granted_admin_role() {
 fn test_deactivate_entity_non_admin_rejected() {
     let env = Env::default();
     env.mock_all_auths();
-    let (_admin, client) = setup(&env);
+    let (_admin, client) = setup_rbac(&env);
 
     let hospital = Address::generate(&env);
     let non_admin = Address::generate(&env);
@@ -764,7 +764,7 @@ fn test_deactivate_entity_non_admin_rejected() {
 fn test_revoke_access_by_payer_reviewer_role() {
     let env = Env::default();
     env.mock_all_auths();
-    let (admin, client) = setup(&env);
+    let (admin, client) = setup_rbac(&env);
 
     let hospital = Address::generate(&env);
     let doctor = Address::generate(&env);
@@ -784,7 +784,7 @@ fn test_revoke_access_by_payer_reviewer_role() {
     );
 
     let resource = String::from_str(&env, "patient-records");
-    client.grant_access(&hospital, &doctor, &resource, &0);
+    client.grant_access(&hospital, &doctor, &resource, &0, &None);
 
     // Grant PayerReviewer role to payer.
     client.grant_role(&admin, &payer, &Role::PayerReviewer, &0);
@@ -798,7 +798,7 @@ fn test_revoke_access_by_payer_reviewer_role() {
 fn test_revoke_access_by_unprivileged_non_grantor_rejected() {
     let env = Env::default();
     env.mock_all_auths();
-    let (admin, client) = setup(&env);
+    let (admin, client) = setup_rbac(&env);
 
     let hospital = Address::generate(&env);
     let doctor = Address::generate(&env);
@@ -824,7 +824,7 @@ fn test_revoke_access_by_unprivileged_non_grantor_rejected() {
     );
 
     let resource = String::from_str(&env, "patient-records");
-    client.grant_access(&hospital, &doctor, &resource, &0);
+    client.grant_access(&hospital, &doctor, &resource, &0, &None);
 
     // `other` has no role and is not the grantor.
     let result = client.try_revoke_access(&other, &doctor, &resource);
@@ -832,4 +832,36 @@ fn test_revoke_access_by_unprivileged_non_grantor_rejected() {
 
     // Silence unused-variable warning for admin.
     let _ = admin;
+}
+
+// ---------------------------------------------------------------------------
+// #223: consent expiry enforcement
+// ---------------------------------------------------------------------------
+#[test]
+fn test_check_consent_expired() {
+    use soroban_sdk::testutils::Ledger;
+
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let patient = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let purpose = String::from_str(&env, "treatment");
+
+    // Grant consent that expires at ledger timestamp 100.
+    client.grant_consent(
+        &patient,
+        &provider,
+        &0x01u32, // read
+        &purpose,
+        &String::from_str(&env, "explicit_consent"),
+        &100,
+    );
+
+    // Advance ledger past the expiry.
+    env.ledger().set_timestamp(101);
+
+    let result = client.try_check_consent(&patient, &provider, &purpose, &0x01u32);
+    assert_eq!(result, Err(Ok(ContractError::ConsentExpired)));
 }


### PR DESCRIPTION
closes #332 

## Summary

Adds `test_check_consent_expired` to cover the consent expiry code path in `check_consent`. Without this test, any regression in the expiry check would be invisible.

## What the test does

1. Grants consent with `expires_at = 100`
2. Advances the ledger timestamp to `101` (past expiry)
3. Calls `check_consent` and asserts it returns `ConsentExpired`

## Pre-existing compile errors also fixed

The RBAC test section had 20 compile errors that prevented the test suite from building at all:
- `setup(&env)` → `setup_rbac(&env)` in role/deactivate tests (wrong helper called)
- Missing `&None` nonce argument in two `grant_access` calls

Note: `test_deactivate_entity_by_granted_admin_role` still fails — it is a pre-existing logic bug where `deactivate_entity` checks the stored admin address directly rather than the role system. That is out of scope for this PR.

## Testing

`cargo test -p access-control`: **42/43 pass** (the 1 failure is the pre-existing logic bug noted above).