### PR TITLE
fix(access-control): enforce W3C DID method/identifier in validate_did

### DIFF
--- a/contracts/access-control/src/lib.rs
+++ b/contracts/access-control/src/lib.rs
@@ -1034,14 +1034,45 @@ impl AccessControl {
     // -----------------------------------------------------------------------
 
     fn validate_did(did: &Bytes) -> Result<(), ContractError> {
-        if did.len() < 4 {
+        // Minimum: "did:a:b" = 7 bytes
+        if did.len() < 7 {
             return Err(ContractError::InvalidDidFormat);
         }
-        let d = did.get(0).unwrap_or_default();
-        let i = did.get(1).unwrap_or_default();
-        let d2 = did.get(2).unwrap_or_default();
-        let colon = did.get(3).unwrap_or_default();
-        if d != b'd' || i != b'i' || d2 != b'd' || colon != b':' {
+        // Must start with "did:"
+        if did.get(0).unwrap_or_default() != b'd'
+            || did.get(1).unwrap_or_default() != b'i'
+            || did.get(2).unwrap_or_default() != b'd'
+            || did.get(3).unwrap_or_default() != b':'
+        {
+            return Err(ContractError::InvalidDidFormat);
+        }
+        // Find the second colon separating method from identifier.
+        // Method must be [a-z0-9]+ (W3C DID spec §3.1).
+        let mut second_colon: Option<u32> = None;
+        let len = did.len();
+        let mut i = 4u32;
+        while i < len {
+            let ch = did.get(i).unwrap_or_default();
+            if ch == b':' {
+                second_colon = Some(i);
+                break;
+            }
+            // Method chars must be lowercase alpha or digit
+            if !ch.is_ascii_lowercase() && !ch.is_ascii_digit() {
+                return Err(ContractError::InvalidDidFormat);
+            }
+            i += 1;
+        }
+        let method_end = match second_colon {
+            Some(pos) => pos,
+            None => return Err(ContractError::InvalidDidFormat), // no second colon
+        };
+        // Method must be non-empty (method_end > 4)
+        if method_end == 4 {
+            return Err(ContractError::InvalidDidFormat);
+        }
+        // Identifier (everything after the second colon) must be non-empty
+        if method_end + 1 >= len {
             return Err(ContractError::InvalidDidFormat);
         }
         Ok(())

--- a/contracts/access-control/src/test.rs
+++ b/contracts/access-control/src/test.rs
@@ -441,6 +441,83 @@ fn test_register_did_update_replaces_value() {
     assert_eq!(stored, did_v2);
 }
 
+// ---------------------------------------------------------------------------
+// DID format validation — RFC 3986 / W3C DID spec compliance
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_did_missing_method_rejected() {
+    // "did:" with no method segment
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+
+    let result = client.try_register_did(&user, &Bytes::from_slice(&env, b"did:"));
+    assert_eq!(result, Err(Ok(ContractError::InvalidDidFormat)));
+}
+
+#[test]
+fn test_did_empty_method_rejected() {
+    // "did::identifier" — empty method between the two colons
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+
+    let result = client.try_register_did(&user, &Bytes::from_slice(&env, b"did::identifier"));
+    assert_eq!(result, Err(Ok(ContractError::InvalidDidFormat)));
+}
+
+#[test]
+fn test_did_uppercase_method_rejected() {
+    // W3C DID spec §3.1: method must be lowercase
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+
+    let result = client.try_register_did(&user, &Bytes::from_slice(&env, b"did:Stellar:abc"));
+    assert_eq!(result, Err(Ok(ContractError::InvalidDidFormat)));
+}
+
+#[test]
+fn test_did_invalid_char_in_method_rejected() {
+    // Space in method segment
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+
+    let result = client.try_register_did(&user, &Bytes::from_slice(&env, b"did:bad method:id"));
+    assert_eq!(result, Err(Ok(ContractError::InvalidDidFormat)));
+}
+
+#[test]
+fn test_did_missing_identifier_rejected() {
+    // "did:stellar:" — method present but identifier empty
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    client.initialize(&admin);
+
+    let result = client.try_register_did(&user, &Bytes::from_slice(&env, b"did:stellar:"));
+    assert_eq!(result, Err(Ok(ContractError::InvalidDidFormat)));
+}
+
+#[test]
+fn test_did_valid_methods_accepted() {
+    // did:stellar: and did:key: are both valid DID methods
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let u1 = Address::generate(&env);
+    let u2 = Address::generate(&env);
+    client.initialize(&admin);
+
+    client.register_did(&u1, &Bytes::from_slice(&env, b"did:stellar:GABC123"));
+    client.register_did(&u2, &Bytes::from_slice(&env, b"did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK"));
+}
+
 #[test]
 fn test_grant_access_grantor_not_registered() {
     let (env, client) = setup();


### PR DESCRIPTION

closes #331 

## Problem

`validate_did` only checked for the `did:` prefix. DIDs like `did:`, `did::id`, `did:Bad Method:id`, and `did:stellar:` were all accepted without error.

## Changes

**`lib.rs` — `validate_did`**
- Raises minimum length from 4 to 7 bytes (`did:a:b`)
- Scans the method segment and rejects any character outside `[a-z0-9]` (W3C DID spec §3.1)
- Rejects an empty method segment (`did::id`)
- Rejects a missing or empty identifier after the second colon (`did:stellar:`)

**`test.rs` — 6 new tests**

| Test | Input | Expected |
|---|---|---|
| `test_did_missing_method_rejected` | `did:` | `InvalidDidFormat` |
| `test_did_empty_method_rejected` | `did::identifier` | `InvalidDidFormat` |
| `test_did_uppercase_method_rejected` | `did:Stellar:abc` | `InvalidDidFormat` |
| `test_did_invalid_char_in_method_rejected` | `did:bad method:id` | `InvalidDidFormat` |
| `test_did_missing_identifier_rejected` | `did:stellar:` | `InvalidDidFormat` |
| `test_did_valid_methods_accepted` | `did:stellar:…`, `did:key:…` | accepted |

## Testing

`cargo test -p access-control`: **48/49 pass**. The 1 failure (`test_deactivate_entity_by_granted_admin_role`) is a pre-existing logic bug unrelated to this PR.