### PR TITLE
test(financial-records): verify grant/revoke events and post-revocation denial

### DIFF
--- a/contracts/financial-records/src/lib.rs
+++ b/contracts/financial-records/src/lib.rs
@@ -2,7 +2,7 @@
 use shared::privacy::{
     validate_encrypted_ref, validate_policy_metadata, EncryptedEnvelopeRef, PolicyMetadata,
 };
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, vec, Address, Env, Vec};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, symbol_short, vec, Address, Env, Vec};
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -250,14 +250,18 @@ impl FinancialRecordContract {
         owner.require_auth();
         e.storage()
             .persistent()
-            .set(&DataKey::Access(owner, authorized), &true);
+            .set(&DataKey::Access(owner.clone(), authorized.clone()), &true);
+        e.events()
+            .publish((symbol_short!("grant"), owner, authorized), ());
     }
 
     pub fn revoke_access(e: Env, owner: Address, authorized: Address) {
         owner.require_auth();
         e.storage()
             .persistent()
-            .remove(&DataKey::Access(owner, authorized));
+            .remove(&DataKey::Access(owner.clone(), authorized.clone()));
+        e.events()
+            .publish((symbol_short!("revoke"), owner, authorized), ());
     }
 
     fn check_access(e: &Env, caller: &Address, owner: &Address) -> Result<(), ContractError> {

--- a/contracts/financial-records/src/test.rs
+++ b/contracts/financial-records/src/test.rs
@@ -292,3 +292,90 @@ fn test_date_index_unauthorized_returns_typed_error() {
     let result = client.try_get_records_by_date_range(&stranger, &owner, &0, &999, &0, &10);
     assert_eq!(result, Err(Ok(ContractError::AccessDenied)));
 }
+
+// ---------------------------------------------------------------------------
+// Audit trail: event emission and post-revocation denial
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_grant_access_emits_event() {
+    use soroban_sdk::testutils::Events;
+    use soroban_sdk::{IntoVal, Val, Vec as SdkVec};
+
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(FinancialRecordContract, ());
+    let client = FinancialRecordContractClient::new(&e, &contract_id);
+
+    let owner = Address::generate(&e);
+    let auditor = Address::generate(&e);
+
+    client.grant_access(&owner, &auditor);
+
+    let events = e.events().all();
+    let expected_topics: SdkVec<Val> =
+        (Symbol::new(&e, "grant"), owner.clone(), auditor.clone()).into_val(&e);
+    assert!(
+        events
+            .iter()
+            .any(|(_id, topics, _data)| topics == expected_topics),
+        "grant event not emitted"
+    );
+}
+
+#[test]
+fn test_revoke_access_emits_event() {
+    use soroban_sdk::testutils::Events;
+    use soroban_sdk::{IntoVal, Val, Vec as SdkVec};
+
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(FinancialRecordContract, ());
+    let client = FinancialRecordContractClient::new(&e, &contract_id);
+
+    let owner = Address::generate(&e);
+    let auditor = Address::generate(&e);
+
+    client.grant_access(&owner, &auditor);
+    client.revoke_access(&owner, &auditor);
+
+    let events = e.events().all();
+    let expected_topics: SdkVec<Val> =
+        (Symbol::new(&e, "revoke"), owner.clone(), auditor.clone()).into_val(&e);
+    assert!(
+        events
+            .iter()
+            .any(|(_id, topics, _data)| topics == expected_topics),
+        "revoke event not emitted"
+    );
+}
+
+#[test]
+fn test_read_denied_immediately_after_revocation() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(FinancialRecordContract, ());
+    let client = FinancialRecordContractClient::new(&e, &contract_id);
+
+    let owner = Address::generate(&e);
+    let auditor = Address::generate(&e);
+
+    client.add_financial_record(
+        &owner,
+        &RecordType::Invoice,
+        &encrypted_ref(&e, 3),
+        &policy(&e),
+    );
+
+    client.grant_access(&owner, &auditor);
+    // Confirm access works before revocation.
+    assert_eq!(
+        client.get_financial_records(&auditor, &owner, &0, &10).len(),
+        1
+    );
+
+    client.revoke_access(&owner, &auditor);
+    // Access must be denied in the same block — no delay.
+    let result = client.try_get_financial_records(&auditor, &owner, &0, &10);
+    assert_eq!(result, Err(Ok(ContractError::AccessDenied)));
+}


### PR DESCRIPTION
closes #333 

## Problem

`grant_access` and `revoke_access` emitted no events, so the HIPAA audit trail was completely untested. Any regression in access control logging would be invisible.

## Changes

**`lib.rs`**
- `grant_access`: emits event with topics `("grant", owner, authorized)`
- `revoke_access`: emits event with topics `("revoke", owner, authorized)`

**`test.rs`** — 3 new tests

| Test | What it verifies |
|---|---|
| `test_grant_access_emits_event` | The `grant` event is present in the event log after `grant_access` |
| `test_revoke_access_emits_event` | The `revoke` event is present in the event log after `revoke_access` |
| `test_read_denied_immediately_after_revocation` | Access is denied in the same block as revocation — no delay |

## Testing

`cargo test -p financial-records`: **13/13 pass**