### PR TITLE
feat:  add DSMB role and safety-halt approval flow

### DIFF
--- a/contracts/clinical-trial/src/lib.rs
+++ b/contracts/clinical-trial/src/lib.rs
@@ -54,6 +54,18 @@ pub struct SafetyReportSubmitted {
     pub reporting_period: u64,
 }
 
+#[contractevent]
+pub struct SafetyHaltProposed {
+    pub trial_record_id: u64,
+    pub proposed_by: Address,
+}
+
+#[contractevent]
+pub struct SafetyHaltApproved {
+    pub trial_record_id: u64,
+    pub approval_count: u32,
+}
+
 /// Error codes for clinical trial operations
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -79,6 +91,11 @@ pub enum Error {
     AlreadyInitialized = 18,
     WithdrawalRestricted = 19,
     InvalidConsent = 20,
+    NoDsmBoardConfigured = 21,
+    NotDsmBoardMember = 22,
+    SafetyHaltAlreadyActive = 23,
+    NoSafetyHaltPending = 24,
+    AlreadyVoted = 25,
 }
 
 #[contract]
@@ -642,6 +659,131 @@ impl ClinicalTrialContract {
         }
 
         Ok(event)
+    }
+
+    /// Appoint DSMB members for a trial (PI only)
+    pub fn appoint_dsmb(
+        env: Env,
+        trial_record_id: u64,
+        principal_investigator: Address,
+        members: Vec<Address>,
+    ) -> Result<(), Error> {
+        principal_investigator.require_auth();
+
+        let trial = storage::get_trial(&env, trial_record_id)?;
+        if trial.principal_investigator != principal_investigator {
+            return Err(Error::Unauthorized);
+        }
+
+        storage::save_dsmb_members(&env, trial_record_id, &members);
+
+        Ok(())
+    }
+
+    /// Propose a safety halt for a trial (DSMB member only)
+    /// The proposer's vote is automatically counted as the first approval.
+    pub fn propose_safety_halt(
+        env: Env,
+        trial_record_id: u64,
+        dsmb_member: Address,
+        reason_hash: BytesN<32>,
+    ) -> Result<(), Error> {
+        dsmb_member.require_auth();
+
+        let members = storage::get_dsmb_members(&env, trial_record_id)
+            .ok_or(Error::NoDsmBoardConfigured)?;
+        if !members.contains(&dsmb_member) {
+            return Err(Error::NotDsmBoardMember);
+        }
+
+        if let Some(existing) = storage::get_safety_halt(&env, trial_record_id) {
+            if existing.status == types::SafetyHaltStatus::Pending {
+                return Err(Error::SafetyHaltAlreadyActive);
+            }
+        }
+
+        let mut approvals = Vec::new(&env);
+        approvals.push_back(dsmb_member.clone());
+
+        let proposal = types::SafetyHaltProposal {
+            trial_record_id,
+            proposed_by: dsmb_member.clone(),
+            reason_hash,
+            approvals,
+            status: types::SafetyHaltStatus::Pending,
+            proposed_at: env.ledger().timestamp(),
+        };
+
+        storage::save_safety_halt(&env, &proposal);
+
+        SafetyHaltProposed {
+            trial_record_id,
+            proposed_by: dsmb_member,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Cast an approval vote on the pending safety halt (DSMB member only)
+    /// When votes reach majority of the board the trial is suspended and the
+    /// proposal status transitions to Approved.
+    pub fn approve_safety_halt(
+        env: Env,
+        trial_record_id: u64,
+        dsmb_member: Address,
+    ) -> Result<(), Error> {
+        dsmb_member.require_auth();
+
+        let members = storage::get_dsmb_members(&env, trial_record_id)
+            .ok_or(Error::NoDsmBoardConfigured)?;
+        if !members.contains(&dsmb_member) {
+            return Err(Error::NotDsmBoardMember);
+        }
+
+        let mut proposal = storage::get_safety_halt(&env, trial_record_id)
+            .ok_or(Error::NoSafetyHaltPending)?;
+        if proposal.status != types::SafetyHaltStatus::Pending {
+            return Err(Error::NoSafetyHaltPending);
+        }
+
+        if proposal.approvals.contains(&dsmb_member) {
+            return Err(Error::AlreadyVoted);
+        }
+
+        proposal.approvals.push_back(dsmb_member);
+
+        let threshold = members.len() / 2 + 1;
+        if proposal.approvals.len() >= threshold {
+            proposal.status = types::SafetyHaltStatus::Approved;
+
+            let mut trial = storage::get_trial(&env, trial_record_id)?;
+            trial.status = TrialStatus::Suspended;
+            storage::save_trial(&env, &trial);
+
+            SafetyHaltApproved {
+                trial_record_id,
+                approval_count: proposal.approvals.len(),
+            }
+            .publish(&env);
+        }
+
+        storage::save_safety_halt(&env, &proposal);
+
+        Ok(())
+    }
+
+    /// Get the DSMB member list for a trial
+    pub fn get_dsmb_members(env: Env, trial_record_id: u64) -> Result<Vec<Address>, Error> {
+        storage::get_dsmb_members(&env, trial_record_id).ok_or(Error::NoDsmBoardConfigured)
+    }
+
+    /// Get the current safety-halt proposal for a trial, if any
+    pub fn get_safety_halt(
+        env: Env,
+        trial_record_id: u64,
+    ) -> Option<types::SafetyHaltProposal> {
+        storage::get_safety_halt(&env, trial_record_id)
     }
 
     fn evaluate_rule(

--- a/contracts/clinical-trial/src/storage.rs
+++ b/contracts/clinical-trial/src/storage.rs
@@ -3,7 +3,7 @@ use soroban_sdk::{Address, Env, Vec};
 
 use crate::{
     AdverseEventReport, ClinicalTrial, DataKey, EligibilityCriteria, Error,
-    ParticipantEnrollment, ProtocolDeviation, SafetyReport, StudyVisit,
+    ParticipantEnrollment, ProtocolDeviation, SafetyHaltProposal, SafetyReport, StudyVisit,
 };
 
 /// Get the next trial record ID and increment counter
@@ -181,6 +181,34 @@ fn increment_safety_report_count(env: &Env, trial_record_id: u64) {
     let count = get_safety_report_count(env, trial_record_id);
     let key = DataKey::SafetyReport(trial_record_id, u64::MAX);
     env.storage().persistent().set(&key, &(count + 1));
+}
+
+/// Save DSMB member list for a trial
+pub fn save_dsmb_members(env: &Env, trial_record_id: u64, members: &Vec<Address>) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::DsmBoard(trial_record_id), members);
+}
+
+/// Get DSMB member list for a trial
+pub fn get_dsmb_members(env: &Env, trial_record_id: u64) -> Option<Vec<Address>> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::DsmBoard(trial_record_id))
+}
+
+/// Save a safety-halt proposal
+pub fn save_safety_halt(env: &Env, proposal: &SafetyHaltProposal) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::SafetyHalt(proposal.trial_record_id), proposal);
+}
+
+/// Get the current safety-halt proposal for a trial
+pub fn get_safety_halt(env: &Env, trial_record_id: u64) -> Option<SafetyHaltProposal> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SafetyHalt(trial_record_id))
 }
 
 /// Check if patient is already enrolled in trial

--- a/contracts/clinical-trial/src/types.rs
+++ b/contracts/clinical-trial/src/types.rs
@@ -200,6 +200,26 @@ pub struct DataFilters {
     pub date_range_end: Option<u64>,
 }
 
+/// Status of a DSMB safety-halt proposal
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SafetyHaltStatus {
+    Pending,
+    Approved,
+}
+
+/// Safety-halt proposal submitted by a DSMB member
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SafetyHaltProposal {
+    pub trial_record_id: u64,
+    pub proposed_by: Address,
+    pub reason_hash: BytesN<32>,
+    pub approvals: Vec<Address>,
+    pub status: SafetyHaltStatus,
+    pub proposed_at: u64,
+}
+
 /// Storage keys for the contract
 #[contracttype]
 #[derive(Clone)]
@@ -218,4 +238,6 @@ pub enum DataKey {
     ProtocolDeviation(u64, u64),
     SafetyReport(u64, u64),
     PatientRegistry,
+    DsmBoard(u64),
+    SafetyHalt(u64),
 }

--- a/contracts/emergency-medical-info/src/test.rs
+++ b/contracts/emergency-medical-info/src/test.rs
@@ -2,7 +2,7 @@
 #![allow(deprecated)]
 
 use super::*;
-use soroban_sdk::{testutils::Address as _, Env};
+use soroban_sdk::{testutils::Address as _, BytesN, Env, Symbol, Vec};
 
 fn hash(env: &Env, seed: u8) -> BytesN<32> {
     BytesN::from_array(env, &[seed; 32])
@@ -38,7 +38,8 @@ fn test_set_emergency_profile() {
     env.mock_all_auths();
 
     let blood_type = Symbol::new(&env, "O_POS");
-    let allergies = hash(&env, 21);
+    let mut allergies = Vec::new(&env);
+    allergies.push_back(hash(&env, 21));
 
     let mut conditions = Vec::new(&env);
     conditions.push_back(hash(&env, 31));
@@ -83,7 +84,8 @@ fn test_emergency_access_request() {
 
     // Setup emergency profile
     let blood_type = Symbol::new(&env, "AB_NEG");
-    let allergies = hash(&env, 21);
+    let mut allergies = Vec::new(&env);
+    allergies.push_back(hash(&env, 21));
     let conditions = Vec::new(&env);
     let medications = Vec::new(&env);
     let contacts = create_test_emergency_contacts(&env);
@@ -185,7 +187,8 @@ fn test_notify_emergency_contacts() {
 
     // Setup profile with contacts
     let blood_type = Symbol::new(&env, "A_POS");
-    let allergies = hash(&env, 21);
+    let mut allergies = Vec::new(&env);
+    allergies.push_back(hash(&env, 21));
     let conditions = Vec::new(&env);
     let medications = Vec::new(&env);
     let contacts = create_test_emergency_contacts(&env);
@@ -223,7 +226,8 @@ fn test_record_dnr_order() {
 
     // Setup profile first
     let blood_type = Symbol::new(&env, "B_POS");
-    let allergies = hash(&env, 21);
+    let mut allergies = Vec::new(&env);
+    allergies.push_back(hash(&env, 21));
     let conditions = Vec::new(&env);
     let medications = Vec::new(&env);
     let contacts = Vec::new(&env);
@@ -264,10 +268,12 @@ fn test_configured_emergency_contact_can_read_profile() {
     let contact = Address::generate(&env);
     env.mock_all_auths();
 
+    let mut allergy_hashes = Vec::new(&env);
+    allergy_hashes.push_back(hash(&env, 21));
     client.set_emergency_profile(
         &patient,
         &Symbol::new(&env, "O_POS"),
-        &hash(&env, 21),
+        &allergy_hashes,
         &Vec::new(&env),
         &Vec::new(&env),
         &create_test_emergency_contacts(&env),
@@ -293,10 +299,12 @@ fn test_guardian_threshold_rekeys_emergency_profile() {
     let new_owner = Address::generate(&env);
     env.mock_all_auths();
 
+    let mut allergy_hashes = Vec::new(&env);
+    allergy_hashes.push_back(hash(&env, 22));
     client.set_emergency_profile(
         &patient,
         &Symbol::new(&env, "AB_NEG"),
-        &hash(&env, 22),
+        &allergy_hashes,
         &Vec::new(&env),
         &Vec::new(&env),
         &create_test_emergency_contacts(&env),
@@ -326,7 +334,8 @@ fn test_dnr_with_advance_directives() {
     env.mock_all_auths();
 
     let blood_type = Symbol::new(&env, "O_NEG");
-    let allergies = hash(&env, 21);
+    let mut allergies = Vec::new(&env);
+    allergies.push_back(hash(&env, 21));
     let conditions = Vec::new(&env);
     let medications = Vec::new(&env);
     let contacts = Vec::new(&env);
@@ -381,7 +390,8 @@ fn test_emergency_access_audit_trail() {
 
     // Setup profile
     let blood_type = Symbol::new(&env, "A_NEG");
-    let allergies = hash(&env, 21);
+    let mut allergies = Vec::new(&env);
+    allergies.push_back(hash(&env, 21));
     let conditions = Vec::new(&env);
     let medications = Vec::new(&env);
     let contacts = Vec::new(&env);
@@ -434,7 +444,8 @@ fn test_has_emergency_profile() {
 
     // Create profile
     let blood_type = Symbol::new(&env, "O_POS");
-    let allergies = hash(&env, 21);
+    let mut allergies = Vec::new(&env);
+    allergies.push_back(hash(&env, 21));
     let conditions = Vec::new(&env);
     let medications = Vec::new(&env);
     let contacts = Vec::new(&env);
@@ -465,7 +476,8 @@ fn test_comprehensive_emergency_scenario() {
 
     // 1. Setup comprehensive emergency profile
     let blood_type = Symbol::new(&env, "AB_POS");
-    let allergies = hash(&env, 21);
+    let mut allergies = Vec::new(&env);
+    allergies.push_back(hash(&env, 21));
 
     let mut conditions = Vec::new(&env);
     conditions.push_back(hash(&env, 31));


### PR DESCRIPTION
this pr solves two issues 

   - **emergency-medical-info**: Fixed all remaining `hash(&env, N)` call sites in `test.rs` that were passing a bare `BytesN<32>` where `Vec<BytesN<32>>` is required for `critical_allergy_hashes`. Also added missing `BytesN`, `Symbol`, and `Vec` to the test's soroban_sdk import.
   - **clinical-trial**: Added DSMB (Data Safety Monitoring Board) role and a majority-vote safety-halt approval flow.

   ## Changes

   ### emergency-medical-info / `src/test.rs`
   - Added `BytesN`, `Symbol`, `Vec` to the `soroban_sdk` import line.
   - Wrapped all 9 bare `hash(&env, N)` usages for `critical_allergy_hashes` into `Vec::new(&env)` + `push_back(hash(...))`, including two inline call sites that needed a local variable introduced before `set_emergency_profile`.

   ### clinical-trial / `src/types.rs`
   - Added `SafetyHaltStatus` enum (`Pending` / `Approved`).
   - Added `SafetyHaltProposal` struct (proposer, reason hash, approval list, status, timestamp).
   - Added `DsmBoard(u64)` and `SafetyHalt(u64)` storage keys to `DataKey`.

   ### clinical-trial / `src/storage.rs`
   - Added `save_dsmb_members`, `get_dsmb_members`, `save_safety_halt`, `get_safety_halt`.

   ### clinical-trial / `src/lib.rs`
   - Added 5 new error variants: `NoDsmBoardConfigured`, `NotDsmBoardMember`, `SafetyHaltAlreadyActive`, `NoSafetyHaltPending`, `AlreadyVoted`.
   - Added 2 new events: `SafetyHaltProposed`, `SafetyHaltApproved`.
   - Added 4 public contract methods:
     - `appoint_dsmb` — PI appoints board members for a trial.
     - `propose_safety_halt` — any DSMB member opens a halt proposal; proposer's vote is auto-counted.
     - `approve_safety_halt` — other DSMB members vote; once a majority is reached the trial is set to `Suspended` and `SafetyHaltApproved` is emitted.
     - `get_dsmb_members` / `get_safety_halt` — read-only accessors.

   ## Test plan
   - [ ] `cargo check -p emergency-medical-info` passes with no errors
   - [ ] `cargo check -p clinical-trial` passes with no errors
   - [ ] Run `cargo test -p emergency-medical-info` to confirm all existing tests compile and pass
   - [ ] Manually verify DSMB flow: appoint board → propose halt → approve halt (majority) → trial status becomes `Suspended`
   
   
   closes #464
   closes #483