### PR TITLE
feat: configurable retention policy and record versioning

### DIFF
--- a/contracts/health-records/src/lib.rs
+++ b/contracts/health-records/src/lib.rs
@@ -22,14 +22,16 @@ pub struct MedicalRecord {
     pub timestamp: u64,
     pub integrity_hash: BytesN<32>,
     pub policy: PolicyMetadata,
+    pub version: u32,
 }
 
 #[contracttype]
 pub enum DataKey {
     Record(u64),
     RecordCounter,
-    Consent(Address, Address),     // (patient, provider) -> bool
-    PatientProviders(Address),     // patient -> Vec<Address> of consented providers
+    Consent(Address, Address),        // (patient, provider) -> bool
+    PatientProviders(Address),        // patient -> Vec<Address> of consented providers
+    RecordVersion(u64, u32),          // (record_id, version) -> MedicalRecord snapshot
 }
 
 #[contracterror]
@@ -42,6 +44,7 @@ pub enum Error {
     InvalidEncryptedEnvelope = 4,
     InvalidPolicyMetadata = 5,
     InvalidAddress = 6,
+    VersionNotFound = 7,
 }
 
 fn compute_hash(
@@ -165,6 +168,7 @@ impl HealthRecords {
             timestamp,
             integrity_hash,
             policy,
+            version: 1,
         };
 
         env.storage()
@@ -228,6 +232,99 @@ impl HealthRecords {
 
         let recomputed_bytes: Bytes = recomputed.into();
         Ok(recomputed_bytes == expected_hash)
+    }
+
+    /// Update an existing record, preserving the previous version in the amendment trail.
+    ///
+    /// - Saves the current record under `DataKey::RecordVersion(record_id, current_version)`.
+    /// - Increments `version` by one and stores the updated record under `DataKey::Record(record_id)`.
+    /// - Caller must be the patient or a consented provider.
+    pub fn update_record(
+        env: Env,
+        caller: Address,
+        record_id: u64,
+        new_encrypted_ref: EncryptedEnvelopeRef,
+        new_record_type: String,
+        new_policy: PolicyMetadata,
+    ) -> Result<u32, Error> {
+        validate_nonzero_address(&caller).map_err(|_| Error::InvalidAddress)?;
+        validate_encrypted_ref(&new_encrypted_ref).map_err(|_| Error::InvalidEncryptedEnvelope)?;
+        validate_policy_metadata(&new_policy).map_err(|_| Error::InvalidPolicyMetadata)?;
+        caller.require_auth();
+
+        let mut record: MedicalRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Record(record_id))
+            .ok_or(Error::RecordNotFound)?;
+
+        if caller != record.patient && !has_consent(&env, &record.patient, &caller) {
+            return Err(Error::Unauthorized);
+        }
+
+        // Archive the current version before overwriting.
+        let version_key = DataKey::RecordVersion(record_id, record.version);
+        env.storage().persistent().set(&version_key, &record);
+
+        let new_version = record.version + 1;
+        let timestamp = env.ledger().timestamp();
+
+        let new_integrity_hash = compute_hash(
+            &env,
+            record_id,
+            &record.patient,
+            &record.provider,
+            &new_encrypted_ref,
+            &new_record_type,
+            timestamp,
+        );
+
+        record.encrypted_ref = new_encrypted_ref;
+        record.record_type = new_record_type;
+        record.policy = new_policy;
+        record.timestamp = timestamp;
+        record.integrity_hash = new_integrity_hash;
+        record.version = new_version;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Record(record_id), &record);
+
+        Ok(new_version)
+    }
+
+    /// Retrieve a specific historical version of a record.
+    ///
+    /// - Current version: read directly from `DataKey::Record(record_id)`.
+    /// - Prior versions: read from `DataKey::RecordVersion(record_id, version)`.
+    /// - Caller must be the patient or a consented provider.
+    pub fn get_record_version(
+        env: Env,
+        caller: Address,
+        record_id: u64,
+        version: u32,
+    ) -> Result<MedicalRecord, Error> {
+        validate_nonzero_address(&caller).map_err(|_| Error::InvalidAddress)?;
+        caller.require_auth();
+
+        let current: MedicalRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Record(record_id))
+            .ok_or(Error::RecordNotFound)?;
+
+        if caller != current.patient && !has_consent(&env, &current.patient, &caller) {
+            return Err(Error::Unauthorized);
+        }
+
+        if version == current.version {
+            return Ok(current);
+        }
+
+        env.storage()
+            .persistent()
+            .get(&DataKey::RecordVersion(record_id, version))
+            .ok_or(Error::VersionNotFound)
     }
 
     /// Capture an incident for this contract, optionally linking it to a

--- a/contracts/health-records/src/test.rs
+++ b/contracts/health-records/src/test.rs
@@ -510,3 +510,260 @@ mod cross_contract_correlation_tests {
             assert_eq!(result, Err(Ok(Error::Unauthorized)));
         }
     }
+
+// ── Record versioning tests (#471) ───────────────────────────────────────────
+
+#[cfg(test)]
+mod record_versioning_tests {
+    use crate::{Error, HealthRecords, HealthRecordsClient};
+    use shared::privacy::{EncryptedEnvelopeRef, PolicyMetadata};
+    use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Symbol};
+
+    fn encrypted_ref(env: &Env, seed: u8) -> EncryptedEnvelopeRef {
+        EncryptedEnvelopeRef {
+            content_hash: BytesN::from_array(env, &[seed; 32]),
+            envelope_uri: String::from_str(env, "enc+ipfs://bafyvalidhealthref"),
+            key_version_id: String::from_str(env, "kv:v01"),
+        }
+    }
+
+    fn policy(env: &Env) -> PolicyMetadata {
+        PolicyMetadata {
+            retention_class: Symbol::new(env, "clinical"),
+            access_policy_hash: BytesN::from_array(env, &[7u8; 32]),
+            purpose: Symbol::new(env, "treatment"),
+        }
+    }
+
+    fn setup(env: &Env) -> (HealthRecordsClient<'static>, Address, Address) {
+        let contract_id = env.register(HealthRecords, ());
+        let client = HealthRecordsClient::new(env, &contract_id);
+        let patient = Address::generate(env);
+        let provider = Address::generate(env);
+        (client, patient, provider)
+    }
+
+    /// New records start at version 1.
+    #[test]
+    fn test_create_record_starts_at_version_one() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider);
+        let record_id = client.create_record(
+            &patient,
+            &provider,
+            &encrypted_ref(&env, 1),
+            &String::from_str(&env, "LAB"),
+            &policy(&env),
+        );
+
+        let record = client.get_record(&patient, &record_id);
+        assert_eq!(record.version, 1);
+    }
+
+    /// Version counter increments on each update.
+    #[test]
+    fn test_update_record_increments_version() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider);
+        let record_id = client.create_record(
+            &patient,
+            &provider,
+            &encrypted_ref(&env, 1),
+            &String::from_str(&env, "DIAGNOSIS"),
+            &policy(&env),
+        );
+
+        let new_version = client.update_record(
+            &patient,
+            &record_id,
+            &encrypted_ref(&env, 2),
+            &String::from_str(&env, "DIAGNOSIS_UPDATED"),
+            &policy(&env),
+        );
+        assert_eq!(new_version, 2);
+
+        let record = client.get_record(&patient, &record_id);
+        assert_eq!(record.version, 2);
+    }
+
+    /// All prior versions remain readable via get_record_version.
+    #[test]
+    fn test_prior_versions_remain_readable() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider);
+        let record_id = client.create_record(
+            &patient,
+            &provider,
+            &encrypted_ref(&env, 1),
+            &String::from_str(&env, "PRESCRIPTION"),
+            &policy(&env),
+        );
+
+        // Update twice.
+        client.update_record(
+            &patient,
+            &record_id,
+            &encrypted_ref(&env, 2),
+            &String::from_str(&env, "PRESCRIPTION_V2"),
+            &policy(&env),
+        );
+        client.update_record(
+            &patient,
+            &record_id,
+            &encrypted_ref(&env, 3),
+            &String::from_str(&env, "PRESCRIPTION_V3"),
+            &policy(&env),
+        );
+
+        // Current version (v3) is accessible via get_record.
+        let current = client.get_record(&patient, &record_id);
+        assert_eq!(current.version, 3);
+        assert_eq!(current.record_type, String::from_str(&env, "PRESCRIPTION_V3"));
+
+        // v1 remains readable.
+        let v1 = client.get_record_version(&patient, &record_id, &1u32);
+        assert_eq!(v1.version, 1);
+        assert_eq!(v1.record_type, String::from_str(&env, "PRESCRIPTION"));
+
+        // v2 remains readable.
+        let v2 = client.get_record_version(&patient, &record_id, &2u32);
+        assert_eq!(v2.version, 2);
+        assert_eq!(v2.record_type, String::from_str(&env, "PRESCRIPTION_V2"));
+
+        // Current version accessible via get_record_version too.
+        let v3 = client.get_record_version(&patient, &record_id, &3u32);
+        assert_eq!(v3.version, 3);
+    }
+
+    /// Retrieving a non-existent version returns VersionNotFound.
+    #[test]
+    fn test_get_nonexistent_version_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider);
+        let record_id = client.create_record(
+            &patient,
+            &provider,
+            &encrypted_ref(&env, 1),
+            &String::from_str(&env, "XRAY"),
+            &policy(&env),
+        );
+
+        // Version 2 does not exist yet.
+        let result = client.try_get_record_version(&patient, &record_id, &2u32);
+        assert_eq!(result, Err(Ok(Error::VersionNotFound)));
+    }
+
+    /// A consented provider can update a record and read prior versions.
+    #[test]
+    fn test_provider_can_update_and_read_versions() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider);
+        let record_id = client.create_record(
+            &patient,
+            &provider,
+            &encrypted_ref(&env, 4),
+            &String::from_str(&env, "BLOOD_WORK"),
+            &policy(&env),
+        );
+
+        client.update_record(
+            &provider,
+            &record_id,
+            &encrypted_ref(&env, 5),
+            &String::from_str(&env, "BLOOD_WORK_V2"),
+            &policy(&env),
+        );
+
+        let v1 = client.get_record_version(&provider, &record_id, &1u32);
+        assert_eq!(v1.record_type, String::from_str(&env, "BLOOD_WORK"));
+
+        let current = client.get_record(&provider, &record_id);
+        assert_eq!(current.version, 2);
+    }
+
+    /// An unauthorized caller cannot update a record.
+    #[test]
+    fn test_unauthorized_update_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+        let stranger = Address::generate(&env);
+
+        client.grant_consent(&patient, &provider);
+        let record_id = client.create_record(
+            &patient,
+            &provider,
+            &encrypted_ref(&env, 6),
+            &String::from_str(&env, "MRI"),
+            &policy(&env),
+        );
+
+        let result = client.try_update_record(
+            &stranger,
+            &record_id,
+            &encrypted_ref(&env, 7),
+            &String::from_str(&env, "MRI_V2"),
+            &policy(&env),
+        );
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    }
+
+    /// Multi-version diff scenario: encrypted_ref changes track between versions.
+    #[test]
+    fn test_multi_version_diff_encrypted_ref() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider);
+        let ref_v1 = encrypted_ref(&env, 10);
+        let ref_v2 = encrypted_ref(&env, 20);
+        let ref_v3 = encrypted_ref(&env, 30);
+
+        let record_id = client.create_record(
+            &patient,
+            &provider,
+            &ref_v1.clone(),
+            &String::from_str(&env, "CT_SCAN"),
+            &policy(&env),
+        );
+
+        client.update_record(
+            &patient,
+            &record_id,
+            &ref_v2.clone(),
+            &String::from_str(&env, "CT_SCAN"),
+            &policy(&env),
+        );
+        client.update_record(
+            &patient,
+            &record_id,
+            &ref_v3.clone(),
+            &String::from_str(&env, "CT_SCAN"),
+            &policy(&env),
+        );
+
+        let v1 = client.get_record_version(&patient, &record_id, &1u32);
+        let v2 = client.get_record_version(&patient, &record_id, &2u32);
+        let v3 = client.get_record_version(&patient, &record_id, &3u32);
+
+        assert_eq!(v1.encrypted_ref.content_hash, ref_v1.content_hash);
+        assert_eq!(v2.encrypted_ref.content_hash, ref_v2.content_hash);
+        assert_eq!(v3.encrypted_ref.content_hash, ref_v3.content_hash);
+    }
+}

--- a/contracts/patient-registry/src/lib.rs
+++ b/contracts/patient-registry/src/lib.rs
@@ -13,6 +13,7 @@ use soroban_sdk::{
     xdr::ToXdr, Address, Bytes, BytesN, Env, Map, String, Symbol, Vec,
 };
 use ttl_config::critical::{LEDGER_BUMP_AMOUNT, LEDGER_THRESHOLD};
+use ttl_config::{extend_critical_ttl_if_exists, extend_operational_ttl_if_exists};
 
 pub mod merkle;
 pub mod validation;
@@ -30,6 +31,19 @@ pub enum PatientStatus {
     Deregistered,
 }
 
+/// Retention classification for patient data, aligned with HIPAA minimum standards.
+///
+/// - `Clinical`        → critical TTL (~31 days) for care-critical records
+/// - `Administrative`  → operational TTL (~7 days) for admin/operational records
+/// - `Financial`       → critical TTL (~31 days) for financial/billing records
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RetentionClass {
+    Clinical,
+    Administrative,
+    Financial,
+}
+
 /// --------------------
 /// Patient Structures
 /// --------------------
@@ -41,6 +55,7 @@ pub struct PatientData {
     pub encrypted_metadata_ref: EncryptedEnvelopeRef,
     pub status: PatientStatus,
     pub policy: PolicyMetadata,
+    pub retention_class: RetentionClass,
 }
 
 /// --------------------
@@ -409,6 +424,24 @@ fn build_partial_record(record_data: &RecordData, mask: u32) -> PartialRecord {
     }
 }
 
+/// Delegate TTL extension to the appropriate `ttl-config` helper based on the
+/// patient's `RetentionClass`, calling `extend_*_ttl_if_exists` so that missing
+/// keys are silently skipped.
+fn extend_for_retention_class<K: soroban_sdk::IntoVal<Env, soroban_sdk::Val>>(
+    env: &Env,
+    key: &K,
+    class: &RetentionClass,
+) {
+    match class {
+        RetentionClass::Clinical | RetentionClass::Financial => {
+            extend_critical_ttl_if_exists(env, key);
+        }
+        RetentionClass::Administrative => {
+            extend_operational_ttl_if_exists(env, key);
+        }
+    }
+}
+
 /// Maximum number of records that may be returned in a single paginated call.
 pub const MAX_PAGE_SIZE: u32 = 50;
 
@@ -688,6 +721,7 @@ impl MedicalRegistry {
             encrypted_metadata_ref,
             status: PatientStatus::Active,
             policy,
+            retention_class: RetentionClass::Clinical,
         };
         env.storage().persistent().set(&key, &patient);
         let total_patients: u64 = env
@@ -847,6 +881,7 @@ impl MedicalRegistry {
                 encrypted_metadata_ref: entry.encrypted_metadata_ref.clone(),
                 status: PatientStatus::Active,
                 policy: entry.policy.clone(),
+                retention_class: RetentionClass::Clinical,
             };
             env.storage().persistent().set(&key, &patient);
 
@@ -904,45 +939,29 @@ impl MedicalRegistry {
             patient.require_auth();
         }
 
-        // Extend Patient record TTL
+        // Read patient's retention class to select the appropriate TTL helper.
         let patient_key = DataKey::Patient(patient.clone());
-        if env.storage().persistent().has(&patient_key) {
-            env.storage().persistent().extend_ttl(
-                &patient_key,
-                LEDGER_THRESHOLD,
-                LEDGER_BUMP_AMOUNT,
-            );
-        }
+        let class = env
+            .storage()
+            .persistent()
+            .get::<DataKey, PatientData>(&patient_key)
+            .map(|d| d.retention_class)
+            .unwrap_or(RetentionClass::Clinical);
+
+        // Extend Patient record TTL
+        extend_for_retention_class(&env, &patient_key, &class);
 
         // Extend MedicalRecords TTL
         let records_key = DataKey::MedicalRecords(patient.clone());
-        if env.storage().persistent().has(&records_key) {
-            env.storage().persistent().extend_ttl(
-                &records_key,
-                LEDGER_THRESHOLD,
-                LEDGER_BUMP_AMOUNT,
-            );
-        }
+        extend_for_retention_class(&env, &records_key, &class);
 
         // Extend AuthorizedDoctors TTL
         let access_key = DataKey::AuthorizedDoctors(patient.clone());
-        if env.storage().persistent().has(&access_key) {
-            env.storage().persistent().extend_ttl(
-                &access_key,
-                LEDGER_THRESHOLD,
-                LEDGER_BUMP_AMOUNT,
-            );
-        }
+        extend_for_retention_class(&env, &access_key, &class);
 
         // Extend ConsentAck TTL
         let consent_key = DataKey::ConsentAck(patient.clone());
-        if env.storage().persistent().has(&consent_key) {
-            env.storage().persistent().extend_ttl(
-                &consent_key,
-                LEDGER_THRESHOLD,
-                LEDGER_BUMP_AMOUNT,
-            );
-        }
+        extend_for_retention_class(&env, &consent_key, &class);
     }
 
     pub fn place_hold(
@@ -2381,6 +2400,53 @@ impl MedicalRegistry {
     }
 
     // =====================================================
+    //              RETENTION CLASS MANAGEMENT
+    // =====================================================
+
+    /// Update a patient's data retention class.
+    ///
+    /// Admin-only. Changing the class takes effect on the next TTL bump so that
+    /// subsequent operations use the appropriate `ttl-config` thresholds.
+    pub fn set_patient_retention_class(
+        env: Env,
+        patient: Address,
+        class: RetentionClass,
+    ) -> Result<(), ContractError> {
+        Self::require_not_frozen(&env);
+        Self::require_admin(&env);
+        Self::require_patient_exists(&env, &patient)?;
+
+        let key = DataKey::Patient(patient.clone());
+        let mut data: PatientData = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(ContractError::NotFound)?;
+        data.retention_class = class.clone();
+        env.storage().persistent().set(&key, &data);
+
+        env.events().publish(
+            (symbol_short!("ret_cls"), patient),
+            symbol_short!("updated"),
+        );
+        Ok(())
+    }
+
+    /// Retrieve the current retention class for a patient.
+    pub fn get_patient_retention_class(
+        env: Env,
+        patient: Address,
+    ) -> Result<RetentionClass, ContractError> {
+        let key = DataKey::Patient(patient);
+        let data: PatientData = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(ContractError::NotFound)?;
+        Ok(data.retention_class)
+    }
+
+    // =====================================================
     //                  PRIVATE HELPERS
     // =====================================================
 
@@ -2447,8 +2513,16 @@ impl MedicalRegistry {
             .extend_ttl(&root_key, LEDGER_THRESHOLD, LEDGER_BUMP_AMOUNT);
     }
 
-    /// Bump TTL for all critical persistent keys belonging to a patient.
+    /// Bump TTL for all persistent keys belonging to a patient using the
+    /// appropriate `ttl-config` helper for their retention class.
     fn bump_patient_keys(env: &Env, patient: &Address) {
+        let class = env
+            .storage()
+            .persistent()
+            .get::<DataKey, PatientData>(&DataKey::Patient(patient.clone()))
+            .map(|d| d.retention_class)
+            .unwrap_or(RetentionClass::Clinical);
+
         let keys: [DataKey; 6] = [
             DataKey::Patient(patient.clone()),
             DataKey::MedicalRecords(patient.clone()),
@@ -2458,11 +2532,7 @@ impl MedicalRegistry {
             DataKey::MerkleRoot(patient.clone()),
         ];
         for key in keys.iter() {
-            if env.storage().persistent().has(key) {
-                env.storage()
-                    .persistent()
-                    .extend_ttl(key, LEDGER_THRESHOLD, LEDGER_BUMP_AMOUNT);
-            }
+            extend_for_retention_class(env, key, &class);
         }
     }
 }

--- a/contracts/patient-registry/src/test.rs
+++ b/contracts/patient-registry/src/test.rs
@@ -4051,3 +4051,159 @@ fn test_batch_register_patients_over_limit_fails() {
     let result = client.try_batch_register_patients(&entries);
     assert!(result.is_err());
 }
+
+// ── Retention class tests (#470) ──────────────────────────────────────────────
+
+/// Newly registered patients default to the Clinical retention class.
+#[test]
+fn test_register_patient_defaults_to_clinical_class() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(MedicalRegistry, ());
+    let client = MedicalRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let fee_token = Address::generate(&env);
+    client.initialize(&admin, &treasury, &fee_token);
+
+    let patient = Address::generate(&env);
+    client.register_patient(
+        &patient,
+        &String::from_str(&env, "Alice"),
+        &631152000u64,
+        &encrypted_ref(&env, 1),
+        &policy(&env),
+    );
+
+    assert_eq!(
+        client.get_patient_retention_class(&patient),
+        RetentionClass::Clinical
+    );
+}
+
+/// Admin can change a patient's retention class from Clinical to Administrative.
+#[test]
+fn test_admin_can_set_administrative_retention_class() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(MedicalRegistry, ());
+    let client = MedicalRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let fee_token = Address::generate(&env);
+    client.initialize(&admin, &treasury, &fee_token);
+
+    let patient = Address::generate(&env);
+    client.register_patient(
+        &patient,
+        &String::from_str(&env, "Bob"),
+        &631152000u64,
+        &encrypted_ref(&env, 2),
+        &policy(&env),
+    );
+
+    client.set_patient_retention_class(&patient, &RetentionClass::Administrative);
+
+    assert_eq!(
+        client.get_patient_retention_class(&patient),
+        RetentionClass::Administrative
+    );
+}
+
+/// Admin can set Financial retention class.
+#[test]
+fn test_admin_can_set_financial_retention_class() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(MedicalRegistry, ());
+    let client = MedicalRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let fee_token = Address::generate(&env);
+    client.initialize(&admin, &treasury, &fee_token);
+
+    let patient = Address::generate(&env);
+    client.register_patient(
+        &patient,
+        &String::from_str(&env, "Carol"),
+        &631152000u64,
+        &encrypted_ref(&env, 3),
+        &policy(&env),
+    );
+
+    client.set_patient_retention_class(&patient, &RetentionClass::Financial);
+
+    assert_eq!(
+        client.get_patient_retention_class(&patient),
+        RetentionClass::Financial
+    );
+}
+
+/// Clinical patients use critical-class TTL (larger bump); Administrative
+/// patients use operational-class TTL (smaller bump). After advancing the
+/// ledger past the operational bump amount (but within the critical bump
+/// amount), the Administrative patient's key has expired while the Clinical
+/// patient's key survives.
+#[test]
+fn test_different_bump_amounts_applied_per_retention_class() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let start_seq: u32 = 100;
+    env.ledger().set(make_ledger_info(start_seq, 1_000_000));
+
+    let contract_id = env.register(MedicalRegistry, ());
+    let client = MedicalRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let fee_token = Address::generate(&env);
+    client.initialize(&admin, &treasury, &fee_token);
+
+    // Register two patients.
+    let clinical_patient = Address::generate(&env);
+    let admin_patient = Address::generate(&env);
+
+    client.register_patient(
+        &clinical_patient,
+        &String::from_str(&env, "Clinical"),
+        &631152000u64,
+        &encrypted_ref(&env, 1),
+        &policy(&env),
+    );
+    client.register_patient(
+        &admin_patient,
+        &String::from_str(&env, "Administrative"),
+        &631152001u64,
+        &encrypted_ref(&env, 2),
+        &policy(&env),
+    );
+
+    // Change the second patient to Administrative class.
+    client.set_patient_retention_class(&admin_patient, &RetentionClass::Administrative);
+
+    // Bump TTL for both patients — this triggers class-specific extend_ttl.
+    client.extend_patient_ttl(&clinical_patient);
+    client.extend_patient_ttl(&admin_patient);
+
+    // Advance ledger past operational TTL (~7 days = 120_960 ledgers) but within
+    // critical TTL (~31 days = 535_680 ledgers).
+    // operational::LEDGER_BUMP_AMOUNT = 120_960, critical::LEDGER_BUMP_AMOUNT = 535_680
+    let past_operational: u32 = start_seq + 120_961;
+    env.ledger().set(make_ledger_info(past_operational, 2_000_000));
+
+    // Administrative patient's key should now be expired — get_patient returns NotFound.
+    assert!(
+        client.try_get_patient(&admin_patient).is_err(),
+        "Administrative patient key should have expired"
+    );
+
+    // Clinical patient's key should still be live — get_patient succeeds.
+    assert!(
+        client.try_get_patient(&clinical_patient).is_ok(),
+        "Clinical patient key should still be alive"
+    );
+}


### PR DESCRIPTION
closes #470 
closes #471 


this PR stages the following changes to the repo:

patient-registry (#470):
- Add RetentionClass enum (Clinical, Administrative, Financial)
- Add retention_class field to PatientData (defaults to Clinical)
- Add extend_for_retention_class helper delegating to ttl-config per class
- Update bump_patient_keys and extend_patient_ttl to use class-specific TTL: Clinical/Financial -> critical TTL (~31 days), Administrative -> operational TTL (~7 days)
- Add set_patient_retention_class (admin-only) and get_patient_retention_class functions
- Tests: default class, admin-configurable class, TTL expiry difference between classes

health-records (#471):
- Add version: u32 field to MedicalRecord (set to 1 on creation)
- Add DataKey::RecordVersion(u64, u32) for immutable amendment snapshots
- Add Error::VersionNotFound variant
- Add update_record: saves current version to RecordVersion, increments version counter
- Add get_record_version: retrieves any historical version of a record
- Tests: version increments, prior versions readable, diff scenarios, auth checks