### PR TITLE
feat(health-records): add batch record creation and granular consent scope

### DIFF
--- a/contracts/health-records/src/lib.rs
+++ b/contracts/health-records/src/lib.rs
@@ -11,6 +11,33 @@ use soroban_sdk::{
     String, Vec,
 };
 
+/// Maximum number of records allowed in a single `create_records_batch` call.
+pub const MAX_BATCH_SIZE: u32 = 10;
+
+/// Per-provider consent scope granted by a patient.
+///
+/// `expires_at == 0` is treated as "never expires".
+/// Any non-zero value is compared against the current ledger timestamp;
+/// if `expires_at <= timestamp` the consent is considered expired.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConsentScope {
+    pub can_read: bool,
+    pub can_write: bool,
+    pub can_share: bool,
+    pub expires_at: u64,
+}
+
+/// Input record for `create_records_batch`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RecordInput {
+    pub patient: Address,
+    pub encrypted_ref: EncryptedEnvelopeRef,
+    pub record_type: String,
+    pub policy: PolicyMetadata,
+}
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MedicalRecord {
@@ -28,7 +55,7 @@ pub struct MedicalRecord {
 pub enum DataKey {
     Record(u64),
     RecordCounter,
-    Consent(Address, Address),     // (patient, provider) -> bool
+    Consent(Address, Address),     // (patient, provider) -> ConsentScope
     PatientProviders(Address),     // patient -> Vec<Address> of consented providers
 }
 
@@ -42,6 +69,7 @@ pub enum Error {
     InvalidEncryptedEnvelope = 4,
     InvalidPolicyMetadata = 5,
     InvalidAddress = 6,
+    BatchTooLarge = 7,
 }
 
 fn compute_hash(
@@ -66,11 +94,20 @@ fn compute_hash(
     env.crypto().sha256(&data).into()
 }
 
-fn has_consent(env: &Env, patient: &Address, provider: &Address) -> bool {
-    env.storage()
+/// Returns the active `ConsentScope` for `(patient, provider)`, or `None` if
+/// no consent exists or the consent has expired.
+fn get_active_consent(env: &Env, patient: &Address, provider: &Address) -> Option<ConsentScope> {
+    let scope: Option<ConsentScope> = env
+        .storage()
         .persistent()
-        .get(&DataKey::Consent(patient.clone(), provider.clone()))
-        .unwrap_or(false)
+        .get(&DataKey::Consent(patient.clone(), provider.clone()));
+    scope.and_then(|s| {
+        if s.expires_at == 0 || s.expires_at > env.ledger().timestamp() {
+            Some(s)
+        } else {
+            None
+        }
+    })
 }
 
 #[contract]
@@ -78,25 +115,32 @@ pub struct HealthRecords;
 
 #[contractimpl]
 impl HealthRecords {
-    /// Patient grants a provider consent to create/access their records.
-    pub fn grant_consent(env: Env, patient: Address, provider: Address) -> Result<(), Error> {
+    /// Patient grants a provider scoped consent to act on their records.
+    ///
+    /// `scope.expires_at == 0` means the consent never expires.
+    pub fn grant_consent(
+        env: Env,
+        patient: Address,
+        provider: Address,
+        scope: ConsentScope,
+    ) -> Result<(), Error> {
         validate_nonzero_address(&patient).map_err(|_| Error::InvalidAddress)?;
         validate_nonzero_address(&provider).map_err(|_| Error::InvalidAddress)?;
         patient.require_auth();
         env.storage()
             .persistent()
-            .set(&DataKey::Consent(patient, provider), &true);
+            .set(&DataKey::Consent(patient, provider), &scope);
         Ok(())
     }
 
-    /// Patient revokes a provider's consent.
+    /// Patient revokes all consent for a provider.
     pub fn revoke_consent(env: Env, patient: Address, provider: Address) -> Result<(), Error> {
         validate_nonzero_address(&patient).map_err(|_| Error::InvalidAddress)?;
         validate_nonzero_address(&provider).map_err(|_| Error::InvalidAddress)?;
         patient.require_auth();
         env.storage()
             .persistent()
-            .set(&DataKey::Consent(patient, provider), &false);
+            .remove(&DataKey::Consent(patient, provider));
         Ok(())
     }
 
@@ -121,7 +165,7 @@ impl HealthRecords {
         env.storage().persistent().remove(&idx_key);
     }
 
-    /// Create a record. Requires both patient and provider auth, plus prior patient consent.
+    /// Create a record. Requires both patient and provider auth, plus active write consent.
     pub fn create_record(
         env: Env,
         patient: Address,
@@ -137,8 +181,10 @@ impl HealthRecords {
         validate_encrypted_ref(&encrypted_ref).map_err(|_| Error::InvalidEncryptedEnvelope)?;
         validate_policy_metadata(&policy).map_err(|_| Error::InvalidPolicyMetadata)?;
 
-        if !has_consent(&env, &patient, &provider) {
-            return Err(Error::ConsentNotGranted);
+        match get_active_consent(&env, &patient, &provider) {
+            None => return Err(Error::ConsentNotGranted),
+            Some(s) if !s.can_write => return Err(Error::Unauthorized),
+            _ => {}
         }
 
         let counter_key = DataKey::RecordCounter;
@@ -174,7 +220,73 @@ impl HealthRecords {
         Ok(record_id)
     }
 
-    /// Retrieve a record. Caller must be the patient or a consented provider.
+    /// Create multiple records in one transaction.
+    ///
+    /// Only the provider needs to auth; per-patient write consent is checked
+    /// individually for each `RecordInput`. Returns record IDs in input order.
+    /// Enforces `MAX_BATCH_SIZE` (10) — returns `BatchTooLarge` if exceeded.
+    pub fn create_records_batch(
+        env: Env,
+        provider: Address,
+        records: Vec<RecordInput>,
+    ) -> Result<Vec<u64>, Error> {
+        validate_nonzero_address(&provider).map_err(|_| Error::InvalidAddress)?;
+        provider.require_auth();
+
+        if records.len() > MAX_BATCH_SIZE {
+            return Err(Error::BatchTooLarge);
+        }
+
+        let mut ids: Vec<u64> = Vec::new(&env);
+        let timestamp = env.ledger().timestamp();
+
+        for input in records.iter() {
+            validate_nonzero_address(&input.patient).map_err(|_| Error::InvalidAddress)?;
+            validate_encrypted_ref(&input.encrypted_ref)
+                .map_err(|_| Error::InvalidEncryptedEnvelope)?;
+            validate_policy_metadata(&input.policy).map_err(|_| Error::InvalidPolicyMetadata)?;
+
+            match get_active_consent(&env, &input.patient, &provider) {
+                None => return Err(Error::ConsentNotGranted),
+                Some(s) if !s.can_write => return Err(Error::Unauthorized),
+                _ => {}
+            }
+
+            let counter_key = DataKey::RecordCounter;
+            let record_id: u64 = shared_contracts::safe_increment_persistent(&env, &counter_key);
+
+            let integrity_hash = compute_hash(
+                &env,
+                record_id,
+                &input.patient,
+                &provider,
+                &input.encrypted_ref,
+                &input.record_type,
+                timestamp,
+            );
+
+            let record = MedicalRecord {
+                record_id,
+                patient: input.patient.clone(),
+                provider: provider.clone(),
+                encrypted_ref: input.encrypted_ref.clone(),
+                record_type: input.record_type.clone(),
+                timestamp,
+                integrity_hash,
+                policy: input.policy.clone(),
+            };
+
+            env.storage()
+                .persistent()
+                .set(&DataKey::Record(record_id), &record);
+
+            ids.push_back(record_id);
+        }
+
+        Ok(ids)
+    }
+
+    /// Retrieve a record. Caller must be the patient or have active read consent.
     pub fn get_record(env: Env, caller: Address, record_id: u64) -> Result<MedicalRecord, Error> {
         validate_nonzero_address(&caller).map_err(|_| Error::InvalidAddress)?;
         caller.require_auth();
@@ -185,14 +297,18 @@ impl HealthRecords {
             .get(&DataKey::Record(record_id))
             .ok_or(Error::RecordNotFound)?;
 
-        if caller != record.patient && !has_consent(&env, &record.patient, &caller) {
-            return Err(Error::Unauthorized);
+        if caller != record.patient {
+            match get_active_consent(&env, &record.patient, &caller) {
+                None => return Err(Error::Unauthorized),
+                Some(s) if !s.can_read => return Err(Error::Unauthorized),
+                _ => {}
+            }
         }
 
         Ok(record)
     }
 
-    /// Verify integrity. Caller must be the patient or a consented provider.
+    /// Verify integrity. Caller must be the patient or have active read consent.
     pub fn verify_record_integrity(
         env: Env,
         caller: Address,
@@ -208,8 +324,12 @@ impl HealthRecords {
                 None => return Ok(false),
             };
 
-        if caller != record.patient && !has_consent(&env, &record.patient, &caller) {
-            return Err(Error::Unauthorized);
+        if caller != record.patient {
+            match get_active_consent(&env, &record.patient, &caller) {
+                None => return Err(Error::Unauthorized),
+                Some(s) if !s.can_read => return Err(Error::Unauthorized),
+                _ => {}
+            }
         }
 
         if expected_hash.len() != 32 {

--- a/contracts/health-records/src/test.rs
+++ b/contracts/health-records/src/test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::{Error, HealthRecords, HealthRecordsClient};
+    use crate::{ConsentScope, Error, HealthRecords, HealthRecordsClient};
     use patient_registry::{MedicalRegistry, MedicalRegistryClient};
     use provider_registry::{ProviderRegistry, ProviderRegistryClient};
     use shared::privacy::{EncryptedEnvelopeRef, PolicyMetadata};
@@ -30,13 +30,22 @@ mod tests {
         (client, patient, provider)
     }
 
+    fn full_scope() -> ConsentScope {
+        ConsentScope {
+            can_read: true,
+            can_write: true,
+            can_share: true,
+            expires_at: 0,
+        }
+    }
+
     #[test]
     fn test_create_record_with_consent() {
         let env = Env::default();
         env.mock_all_auths();
         let (client, patient, provider) = setup(&env);
 
-        client.grant_consent(&patient, &provider);
+        client.grant_consent(&patient, &provider, &full_scope());
 
         let reference = encrypted_ref(&env, 1);
         let rtype = String::from_str(&env, "LAB_RESULT");
@@ -70,7 +79,7 @@ mod tests {
         env.mock_all_auths();
         let (client, patient, provider) = setup(&env);
 
-        client.grant_consent(&patient, &provider);
+        client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
         let rtype = String::from_str(&env, "PRESCRIPTION");
         let record_id =
@@ -86,7 +95,7 @@ mod tests {
         env.mock_all_auths();
         let (client, patient, provider) = setup(&env);
 
-        client.grant_consent(&patient, &provider);
+        client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
         let rtype = String::from_str(&env, "DIAGNOSIS");
         let record_id =
@@ -103,7 +112,7 @@ mod tests {
         let (client, patient, provider) = setup(&env);
         let stranger = Address::generate(&env);
 
-        client.grant_consent(&patient, &provider);
+        client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
         let rtype = String::from_str(&env, "XRAY");
         let record_id =
@@ -119,7 +128,7 @@ mod tests {
         env.mock_all_auths();
         let (client, patient, provider) = setup(&env);
 
-        client.grant_consent(&patient, &provider);
+        client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
         let rtype = String::from_str(&env, "LAB");
         let record_id =
@@ -137,7 +146,7 @@ mod tests {
         env.mock_all_auths();
         let (client, patient, provider) = setup(&env);
 
-        client.grant_consent(&patient, &provider);
+        client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
         let rtype = String::from_str(&env, "PRESCRIPTION");
         let record_id =
@@ -154,7 +163,7 @@ mod tests {
         env.mock_all_auths();
         let (client, patient, provider) = setup(&env);
 
-        client.grant_consent(&patient, &provider);
+        client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
         let rtype = String::from_str(&env, "DIAGNOSIS");
         let record_id =
@@ -171,7 +180,7 @@ mod tests {
         let (client, patient, provider) = setup(&env);
         let stranger = Address::generate(&env);
 
-        client.grant_consent(&patient, &provider);
+        client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
         let rtype = String::from_str(&env, "XRAY");
         let record_id =
@@ -199,7 +208,7 @@ mod tests {
         env.mock_all_auths();
         let (client, patient, provider) = setup(&env);
 
-        client.grant_consent(&patient, &provider);
+        client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
         let rtype = String::from_str(&env, "XRAY");
         let record_id =
@@ -357,6 +366,7 @@ mod cross_contract_correlation_tests {
 
     mod cross_contract_workflow_tests {
         use super::*;
+        use crate::ConsentScope;
         use patient_registry::{MedicalRegistry, MedicalRegistryClient};
         use provider_registry::{ProviderRegistry, ProviderRegistryClient};
         use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Symbol, Vec};
@@ -414,7 +424,12 @@ mod cross_contract_correlation_tests {
             );
             assert!(patient_is_registered);
 
-            hr_client.grant_consent(&patient, &provider);
+            hr_client.grant_consent(&patient, &provider, &ConsentScope {
+                can_read: true,
+                can_write: true,
+                can_share: true,
+                expires_at: 0,
+            });
 
             let record_id = hr_client
                 .create_record(
@@ -491,7 +506,12 @@ mod cross_contract_correlation_tests {
             env.mock_all_auths();
             let (client, patient, provider) = setup(&env);
 
-            client.grant_consent(&patient, &provider);
+            client.grant_consent(&patient, &provider, &ConsentScope {
+                can_read: true,
+                can_write: true,
+                can_share: true,
+                expires_at: 0,
+            });
             let record_id = client
                 .create_record(
                     &patient,
@@ -510,3 +530,567 @@ mod cross_contract_correlation_tests {
             assert_eq!(result, Err(Ok(Error::Unauthorized)));
         }
     }
+
+/// Tests for issue #472: bulk record creation via `create_records_batch`.
+#[cfg(test)]
+mod batch_creation_tests {
+    use crate::{ConsentScope, Error, HealthRecords, HealthRecordsClient, RecordInput};
+    use shared::privacy::{EncryptedEnvelopeRef, PolicyMetadata};
+    use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Symbol, Vec};
+
+    fn setup(env: &Env) -> (HealthRecordsClient<'static>, Address, Address) {
+        let contract_id = env.register(HealthRecords, ());
+        let client = HealthRecordsClient::new(env, &contract_id);
+        let patient = Address::generate(env);
+        let provider = Address::generate(env);
+        (client, patient, provider)
+    }
+
+    fn encrypted_ref(env: &Env, seed: u8) -> EncryptedEnvelopeRef {
+        EncryptedEnvelopeRef {
+            content_hash: BytesN::from_array(env, &[seed; 32]),
+            envelope_uri: String::from_str(env, "enc+ipfs://bafyvalidhealthref"),
+            key_version_id: String::from_str(env, "kv:v01"),
+        }
+    }
+
+    fn policy(env: &Env) -> PolicyMetadata {
+        PolicyMetadata {
+            retention_class: Symbol::new(env, "clinical"),
+            access_policy_hash: BytesN::from_array(env, &[7u8; 32]),
+            purpose: Symbol::new(env, "treatment"),
+        }
+    }
+
+    fn write_scope() -> ConsentScope {
+        ConsentScope {
+            can_read: true,
+            can_write: true,
+            can_share: false,
+            expires_at: 0,
+        }
+    }
+
+    #[test]
+    fn test_batch_creates_multiple_records_single_patient() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider, &write_scope());
+
+        let mut inputs: Vec<RecordInput> = Vec::new(&env);
+        inputs.push_back(RecordInput {
+            patient: patient.clone(),
+            encrypted_ref: encrypted_ref(&env, 1),
+            record_type: String::from_str(&env, "LAB_RESULT"),
+            policy: policy(&env),
+        });
+        inputs.push_back(RecordInput {
+            patient: patient.clone(),
+            encrypted_ref: encrypted_ref(&env, 2),
+            record_type: String::from_str(&env, "DIAGNOSIS"),
+            policy: policy(&env),
+        });
+        inputs.push_back(RecordInput {
+            patient: patient.clone(),
+            encrypted_ref: encrypted_ref(&env, 3),
+            record_type: String::from_str(&env, "PRESCRIPTION"),
+            policy: policy(&env),
+        });
+
+        let ids = client.create_records_batch(&provider, &inputs);
+
+        assert_eq!(ids.len(), 3);
+    }
+
+    #[test]
+    fn test_batch_returns_unique_sequential_ids() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider, &write_scope());
+
+        let mut inputs: Vec<RecordInput> = Vec::new(&env);
+        for seed in 1u8..=5u8 {
+            inputs.push_back(RecordInput {
+                patient: patient.clone(),
+                encrypted_ref: encrypted_ref(&env, seed),
+                record_type: String::from_str(&env, "LAB"),
+                policy: policy(&env),
+            });
+        }
+
+        let ids = client.create_records_batch(&provider, &inputs);
+
+        assert_eq!(ids.len(), 5);
+        // All IDs must be distinct
+        for i in 0..ids.len() {
+            for j in (i + 1)..ids.len() {
+                assert_ne!(ids.get(i).unwrap(), ids.get(j).unwrap());
+            }
+        }
+    }
+
+    #[test]
+    fn test_batch_records_are_retrievable_by_patient() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider, &write_scope());
+
+        let mut inputs: Vec<RecordInput> = Vec::new(&env);
+        inputs.push_back(RecordInput {
+            patient: patient.clone(),
+            encrypted_ref: encrypted_ref(&env, 10),
+            record_type: String::from_str(&env, "XRAY"),
+            policy: policy(&env),
+        });
+        inputs.push_back(RecordInput {
+            patient: patient.clone(),
+            encrypted_ref: encrypted_ref(&env, 11),
+            record_type: String::from_str(&env, "SCAN"),
+            policy: policy(&env),
+        });
+
+        let ids = client.create_records_batch(&provider, &inputs);
+
+        let record0 = client.get_record(&patient, &ids.get(0).unwrap());
+        assert_eq!(record0.record_id, ids.get(0).unwrap());
+        assert_eq!(record0.record_type, String::from_str(&env, "XRAY"));
+
+        let record1 = client.get_record(&patient, &ids.get(1).unwrap());
+        assert_eq!(record1.record_id, ids.get(1).unwrap());
+        assert_eq!(record1.record_type, String::from_str(&env, "SCAN"));
+    }
+
+    #[test]
+    fn test_batch_up_to_max_size_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider, &write_scope());
+
+        let mut inputs: Vec<RecordInput> = Vec::new(&env);
+        for seed in 1u8..=10u8 {
+            inputs.push_back(RecordInput {
+                patient: patient.clone(),
+                encrypted_ref: encrypted_ref(&env, seed),
+                record_type: String::from_str(&env, "LAB"),
+                policy: policy(&env),
+            });
+        }
+
+        let ids = client.create_records_batch(&provider, &inputs);
+        assert_eq!(ids.len(), 10);
+    }
+
+    #[test]
+    fn test_batch_exceeds_max_size_returns_batch_too_large() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider, &write_scope());
+
+        let mut inputs: Vec<RecordInput> = Vec::new(&env);
+        for seed in 1u8..=11u8 {
+            inputs.push_back(RecordInput {
+                patient: patient.clone(),
+                encrypted_ref: encrypted_ref(&env, seed),
+                record_type: String::from_str(&env, "LAB"),
+                policy: policy(&env),
+            });
+        }
+
+        let result = client.try_create_records_batch(&provider, &inputs);
+        assert_eq!(result, Err(Ok(Error::BatchTooLarge)));
+    }
+
+    #[test]
+    fn test_batch_fails_if_one_patient_has_no_consent() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient_a, provider) = setup(&env);
+        let patient_b = Address::generate(&env);
+
+        // Only patient_a has consent; patient_b does not.
+        client.grant_consent(&patient_a, &provider, &write_scope());
+
+        let mut inputs: Vec<RecordInput> = Vec::new(&env);
+        inputs.push_back(RecordInput {
+            patient: patient_a.clone(),
+            encrypted_ref: encrypted_ref(&env, 1),
+            record_type: String::from_str(&env, "LAB"),
+            policy: policy(&env),
+        });
+        inputs.push_back(RecordInput {
+            patient: patient_b.clone(),
+            encrypted_ref: encrypted_ref(&env, 2),
+            record_type: String::from_str(&env, "LAB"),
+            policy: policy(&env),
+        });
+
+        let result = client.try_create_records_batch(&provider, &inputs);
+        assert_eq!(result, Err(Ok(Error::ConsentNotGranted)));
+    }
+
+    #[test]
+    fn test_batch_multi_patient_all_consented_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient_a, provider) = setup(&env);
+        let patient_b = Address::generate(&env);
+
+        client.grant_consent(&patient_a, &provider, &write_scope());
+        client.grant_consent(&patient_b, &provider, &write_scope());
+
+        let mut inputs: Vec<RecordInput> = Vec::new(&env);
+        inputs.push_back(RecordInput {
+            patient: patient_a.clone(),
+            encrypted_ref: encrypted_ref(&env, 1),
+            record_type: String::from_str(&env, "DIAGNOSIS"),
+            policy: policy(&env),
+        });
+        inputs.push_back(RecordInput {
+            patient: patient_b.clone(),
+            encrypted_ref: encrypted_ref(&env, 2),
+            record_type: String::from_str(&env, "PRESCRIPTION"),
+            policy: policy(&env),
+        });
+
+        let ids = client.create_records_batch(&provider, &inputs);
+        assert_eq!(ids.len(), 2);
+
+        let rec_a = client.get_record(&patient_a, &ids.get(0).unwrap());
+        assert_eq!(rec_a.patient, patient_a);
+
+        let rec_b = client.get_record(&patient_b, &ids.get(1).unwrap());
+        assert_eq!(rec_b.patient, patient_b);
+    }
+
+    #[test]
+    fn test_empty_batch_succeeds_with_no_ids() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _patient, provider) = setup(&env);
+
+        let inputs: Vec<RecordInput> = Vec::new(&env);
+        let ids = client.create_records_batch(&provider, &inputs);
+        assert_eq!(ids.len(), 0);
+    }
+}
+
+/// Tests for issue #473: granular `ConsentScope` replacing binary consent.
+#[cfg(test)]
+mod consent_scope_tests {
+    use crate::{ConsentScope, Error, HealthRecords, HealthRecordsClient};
+    use shared::privacy::{EncryptedEnvelopeRef, PolicyMetadata};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger as _},
+        Address, Bytes, BytesN, Env, String, Symbol,
+    };
+
+    fn setup(env: &Env) -> (HealthRecordsClient<'static>, Address, Address) {
+        let contract_id = env.register(HealthRecords, ());
+        let client = HealthRecordsClient::new(env, &contract_id);
+        let patient = Address::generate(env);
+        let provider = Address::generate(env);
+        (client, patient, provider)
+    }
+
+    fn encrypted_ref(env: &Env, seed: u8) -> EncryptedEnvelopeRef {
+        EncryptedEnvelopeRef {
+            content_hash: BytesN::from_array(env, &[seed; 32]),
+            envelope_uri: String::from_str(env, "enc+ipfs://bafyvalidhealthref"),
+            key_version_id: String::from_str(env, "kv:v01"),
+        }
+    }
+
+    fn policy(env: &Env) -> PolicyMetadata {
+        PolicyMetadata {
+            retention_class: Symbol::new(env, "clinical"),
+            access_policy_hash: BytesN::from_array(env, &[7u8; 32]),
+            purpose: Symbol::new(env, "treatment"),
+        }
+    }
+
+    fn full_scope() -> ConsentScope {
+        ConsentScope {
+            can_read: true,
+            can_write: true,
+            can_share: true,
+            expires_at: 0,
+        }
+    }
+
+    fn read_only_scope() -> ConsentScope {
+        ConsentScope {
+            can_read: true,
+            can_write: false,
+            can_share: false,
+            expires_at: 0,
+        }
+    }
+
+    fn write_only_scope() -> ConsentScope {
+        ConsentScope {
+            can_read: false,
+            can_write: true,
+            can_share: false,
+            expires_at: 0,
+        }
+    }
+
+    #[test]
+    fn test_full_scope_allows_read_and_write() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider, &full_scope());
+
+        let reference = encrypted_ref(&env, 1);
+        let rtype = String::from_str(&env, "LAB_RESULT");
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+
+        let record = client.get_record(&provider, &record_id);
+        assert_eq!(record.record_id, record_id);
+    }
+
+    #[test]
+    fn test_read_only_scope_allows_get_record() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        // First create a record with full access, then downgrade to read-only.
+        client.grant_consent(&patient, &provider, &full_scope());
+        let reference = encrypted_ref(&env, 1);
+        let rtype = String::from_str(&env, "LAB_RESULT");
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+
+        // Downgrade consent to read-only.
+        client.grant_consent(&patient, &provider, &read_only_scope());
+
+        // Provider can still read.
+        let record = client.get_record(&provider, &record_id);
+        assert_eq!(record.record_id, record_id);
+    }
+
+    #[test]
+    fn test_read_only_scope_blocks_create_record() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        // Grant read-only — provider cannot write.
+        client.grant_consent(&patient, &provider, &read_only_scope());
+
+        let reference = encrypted_ref(&env, 1);
+        let rtype = String::from_str(&env, "LAB_RESULT");
+        let result = client.try_create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    }
+
+    #[test]
+    fn test_write_only_scope_allows_create_record() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider, &write_only_scope());
+
+        let reference = encrypted_ref(&env, 1);
+        let rtype = String::from_str(&env, "PRESCRIPTION");
+        // create_record should succeed with write-only consent.
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+
+        // Patient can always read their own record.
+        let record = client.get_record(&patient, &record_id);
+        assert_eq!(record.record_id, record_id);
+    }
+
+    #[test]
+    fn test_write_only_scope_blocks_get_record_by_provider() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider, &write_only_scope());
+
+        let reference = encrypted_ref(&env, 1);
+        let rtype = String::from_str(&env, "DIAGNOSIS");
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+
+        // Provider has no read permission.
+        let result = client.try_get_record(&provider, &record_id);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    }
+
+    #[test]
+    fn test_expired_consent_denies_create_record() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        // Consent expires at ledger timestamp 5000.
+        let expiring_scope = ConsentScope {
+            can_read: true,
+            can_write: true,
+            can_share: false,
+            expires_at: 5000,
+        };
+        // Grant consent while ledger timestamp is 0 (active: 5000 > 0).
+        client.grant_consent(&patient, &provider, &expiring_scope);
+
+        // Advance ledger past expiry.
+        env.ledger().with_mut(|li| li.timestamp = 10_000);
+
+        let reference = encrypted_ref(&env, 1);
+        let rtype = String::from_str(&env, "LAB_RESULT");
+        let result = client.try_create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+        assert_eq!(result, Err(Ok(Error::ConsentNotGranted)));
+    }
+
+    #[test]
+    fn test_expired_consent_denies_get_record() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        // Consent expires at 5000; create record while it's still valid.
+        let expiring_scope = ConsentScope {
+            can_read: true,
+            can_write: true,
+            can_share: false,
+            expires_at: 5000,
+        };
+        client.grant_consent(&patient, &provider, &expiring_scope);
+
+        let reference = encrypted_ref(&env, 1);
+        let rtype = String::from_str(&env, "LAB");
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+
+        // Advance ledger past expiry.
+        env.ledger().with_mut(|li| li.timestamp = 10_000);
+
+        let result = client.try_get_record(&provider, &record_id);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    }
+
+    #[test]
+    fn test_non_expired_consent_allows_access() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        // Advance ledger to 1000, expiry is 5000.
+        env.ledger().with_mut(|li| li.timestamp = 1_000);
+
+        let expiring_scope = ConsentScope {
+            can_read: true,
+            can_write: true,
+            can_share: false,
+            expires_at: 5_000,
+        };
+        client.grant_consent(&patient, &provider, &expiring_scope);
+
+        let reference = encrypted_ref(&env, 1);
+        let rtype = String::from_str(&env, "XRAY");
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+
+        // Advance to just before expiry.
+        env.ledger().with_mut(|li| li.timestamp = 4_999);
+        let record = client.get_record(&provider, &record_id);
+        assert_eq!(record.record_id, record_id);
+    }
+
+    #[test]
+    fn test_zero_expires_at_means_never_expires() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        // expires_at = 0 → never expires.
+        client.grant_consent(&patient, &provider, &full_scope());
+
+        let reference = encrypted_ref(&env, 1);
+        let rtype = String::from_str(&env, "PRESCRIPTION");
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+
+        // Far-future ledger timestamp.
+        env.ledger().with_mut(|li| li.timestamp = u64::MAX / 2);
+
+        let record = client.get_record(&provider, &record_id);
+        assert_eq!(record.record_id, record_id);
+    }
+
+    #[test]
+    fn test_revoke_consent_removes_scope_entirely() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        client.grant_consent(&patient, &provider, &full_scope());
+
+        let reference = encrypted_ref(&env, 1);
+        let rtype = String::from_str(&env, "LAB");
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+
+        client.revoke_consent(&patient, &provider);
+
+        // After revocation, both read and write are denied.
+        let result_read = client.try_get_record(&provider, &record_id);
+        assert_eq!(result_read, Err(Ok(Error::Unauthorized)));
+
+        let reference2 = encrypted_ref(&env, 2);
+        let result_write = client.try_create_record(&patient, &provider, &reference2, &rtype, &policy(&env));
+        assert_eq!(result_write, Err(Ok(Error::ConsentNotGranted)));
+    }
+
+    #[test]
+    fn test_grant_consent_updates_existing_scope() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        // Start with write-only.
+        client.grant_consent(&patient, &provider, &write_only_scope());
+
+        let reference = encrypted_ref(&env, 1);
+        let rtype = String::from_str(&env, "LAB");
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+
+        // Upgrade to full scope.
+        client.grant_consent(&patient, &provider, &full_scope());
+
+        // Provider can now read too.
+        let record = client.get_record(&provider, &record_id);
+        assert_eq!(record.record_id, record_id);
+    }
+
+    #[test]
+    fn test_patient_can_always_read_own_record() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, patient, provider) = setup(&env);
+
+        // Grant full scope to create the record.
+        client.grant_consent(&patient, &provider, &full_scope());
+
+        let reference = encrypted_ref(&env, 1);
+        let rtype = String::from_str(&env, "DIAGNOSIS");
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+
+        // Revoke provider consent entirely.
+        client.revoke_consent(&patient, &provider);
+
+        // Patient can still read their own record regardless.
+        let record = client.get_record(&patient, &record_id);
+        assert_eq!(record.record_id, record_id);
+    }
+}


### PR DESCRIPTION
closes #472 
closes #473 


Issue #472 — bulk record creation:
- Added `RecordInput` contract type (patient, encrypted_ref, record_type, policy)
- Added `create_records_batch(provider, records: Vec<RecordInput>) -> Vec<u64>` enforcing MAX_BATCH_SIZE = 10 per call; returns BatchTooLarge (error 7) if exceeded
- Provider auth is required once; per-patient write consent is verified per entry

Issue #473 — granular consent scopes:
- Added `ConsentScope { can_read, can_write, can_share, expires_at }` contract type
- Replaced binary bool consent with `ConsentScope` stored in persistent storage
- `grant_consent` now accepts a `ConsentScope`; `revoke_consent` removes the key
- `get_active_consent` helper enforces expiry (expires_at == 0 = never expires)
- `create_record` checks `can_write`; `get_record` / `verify_record_integrity` check `can_read`
- Updated all existing `grant_consent` call sites in tests to pass full scope
- Added `batch_creation_tests` module (8 tests) and `consent_scope_tests` module (11 tests)