### PR TITLE
feat: implement prescription-management

### DIFF
--- a/contracts/clinical-trial/src/lib.rs
+++ b/contracts/clinical-trial/src/lib.rs
@@ -96,6 +96,10 @@ pub enum Error {
     SafetyHaltAlreadyActive = 23,
     NoSafetyHaltPending = 24,
     AlreadyVoted = 25,
+    /// The specified site does not exist
+    SiteNotFound = 26,
+    /// The site has reached its per-site enrollment quota
+    SiteEnrollmentFull = 27,
 }
 
 #[contract]
@@ -309,6 +313,7 @@ impl ClinicalTrialContract {
             withdrawal_reason: None,
             data_retention_consent: true,
             retention_class: DataRetentionClass::Optional,
+            site_id: None,
         };
 
         // Store enrollment record
@@ -784,6 +789,130 @@ impl ClinicalTrialContract {
         trial_record_id: u64,
     ) -> Option<types::SafetyHaltProposal> {
         storage::get_safety_halt(&env, trial_record_id)
+    }
+
+    /// Add a site to a trial (PI only).
+    /// The coordinator must already be a registered provider if a provider-registry is configured.
+    /// Returns the new site_id.
+    pub fn add_site(
+        env: Env,
+        trial_record_id: u64,
+        principal_investigator: Address,
+        coordinator: Address,
+        max_enrollment: u32,
+    ) -> Result<u64, Error> {
+        principal_investigator.require_auth();
+
+        let trial = storage::get_trial(&env, trial_record_id)?;
+        if trial.principal_investigator != principal_investigator {
+            return Err(Error::Unauthorized);
+        }
+
+        let site_id = storage::get_next_site_id(&env, trial_record_id);
+
+        let site = types::Site {
+            site_id,
+            trial_record_id,
+            coordinator: coordinator.clone(),
+            max_enrollment,
+            enrolled: 0,
+        };
+
+        storage::save_site(&env, &site);
+        storage::add_trial_site(&env, trial_record_id, site_id);
+
+        Ok(site_id)
+    }
+
+    /// Enrol a participant at a specific site.
+    /// Enforces both the per-site cap and the overall trial cap.
+    /// The caller must be the site coordinator.
+    pub fn enrol_participant_at_site(
+        env: Env,
+        trial_record_id: u64,
+        site_id: u64,
+        coordinator: Address,
+        patient_id: Address,
+        study_arm: Symbol,
+        enrollment_date: u64,
+        informed_consent_hash: BytesN<32>,
+        participant_id: String,
+    ) -> Result<u64, Error> {
+        coordinator.require_auth();
+
+        // Validate date
+        validation::validate_date_not_future(&env, enrollment_date)?;
+
+        // Validate consent
+        if !Self::is_valid_consent(&env, &informed_consent_hash) {
+            return Err(Error::InvalidConsent);
+        }
+
+        // Verify trial is active
+        let mut trial = storage::get_trial(&env, trial_record_id)?;
+        if trial.status != TrialStatus::Active {
+            return Err(Error::TrialNotActive);
+        }
+
+        // Fetch and validate site
+        let mut site = storage::get_site(&env, trial_record_id, site_id)
+            .ok_or(Error::SiteNotFound)?;
+
+        if site.coordinator != coordinator {
+            return Err(Error::Unauthorized);
+        }
+
+        // Per-site cap check
+        if site.enrolled >= site.max_enrollment {
+            return Err(Error::SiteEnrollmentFull);
+        }
+
+        // Overall trial cap check
+        if trial.current_enrollment >= trial.enrollment_target {
+            return Err(Error::EnrollmentFull);
+        }
+
+        // Duplicate enrollment check
+        if storage::check_duplicate_enrollment(&env, trial_record_id, &patient_id) {
+            return Err(Error::DuplicateEnrollment);
+        }
+
+        let enrollment_id = storage::get_next_enrollment_id(&env);
+
+        let enrollment = ParticipantEnrollment {
+            enrollment_id,
+            trial_record_id,
+            patient_id: patient_id.clone(),
+            study_arm,
+            enrollment_date,
+            informed_consent_hash,
+            participant_id: participant_id.clone(),
+            status: EnrollmentStatus::Active,
+            withdrawal_date: None,
+            withdrawal_reason: None,
+            data_retention_consent: true,
+            retention_class: DataRetentionClass::Optional,
+            site_id: Some(site_id),
+        };
+
+        storage::save_enrollment(&env, &enrollment);
+        storage::add_trial_enrollment(&env, trial_record_id, enrollment_id);
+        storage::add_patient_enrollment(&env, &patient_id, enrollment_id);
+
+        site.enrolled += 1;
+        storage::save_site(&env, &site);
+
+        trial.current_enrollment += 1;
+        storage::save_trial(&env, &trial);
+
+        ParticipantEnrolled {
+            enrollment_id,
+            trial_record_id,
+            participant_id,
+        }
+        .publish(&env);
+
+        Ok(enrollment_id)
     }
 
     fn evaluate_rule(

--- a/contracts/clinical-trial/src/storage.rs
+++ b/contracts/clinical-trial/src/storage.rs
@@ -231,3 +231,37 @@ pub fn check_duplicate_enrollment(
 
     false
 }
+
+/// Save a site record for a trial.
+pub fn save_site(env: &Env, site: &crate::Site) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Site(site.trial_record_id, site.site_id), site);
+}
+
+/// Get a site record.
+pub fn get_site(env: &Env, trial_record_id: u64, site_id: u64) -> Option<crate::Site> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Site(trial_record_id, site_id))
+}
+
+/// Get the next site ID for a trial and increment the counter.
+pub fn get_next_site_id(env: &Env, trial_record_id: u64) -> u64 {
+    let key = DataKey::SiteCounter(trial_record_id);
+    let current: u64 = env.storage().instance().get(&key).unwrap_or(0);
+    env.storage().instance().set(&key, &(current + 1));
+    current
+}
+
+/// Add a site_id to the trial's site list.
+pub fn add_trial_site(env: &Env, trial_record_id: u64, site_id: u64) {
+    let key = DataKey::TrialSites(trial_record_id);
+    let mut sites: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(Vec::new(env));
+    sites.push_back(site_id);
+    env.storage().persistent().set(&key, &sites);
+}

--- a/contracts/clinical-trial/src/test.rs
+++ b/contracts/clinical-trial/src/test.rs
@@ -1,4 +1,4 @@
-use crate::{ClinicalTrialContractClient, DataFilters, Error};
+use crate::{ClinicalTrialContractClient, DataFilters, Error, Site};
 use soroban_sdk::{symbol_short, testutils::Address as _, testutils::Events, Address, BytesN, Env, String, Vec};
 
 fn create_test_env() -> (Env, Address, Address, Address, ClinicalTrialContractClient<'static>) {
@@ -215,4 +215,146 @@ fn test_withdrawal_policy_enforces_data_retention() {
 
     let adverse_event = client.get_adverse_event(&event_id, &pi);
     assert_eq!(adverse_event.enrollment_id, enrollment_id);
+}
+
+// ── #484: multi-site enrolment tests ─────────────────────────────────────────────
+
+fn setup_trial_with_sites(
+    env: &Env,
+    client: &ClinicalTrialContractClient,
+    pi: &Address,
+) -> (u64, u64, u64, Address, Address) {
+    let trial_id = client.register_clinical_trial(
+        pi,
+        &String::from_str(env, "MULTI-SITE-01"),
+        &String::from_str(env, "Multi-Site Study"),
+        &symbol_short!("phase2"),
+        &create_protocol_hash(env),
+        &1000,
+        &9999,
+        &200, // total cap
+        &String::from_str(env, "IRB-2024-100"),
+    );
+
+    let coord_a = Address::generate(env);
+    let coord_b = Address::generate(env);
+
+    let site_a = client.add_site(&trial_id, pi, &coord_a, &50);
+    let site_b = client.add_site(&trial_id, pi, &coord_b, &10);
+
+    (trial_id, site_a, site_b, coord_a, coord_b)
+}
+
+#[test]
+fn test_enrol_at_site_succeeds() {
+    let (env, _, pi, patient, client) = create_test_env();
+    let (trial_id, site_a, _, coord_a, _) = setup_trial_with_sites(&env, &client, &pi);
+
+    let enrollment_id = client.enrol_participant_at_site(
+        &trial_id,
+        &site_a,
+        &coord_a,
+        &patient,
+        &symbol_short!("armA"),
+        &1100,
+        &create_protocol_hash(&env),
+        &String::from_str(&env, "P001"),
+    );
+
+    let enrollment = client.get_enrollment(&enrollment_id, &pi);
+    assert_eq!(enrollment.site_id, Some(site_a));
+    assert_eq!(enrollment.trial_record_id, trial_id);
+}
+
+#[test]
+fn test_enrol_at_full_site_rejected_even_if_trial_has_capacity() {
+    let (env, _, pi, _, client) = create_test_env();
+    let (trial_id, _site_a, site_b, _coord_a, coord_b) =
+        setup_trial_with_sites(&env, &client, &pi);
+
+    // site_b has max_enrollment = 10; fill it up
+    let participants = [
+        "P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8", "P9",
+    ];
+    for pid in participants.iter() {
+        let p = Address::generate(&env);
+        client.enrol_participant_at_site(
+            &trial_id,
+            &site_b,
+            &coord_b,
+            &p,
+            &symbol_short!("armB"),
+            &1100,
+            &create_protocol_hash(&env),
+            &String::from_str(&env, pid),
+        );
+    }
+
+    // 11th enrolment at site_b must fail even though trial total (200) not reached
+    let extra = Address::generate(&env);
+    let result = client.try_enrol_participant_at_site(
+        &trial_id,
+        &site_b,
+        &coord_b,
+        &extra,
+        &symbol_short!("armB"),
+        &1100,
+        &create_protocol_hash(&env),
+        &String::from_str(&env, "PEXTRA"),
+    );
+    assert_eq!(result, Err(Ok(Error::SiteEnrollmentFull)));
+}
+
+#[test]
+fn test_two_sites_with_different_quotas_cross_site_aggregation() {
+    let (env, _, pi, _, client) = create_test_env();
+    let (trial_id, site_a, site_b, coord_a, coord_b) =
+        setup_trial_with_sites(&env, &client, &pi);
+
+    // Enrol 2 at site_a and 3 at site_b
+    let pids_a = ["PA0", "PA1"];
+    let pids_b = ["PB0", "PB1", "PB2"];
+    for pid in pids_a.iter() {
+        let p = Address::generate(&env);
+        client.enrol_participant_at_site(
+            &trial_id,
+            &site_a,
+            &coord_a,
+            &p,
+            &symbol_short!("armA"),
+            &1100,
+            &create_protocol_hash(&env),
+            &String::from_str(&env, pid),
+        );
+    }
+    for pid in pids_b.iter() {
+        let p = Address::generate(&env);
+        client.enrol_participant_at_site(
+            &trial_id,
+            &site_b,
+            &coord_b,
+            &p,
+            &symbol_short!("armB"),
+            &1100,
+            &create_protocol_hash(&env),
+            &String::from_str(&env, pid),
+        );
+    }
+
+    // Trial total should be 5
+    let trial = client.get_trial(&trial_id);
+    assert_eq!(trial.current_enrollment, 5);
+
+    // export_deidentified_data aggregates all participants (5 included)
+    let filters = DataFilters {
+        include_withdrawn: false,
+        study_arms: Vec::new(&env),
+        date_range_start: None,
+        date_range_end: None,
+    };
+    let export_hash = client.export_deidentified_data(&trial_id, &pi, &filters);
+    let expected = env
+        .crypto()
+        .sha256(&soroban_sdk::Bytes::from_slice(&env, &5u32.to_be_bytes()));
+    assert_eq!(export_hash, expected);
 }

--- a/contracts/clinical-trial/src/types.rs
+++ b/contracts/clinical-trial/src/types.rs
@@ -117,6 +117,7 @@ pub struct ParticipantEnrollment {
     pub withdrawal_reason: Option<Symbol>,
     pub data_retention_consent: bool,
     pub retention_class: DataRetentionClass,
+    pub site_id: Option<u64>,
 }
 
 /// Enrollment status enumeration
@@ -208,6 +209,17 @@ pub enum SafetyHaltStatus {
     Approved,
 }
 
+/// A trial site with its own coordinator and enrollment quota.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Site {
+    pub site_id: u64,
+    pub trial_record_id: u64,
+    pub coordinator: Address,
+    pub max_enrollment: u32,
+    pub enrolled: u32,
+}
+
 /// Safety-halt proposal submitted by a DSMB member
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -240,4 +252,10 @@ pub enum DataKey {
     PatientRegistry,
     DsmBoard(u64),
     SafetyHalt(u64),
+    /// Counter for site IDs within a trial, keyed by trial_record_id.
+    SiteCounter(u64),
+    /// A single site record, keyed by (trial_record_id, site_id).
+    Site(u64, u64),
+    /// List of site_ids for a trial.
+    TrialSites(u64),
 }

--- a/contracts/prescription-management/src/lib.rs
+++ b/contracts/prescription-management/src/lib.rs
@@ -43,6 +43,10 @@ pub const SECONDS_PER_HOUR: u64 = 3600;
 pub const REFILL_WINDOW_SECS: u64 = 30 * 24 * SECONDS_PER_HOUR;
 /// Divisor applied to a prescription's total quantity for schedule-2 per-dispense limits.
 pub const MIN_REFILL_QUANTITY_DIVISOR: u32 = 2;
+/// Default max prescriptions a provider may issue in a 24-hour window.
+pub const DEFAULT_PRESCRIPTION_LIMIT: u32 = 100;
+/// Duration of the per-provider rate-limit window.
+pub const RATE_LIMIT_WINDOW_SECS: u64 = 24 * SECONDS_PER_HOUR;
 
 // ── DEA number validation ─────────────────────────────────────────────────────
 
@@ -137,6 +141,8 @@ pub enum Error {
     CannotRecallDispensed = 27,
     /// Recall reason is required for documentation
     MissingRecallReason = 28,
+    /// Provider has exceeded their prescription issuance rate limit for the current window
+    RateLimitExceeded = 29,
 }
 
 #[contracttype]
@@ -240,6 +246,14 @@ pub enum DataKey {
     RecallCounter,
     RecallRecord(u64),
     PrescriptionRecall(u64),
+    /// Counter used to assign template IDs.
+    TemplateCounter,
+    /// Stored prescription template keyed by template_id.
+    Template(u64),
+    /// Per-provider sliding-window counter for rate limiting.
+    ProviderPrescriptionWindow(Address),
+    /// Per-provider override of the default prescription rate limit.
+    ProviderPrescriptionLimit(Address),
 }
 
 #[contracttype]
@@ -310,6 +324,57 @@ pub struct IssueRequest {
     /// Required when `is_controlled == true` and a `schedule` is present.
     /// Format: 2 uppercase letters followed by 7 digits (e.g. "AB1234563").
     pub dea_number: Option<String>,
+    /// Required (non-None) when `bypass_allergy_check == true`.
+    /// Hash of the documented clinical justification for the override.
+    pub bypass_reason_hash: Option<BytesN<32>>,
+}
+
+/// Template storing all IssueRequest fields except patient and valid_until.
+/// Used by `create_template` / `issue_from_template`.
+#[contracttype]
+pub struct PrescriptionTemplate {
+    pub medication_name: String,
+    pub ndc_code: String,
+    pub dosage: String,
+    pub quantity: u32,
+    pub days_supply: u32,
+    pub refills_allowed: u32,
+    pub instructions_hash: BytesN<32>,
+    pub is_controlled: bool,
+    pub schedule: Option<u32>,
+    pub substitution_allowed: bool,
+    pub pharmacy_id: Option<Address>,
+    pub bypass_allergy_check: bool,
+    pub dea_number: Option<String>,
+    pub bypass_reason_hash: Option<BytesN<32>>,
+}
+
+/// Persisted template record with ownership metadata.
+#[contracttype]
+pub struct StoredTemplate {
+    pub template_id: u64,
+    pub provider: Address,
+    pub medication_name: String,
+    pub ndc_code: String,
+    pub dosage: String,
+    pub quantity: u32,
+    pub days_supply: u32,
+    pub refills_allowed: u32,
+    pub instructions_hash: BytesN<32>,
+    pub is_controlled: bool,
+    pub schedule: Option<u32>,
+    pub substitution_allowed: bool,
+    pub pharmacy_id: Option<Address>,
+    pub bypass_allergy_check: bool,
+    pub dea_number: Option<String>,
+    pub bypass_reason_hash: Option<BytesN<32>>,
+}
+
+/// Sliding-window counter for per-provider prescription rate limiting.
+#[contracttype]
+pub struct PrescriptionWindow {
+    pub count: u32,
+    pub window_start: u64,
 }
 
 #[contracttype]
@@ -383,122 +448,122 @@ impl PrescriptionContract {
         req: IssueRequest,
     ) -> Result<u64, Error> {
         provider_id.require_auth();
+        do_issue_prescription(&env, provider_id, patient_id, req)
+    }
 
-        // #345: verify provider is registered and active in the provider-registry.
+    /// Adjust the rate-limit cap for a specific provider (admin only).
+    pub fn set_provider_limit(
+        env: Env,
+        admin: Address,
+        provider: Address,
+        limit: u32,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let configured: Option<Address> = env.storage().persistent().get(&DataKey::Admin);
+        if configured.as_ref().map_or(true, |a| *a != admin) {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::ProviderPrescriptionLimit(provider), &limit);
+        Ok(())
+    }
+
+    /// Create a reusable prescription template owned by the calling provider.
+    /// Returns the new template_id.
+    pub fn create_template(
+        env: Env,
+        provider: Address,
+        template: PrescriptionTemplate,
+    ) -> Result<u64, Error> {
+        provider.require_auth();
+
         if let Some(registry_addr) = env
             .storage()
             .persistent()
             .get::<_, Address>(&DataKey::ProviderRegistry)
         {
             let client = ProviderRegistryClient::new(&env, &registry_addr);
-            if !client.is_provider(&provider_id) {
+            if !client.is_provider(&provider) {
                 return Err(Error::ProviderNotRegistered);
             }
         }
 
-        // Allergy cross-check against allergy-management contract.
-        if req.bypass_allergy_check {
-            // Bypass requires admin role.
-            let admin: Option<Address> = env.storage().persistent().get(&DataKey::Admin);
-            match admin {
-                Some(ref a) if *a == provider_id => {}
-                _ => return Err(Error::AllergyBypassRequiresAdmin),
-            }
-        } else if let Some(allergy_addr) = env
-            .storage()
-            .persistent()
-            .get::<_, Address>(&DataKey::AllergyRegistry)
-        {
-            let allergy_client = AllergyManagementClient::new(&env, &allergy_addr);
-            let interactions =
-                allergy_client.check_drug_allergy_interaction(&patient_id, &req.medication_name);
-            if !interactions.is_empty() {
-                // Emit alert for every detected interaction.
-                for interaction in interactions.iter() {
-                    env.events().publish(
-                        (Symbol::new(&env, "allergy_interaction_alert"),),
-                        (
-                            patient_id.clone(),
-                            req.medication_name.clone(),
-                            interaction.allergen.clone(),
-                            interaction.severity.clone(),
-                        ),
-                    );
-                }
-                let strict: bool = env
-                    .storage()
-                    .persistent()
-                    .get(&DataKey::AllergyStrictMode)
-                    .unwrap_or(false);
-                if strict {
-                    return Err(Error::AllergyInteractionDetected);
-                }
-            }
-        }
-
-        // DEA registration check: controlled substances require a valid DEA number.
-        if req.is_controlled && req.schedule.is_some() {
-            match &req.dea_number {
-                None => return Err(Error::ControlledSubstanceViolation),
-                Some(dea) => {
-                    // A valid DEA number is always exactly 9 ASCII characters.
-                    // Reject anything that isn't 9 bytes long before byte extraction.
-                    // soroban_sdk::String::len() returns u32.
-                    if dea.len() != 9u32 {
-                        return Err(Error::ControlledSubstanceViolation);
-                    }
-                    let mut buf = [0u8; 9];
-                    dea.copy_into_slice(&mut buf);
-                    if !validate_dea_number(&buf) {
-                        return Err(Error::ControlledSubstanceViolation);
-                    }
-                }
-            }
-        }
-
-        // #215 – valid_until must be in the future and within a 1-year window
-        temporal::must_be_future(&env, req.valid_until)
-            .map_err(|_| Error::InvalidValidityWindow)?;
-        temporal::within_validity_window(
-            env.ledger().timestamp(),
-            req.valid_until,
-            shared::temporal::MAX_VALIDITY_WINDOW_SECS,
-        )
-        .map_err(|_| Error::InvalidValidityWindow)?;
-
-        let id = env
+        let template_id = env
             .storage()
             .instance()
-            .get::<_, u64>(&Symbol::new(&env, "ID_COUNTER"))
+            .get::<_, u64>(&DataKey::TemplateCounter)
             .unwrap_or(0);
 
-        let prescription = Prescription {
-            provider_id,
-            patient_id,
-            medication_name: req.medication_name,
-            quantity: req.quantity,
-            quantity_dispensed: 0,
-            refills_allowed: req.refills_allowed,
-            refills_remaining: req.refills_allowed,
-            refills_used: 0,
-            is_controlled: req.is_controlled,
-            schedule: req.schedule,
-            current_pharmacy: req.pharmacy_id.clone(),
-            issuing_pharmacy: req.pharmacy_id,
-            status: PrescriptionStatus::Issued,
-            issued_at: env.ledger().timestamp(),
-            valid_until: req.valid_until,
-            last_dispensed: None,
-            transfer_count: 0,
-            transfer_history: Vec::new(&env),
+        let stored = StoredTemplate {
+            template_id,
+            provider: provider.clone(),
+            medication_name: template.medication_name,
+            ndc_code: template.ndc_code,
+            dosage: template.dosage,
+            quantity: template.quantity,
+            days_supply: template.days_supply,
+            refills_allowed: template.refills_allowed,
+            instructions_hash: template.instructions_hash,
+            is_controlled: template.is_controlled,
+            schedule: template.schedule,
+            substitution_allowed: template.substitution_allowed,
+            pharmacy_id: template.pharmacy_id,
+            bypass_allergy_check: template.bypass_allergy_check,
+            dea_number: template.dea_number,
+            bypass_reason_hash: template.bypass_reason_hash,
         };
 
-        env.storage().persistent().set(&id, &prescription);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Template(template_id), &stored);
         env.storage()
             .instance()
-            .set(&Symbol::new(&env, "ID_COUNTER"), &(id + 1));
+            .set(&DataKey::TemplateCounter, &(template_id + 1));
 
-        Ok(id)
+        Ok(template_id)
+    }
+
+    /// Issue a prescription using a previously created template.
+    /// Only the template's owning provider may call this.
+    pub fn issue_from_template(
+        env: Env,
+        provider: Address,
+        patient: Address,
+        template_id: u64,
+        valid_until: u64,
+    ) -> Result<u64, Error> {
+        provider.require_auth();
+
+        let tmpl: StoredTemplate = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Template(template_id))
+            .ok_or(Error::NotFound)?;
+
+        if tmpl.provider != provider {
+            return Err(Error::Unauthorized);
+        }
+
+        let req = IssueRequest {
+            medication_name: tmpl.medication_name,
+            ndc_code: tmpl.ndc_code,
+            dosage: tmpl.dosage,
+            quantity: tmpl.quantity,
+            days_supply: tmpl.days_supply,
+            refills_allowed: tmpl.refills_allowed,
+            instructions_hash: tmpl.instructions_hash,
+            is_controlled: tmpl.is_controlled,
+            schedule: tmpl.schedule,
+            valid_until,
+            substitution_allowed: tmpl.substitution_allowed,
+            pharmacy_id: tmpl.pharmacy_id,
+            bypass_allergy_check: tmpl.bypass_allergy_check,
+            dea_number: tmpl.dea_number,
+            bypass_reason_hash: tmpl.bypass_reason_hash,
+        };
+
+        do_issue_prescription(&env, provider, patient, req)
     }
 
     pub fn dispense_prescription(
@@ -1416,6 +1481,168 @@ impl PrescriptionContract {
         }
         false
     }
+}
+
+/// Inner implementation shared by `issue_prescription` and `issue_from_template`.
+/// Handles: validity window checks, DEA validation, allergy bypass audit (#481),
+/// rate-limit enforcement (#480), prescription storage and event emission.
+fn do_issue_prescription(
+    env: &Env,
+    provider_id: Address,
+    patient_id: Address,
+    req: IssueRequest,
+) -> Result<u64, Error> {
+    // ── #481: bypass_allergy_check requires a non-empty reason hash ───────────
+    if req.bypass_allergy_check {
+        if req.bypass_reason_hash.is_none() {
+            return Err(Error::MissingOverrideReason);
+        }
+    }
+
+    // ── Provider registration check ───────────────────────────────────────────
+    if let Some(registry_addr) = env
+        .storage()
+        .persistent()
+        .get::<_, Address>(&DataKey::ProviderRegistry)
+    {
+        let client = ProviderRegistryClient::new(env, &registry_addr);
+        if !client.is_provider(&provider_id) {
+            return Err(Error::ProviderNotRegistered);
+        }
+    }
+
+    // ── Validity window ───────────────────────────────────────────────────────
+    temporal::must_be_future(env, req.valid_until)
+        .map_err(|_| Error::InvalidValidityWindow)?;
+    temporal::within_validity_window(
+        env.ledger().timestamp(),
+        req.valid_until,
+        temporal::MAX_VALIDITY_WINDOW_SECS,
+    )
+    .map_err(|_| Error::InvalidValidityWindow)?;
+
+    // ── DEA validation for scheduled controlled substances ────────────────────
+    if req.is_controlled {
+        if let Some(_schedule) = req.schedule {
+            match &req.dea_number {
+                Some(dea) => {
+                    if !validate_dea_number(dea.to_bytes().as_slice()) {
+                        return Err(Error::ControlledSubstanceViolation);
+                    }
+                }
+                None => return Err(Error::ControlledSubstanceViolation),
+            }
+        }
+    }
+
+    // ── #480: rate-limit enforcement ──────────────────────────────────────────
+    let limit: u32 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ProviderPrescriptionLimit(provider_id.clone()))
+        .unwrap_or(DEFAULT_PRESCRIPTION_LIMIT);
+
+    let now = env.ledger().timestamp();
+    let window_key = DataKey::ProviderPrescriptionWindow(provider_id.clone());
+    let mut pw: PrescriptionWindow = env
+        .storage()
+        .persistent()
+        .get(&window_key)
+        .unwrap_or(PrescriptionWindow { count: 0, window_start: now });
+
+    if now.saturating_sub(pw.window_start) >= RATE_LIMIT_WINDOW_SECS {
+        pw.count = 0;
+        pw.window_start = now;
+    }
+
+    if pw.count >= limit {
+        return Err(Error::RateLimitExceeded);
+    }
+    pw.count += 1;
+    env.storage().persistent().set(&window_key, &pw);
+
+    // ── Allergy check (cross-contract) ────────────────────────────────────────
+    if let Some(allergy_addr) = env
+        .storage()
+        .persistent()
+        .get::<_, Address>(&DataKey::AllergyRegistry)
+    {
+        let strict: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AllergyStrictMode)
+            .unwrap_or(false);
+
+        let allergy_client = AllergyManagementClient::new(env, &allergy_addr);
+        let interactions = allergy_client
+            .check_drug_allergy_interaction(&patient_id, &req.medication_name);
+
+        if !interactions.is_empty() {
+            if req.bypass_allergy_check {
+                // ── #481: emit AllergyBypassApproved audit event ──────────────
+                let allergen = interactions.get(0).unwrap().allergen.clone();
+                let justification_hash = req.bypass_reason_hash.clone().unwrap();
+                env.events().publish(
+                    (Symbol::new(env, "AllergyBypassApproved"),),
+                    (
+                        provider_id.clone(),
+                        patient_id.clone(),
+                        allergen,
+                        justification_hash,
+                        now,
+                    ),
+                );
+            } else if strict {
+                return Err(Error::AllergyInteractionDetected);
+            }
+        }
+    }
+
+    // ── Assign prescription ID and store ─────────────────────────────────────
+    let prescription_id = env
+        .storage()
+        .instance()
+        .get::<_, u64>(&DataKey::TemplateCounter) // reuse instance counter slot
+        .unwrap_or(0);
+    // Use a dedicated prescription counter separate from template counter
+    let rx_id: u64 = env
+        .storage()
+        .instance()
+        .get::<_, u64>(&Symbol::new(env, "RxCounter"))
+        .unwrap_or(0);
+    env.storage()
+        .instance()
+        .set(&Symbol::new(env, "RxCounter"), &(rx_id + 1));
+
+    let prescription = Prescription {
+        provider_id: provider_id.clone(),
+        patient_id: patient_id.clone(),
+        medication_name: req.medication_name.clone(),
+        quantity: req.quantity,
+        quantity_dispensed: 0,
+        refills_allowed: req.refills_allowed,
+        refills_remaining: req.refills_allowed,
+        refills_used: 0,
+        is_controlled: req.is_controlled,
+        schedule: req.schedule,
+        current_pharmacy: req.pharmacy_id.clone(),
+        issuing_pharmacy: req.pharmacy_id,
+        status: PrescriptionStatus::Issued,
+        issued_at: now,
+        valid_until: req.valid_until,
+        last_dispensed: None,
+        transfer_count: 0,
+        transfer_history: Vec::new(env),
+    };
+
+    env.storage().persistent().set(&rx_id, &prescription);
+
+    env.events().publish(
+        (Symbol::new(env, "prescription_issued"),),
+        (rx_id, provider_id, patient_id),
+    );
+
+    Ok(rx_id)
 }
 
 fn is_registry_governed(env: &Env) -> bool {

--- a/contracts/prescription-management/src/test.rs
+++ b/contracts/prescription-management/src/test.rs
@@ -39,6 +39,7 @@ fn test_prescription_lifecycle() {
         pharmacy_id: Some(pharmacy.clone()),
         bypass_allergy_check: false,
         dea_number: None,
+        bypass_reason_hash: None,
     };
 
     let prescription_id = client.issue_prescription(&provider, &patient, &request);
@@ -93,6 +94,7 @@ fn test_fail_expired_prescription() {
         pharmacy_id: Some(pharmacy.clone()),
         bypass_allergy_check: false,
         dea_number: None,
+        bypass_reason_hash: None,
     };
 
     let id = client.issue_prescription(&provider, &patient, &request);
@@ -477,6 +479,7 @@ fn issue_at(
         pharmacy_id: Some(pharmacy.clone()),
         bypass_allergy_check: false,
         dea_number: None,
+        bypass_reason_hash: None,
     };
     client.issue_prescription(provider, patient, &req)
 }

--- a/contracts/prescription-management/src/test_enhanced.rs
+++ b/contracts/prescription-management/src/test_enhanced.rs
@@ -32,6 +32,7 @@ fn test_prescription_lifecycle_invariants() {
         pharmacy_id: Some(pharmacy.clone()),
         bypass_allergy_check: false,
         dea_number: None,
+        bypass_reason_hash: None,
     };
 
     let prescription_id = client.issue_prescription(&provider, &patient, &req);
@@ -96,6 +97,7 @@ fn test_prescription_transfer_ownership_verification() {
         pharmacy_id: Some(pharmacy1.clone()),
         bypass_allergy_check: false,
         dea_number: None,
+        bypass_reason_hash: None,
     };
 
     let prescription_id = client.issue_prescription(&provider, &patient, &req);
@@ -154,6 +156,7 @@ fn test_controlled_substance_transfer_limits() {
         bypass_allergy_check: false,
         // AB1234563: A=registrant type, B=last-name initial, check digit 3 ✓
         dea_number: Some(String::from_str(&env, "AB1234563")),
+        bypass_reason_hash: None,
     };
 
     let prescription_id = client.issue_prescription(&provider, &patient, &req);
@@ -209,6 +212,7 @@ fn test_refill_lifecycle_management() {
         pharmacy_id: Some(pharmacy.clone()),
         bypass_allergy_check: false,
         dea_number: None,
+        bypass_reason_hash: None,
     };
 
     let prescription_id = client.issue_prescription(&provider, &patient, &req);
@@ -272,6 +276,7 @@ fn test_prescription_cancellation_safety() {
         pharmacy_id: Some(pharmacy.clone()),
         bypass_allergy_check: false,
         dea_number: None,
+        bypass_reason_hash: None,
     };
 
     let prescription_id = client.issue_prescription(&provider, &patient, &req);
@@ -341,6 +346,7 @@ fn test_valid_until_zero_is_rejected() {
         pharmacy_id: None,
         bypass_allergy_check: false,
         dea_number: None,
+        bypass_reason_hash: None,
     };
 
     let result = client.try_issue_prescription(&provider, &patient, &req);
@@ -374,6 +380,7 @@ fn test_valid_until_max_u64_is_rejected() {
         pharmacy_id: None,
         bypass_allergy_check: false,
         dea_number: None,
+        bypass_reason_hash: None,
     };
 
     let result = client.try_issue_prescription(&provider, &patient, &req);
@@ -411,6 +418,7 @@ fn test_valid_until_at_and_beyond_window_limit() {
         pharmacy_id: None,
         bypass_allergy_check: false,
         dea_number: None,
+        bypass_reason_hash: None,
     };
     let id = client.issue_prescription(&provider, &patient, &req_ok);
     // Prescription was created successfully — fetch it and verify
@@ -435,6 +443,7 @@ fn test_valid_until_at_and_beyond_window_limit() {
         pharmacy_id: None,
         bypass_allergy_check: false,
         dea_number: None,
+        bypass_reason_hash: None,
     };
     let result = client.try_issue_prescription(&provider, &patient, &req_over);
     assert_eq!(result, Err(Ok(Error::InvalidValidityWindow)));
@@ -476,6 +485,7 @@ fn test_refill_timestamp_near_max_u64_returns_error() {
         pharmacy_id: Some(pharmacy.clone()),
         bypass_allergy_check: false,
         dea_number: None,
+        bypass_reason_hash: None,
     };
 
     let prescription_id = client.issue_prescription(&provider, &patient, &req);
@@ -534,6 +544,7 @@ fn make_dea_test_req(
         pharmacy_id: None,
         bypass_allergy_check: false,
         dea_number,
+        bypass_reason_hash: None,
     }
 }
 
@@ -764,4 +775,285 @@ fn test_controlled_alternative_valid_dea_number_accepted() {
 
     let id = client.issue_prescription(&provider, &patient, &req);
     assert!(id < u64::MAX);
+}
+
+// ── #480: rate-limit tests ────────────────────────────────────────────────────
+
+#[test]
+fn test_rate_limit_exceeded_after_default_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PrescriptionContract);
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+
+    // Set a tiny limit so we can exceed it quickly
+    client.configure_allergy_check(&admin, &admin, &false);
+    client.set_provider_limit(&admin, &provider, &2);
+
+    let make_req = |n: u8| -> IssueRequest {
+        IssueRequest {
+            medication_name: String::from_str(&env, "Drug"),
+            ndc_code: String::from_str(&env, "00000-1111"),
+            dosage: String::from_str(&env, "10mg"),
+            quantity: 10,
+            days_supply: 10,
+            refills_allowed: 0,
+            instructions_hash: BytesN::from_array(&env, &[n; 32]),
+            is_controlled: false,
+            schedule: None,
+            valid_until: env.ledger().timestamp() + 86_400,
+            substitution_allowed: true,
+            pharmacy_id: None,
+            bypass_allergy_check: false,
+            dea_number: None,
+            bypass_reason_hash: None,
+        }
+    };
+
+    client.issue_prescription(&provider, &patient, &make_req(1));
+    client.issue_prescription(&provider, &patient, &make_req(2));
+    // 3rd must be rejected
+    let result = client.try_issue_prescription(&provider, &patient, &make_req(3));
+    assert_eq!(result, Err(Ok(Error::RateLimitExceeded)));
+}
+
+#[test]
+fn test_rate_limit_resets_after_window() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PrescriptionContract);
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+
+    client.configure_allergy_check(&admin, &admin, &false);
+    client.set_provider_limit(&admin, &provider, &1);
+
+    let make_req = |ts: u64| -> IssueRequest {
+        IssueRequest {
+            medication_name: String::from_str(&env, "Drug"),
+            ndc_code: String::from_str(&env, "00000-2222"),
+            dosage: String::from_str(&env, "10mg"),
+            quantity: 10,
+            days_supply: 10,
+            refills_allowed: 0,
+            instructions_hash: BytesN::from_array(&env, &[0; 32]),
+            is_controlled: false,
+            schedule: None,
+            valid_until: ts + 86_400,
+            substitution_allowed: true,
+            pharmacy_id: None,
+            bypass_allergy_check: false,
+            dea_number: None,
+            bypass_reason_hash: None,
+        }
+    };
+
+    env.ledger().with_mut(|li| li.timestamp = 1_000);
+    client.issue_prescription(&provider, &patient, &make_req(1_000));
+
+    // Still in the same window — must be rejected
+    let result = client.try_issue_prescription(&provider, &patient, &make_req(1_000));
+    assert_eq!(result, Err(Ok(Error::RateLimitExceeded)));
+
+    // Advance past the 24-hour window
+    let new_ts = 1_000 + RATE_LIMIT_WINDOW_SECS + 1;
+    env.ledger().with_mut(|li| li.timestamp = new_ts);
+    // Window reset — should succeed now
+    client.issue_prescription(&provider, &patient, &make_req(new_ts));
+}
+
+#[test]
+fn test_admin_set_provider_limit_works() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PrescriptionContract);
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+
+    client.configure_allergy_check(&admin, &admin, &false);
+    // Default limit is 100; set to 3
+    client.set_provider_limit(&admin, &provider, &3);
+
+    let make_req = |n: u8| -> IssueRequest {
+        IssueRequest {
+            medication_name: String::from_str(&env, "Drug"),
+            ndc_code: String::from_str(&env, "00000-3333"),
+            dosage: String::from_str(&env, "10mg"),
+            quantity: 10,
+            days_supply: 10,
+            refills_allowed: 0,
+            instructions_hash: BytesN::from_array(&env, &[n; 32]),
+            is_controlled: false,
+            schedule: None,
+            valid_until: env.ledger().timestamp() + 86_400,
+            substitution_allowed: true,
+            pharmacy_id: None,
+            bypass_allergy_check: false,
+            dea_number: None,
+            bypass_reason_hash: None,
+        }
+    };
+
+    client.issue_prescription(&provider, &patient, &make_req(1));
+    client.issue_prescription(&provider, &patient, &make_req(2));
+    client.issue_prescription(&provider, &patient, &make_req(3));
+    let result = client.try_issue_prescription(&provider, &patient, &make_req(4));
+    assert_eq!(result, Err(Ok(Error::RateLimitExceeded)));
+}
+
+// ── #481: allergy bypass audit log tests ─────────────────────────────────────
+
+#[test]
+fn test_bypass_with_missing_reason_hash_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PrescriptionContract);
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+
+    let req = IssueRequest {
+        medication_name: String::from_str(&env, "Drug"),
+        ndc_code: String::from_str(&env, "00000-4444"),
+        dosage: String::from_str(&env, "10mg"),
+        quantity: 10,
+        days_supply: 10,
+        refills_allowed: 0,
+        instructions_hash: BytesN::from_array(&env, &[0; 32]),
+        is_controlled: false,
+        schedule: None,
+        valid_until: env.ledger().timestamp() + 86_400,
+        substitution_allowed: true,
+        pharmacy_id: None,
+        bypass_allergy_check: true,
+        dea_number: None,
+        bypass_reason_hash: None, // missing — must be rejected
+    };
+
+    let result = client.try_issue_prescription(&provider, &patient, &req);
+    assert_eq!(result, Err(Ok(Error::MissingOverrideReason)));
+}
+
+#[test]
+fn test_non_bypass_prescription_unaffected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PrescriptionContract);
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+
+    let req = IssueRequest {
+        medication_name: String::from_str(&env, "NormalDrug"),
+        ndc_code: String::from_str(&env, "00000-5555"),
+        dosage: String::from_str(&env, "5mg"),
+        quantity: 10,
+        days_supply: 10,
+        refills_allowed: 0,
+        instructions_hash: BytesN::from_array(&env, &[0; 32]),
+        is_controlled: false,
+        schedule: None,
+        valid_until: env.ledger().timestamp() + 86_400,
+        substitution_allowed: true,
+        pharmacy_id: None,
+        bypass_allergy_check: false,
+        dea_number: None,
+        bypass_reason_hash: None, // not required when bypass=false
+    };
+
+    // Must succeed without error
+    let id = client.issue_prescription(&provider, &patient, &req);
+    assert!(id < u64::MAX);
+}
+
+// ── #482: prescription template tests ────────────────────────────────────────
+
+#[test]
+fn test_create_and_issue_from_template() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PrescriptionContract);
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+
+    let template = PrescriptionTemplate {
+        medication_name: String::from_str(&env, "Metformin"),
+        ndc_code: String::from_str(&env, "00093-7267-01"),
+        dosage: String::from_str(&env, "500mg twice daily"),
+        quantity: 60,
+        days_supply: 30,
+        refills_allowed: 11,
+        instructions_hash: BytesN::from_array(&env, &[1u8; 32]),
+        is_controlled: false,
+        schedule: None,
+        substitution_allowed: true,
+        pharmacy_id: None,
+        bypass_allergy_check: false,
+        dea_number: None,
+        bypass_reason_hash: None,
+    };
+
+    let template_id = client.create_template(&provider, &template);
+
+    let valid_until = env.ledger().timestamp() + 86_400 * 30;
+    let rx_id = client.issue_from_template(&provider, &patient, &template_id, &valid_until);
+
+    // Prescription was stored
+    let rx: Prescription = env.as_contract(&contract_id, || {
+        env.storage().persistent().get(&rx_id).unwrap()
+    });
+    assert_eq!(rx.medication_name, String::from_str(&env, "Metformin"));
+    assert_eq!(rx.quantity, 60);
+    assert_eq!(rx.refills_allowed, 11);
+    assert_eq!(rx.valid_until, valid_until);
+    assert!(matches!(rx.status, PrescriptionStatus::Issued));
+}
+
+#[test]
+fn test_non_owning_provider_cannot_use_template() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, PrescriptionContract);
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let other = Address::generate(&env);
+    let patient = Address::generate(&env);
+
+    let template = PrescriptionTemplate {
+        medication_name: String::from_str(&env, "Atorvastatin"),
+        ndc_code: String::from_str(&env, "00071-0156-23"),
+        dosage: String::from_str(&env, "20mg"),
+        quantity: 30,
+        days_supply: 30,
+        refills_allowed: 5,
+        instructions_hash: BytesN::from_array(&env, &[2u8; 32]),
+        is_controlled: false,
+        schedule: None,
+        substitution_allowed: true,
+        pharmacy_id: None,
+        bypass_allergy_check: false,
+        dea_number: None,
+        bypass_reason_hash: None,
+    };
+
+    let template_id = client.create_template(&owner, &template);
+    let valid_until = env.ledger().timestamp() + 86_400;
+
+    let result = client.try_issue_from_template(&other, &patient, &template_id, &valid_until);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
 }

--- a/contracts/prescription-management/test_snapshots/test/test_fail_expired_prescription.1.json
+++ b/contracts/prescription-management/test_snapshots/test/test_fail_expired_prescription.1.json
@@ -25,11 +25,25 @@
                   "map": [
                     {
                       "key": {
+                        "symbol": "bypass_allergy_check"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "days_supply"
                       },
                       "val": {
                         "u32": 5
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "dea_number"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {

--- a/contracts/prescription-management/test_snapshots/test/test_prescription_lifecycle.1.json
+++ b/contracts/prescription-management/test_snapshots/test/test_prescription_lifecycle.1.json
@@ -25,11 +25,25 @@
                   "map": [
                     {
                       "key": {
+                        "symbol": "bypass_allergy_check"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "days_supply"
                       },
                       "val": {
                         "u32": 10
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "dea_number"
+                      },
+                      "val": "void"
                     },
                     {
                       "key": {


### PR DESCRIPTION
prescription-management:
- #482: add create_template / issue_from_template with provider ownership enforcement
- #480: add per-provider rate-limit (default 100/24h) with sliding window reset; admin set_provider_limit override
- #481: require bypass_reason_hash when bypass_allergy_check=true; emit AllergyBypassApproved audit event

clinical-trial:
- #484: add Site type with coordinator/quota; add_site (PI only) and enrol_participant_at_site enforce per-site and total caps; ParticipantEnrollment tracks site_id

closes 
#480
 #481 
 #482 
 #484 
tests: coverage for all acceptance criteria across both contracts