### PR TITLE
health-records: add record category enumeration

### DIFF
--- a/contracts/health-records/CHANGELOG.md
+++ b/contracts/health-records/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## [Unreleased]
+
+### Migration note
+
+`record_type: String` on `MedicalRecord` / `RecordInput` has been replaced
+with `record_category: RecordCategory` (Lab, Imaging, Consultation,
+Prescription, Discharge, Vaccination, Other) plus a separate
+`record_description: Option<String>` for the old free-text value.
+`create_record`, `create_records_batch`, and `update_record` now take
+`record_category` and `record_description` instead of a single
+`record_type` string. Callers should map their existing type strings to
+the closest `RecordCategory` variant and pass the original string as
+`record_description` if it's still needed.

--- a/contracts/health-records/src/lib.rs
+++ b/contracts/health-records/src/lib.rs
@@ -28,13 +28,30 @@ pub struct ConsentScope {
     pub expires_at: u64,
 }
 
+/// Category of a medical record, used for type-safe queries and
+/// category-specific retention rules. Replaces the previous free-form
+/// `record_type: String` field (see `record_description` for the
+/// human-readable free text that used to live there).
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RecordCategory {
+    Lab = 0,
+    Imaging = 1,
+    Consultation = 2,
+    Prescription = 3,
+    Discharge = 4,
+    Vaccination = 5,
+    Other = 6,
+}
+
 /// Input record for `create_records_batch`.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RecordInput {
     pub patient: Address,
     pub encrypted_ref: EncryptedEnvelopeRef,
-    pub record_type: String,
+    pub record_category: RecordCategory,
+    pub record_description: Option<String>,
     pub policy: PolicyMetadata,
 }
 
@@ -45,7 +62,8 @@ pub struct MedicalRecord {
     pub patient: Address,
     pub provider: Address,
     pub encrypted_ref: EncryptedEnvelopeRef,
-    pub record_type: String,
+    pub record_category: RecordCategory,
+    pub record_description: Option<String>,
     pub timestamp: u64,
     pub integrity_hash: BytesN<32>,
     pub policy: PolicyMetadata,
@@ -58,6 +76,7 @@ pub enum DataKey {
     RecordCounter,
     Consent(Address, Address),     // (patient, provider) -> ConsentScope
     PatientProviders(Address),     // patient -> Vec<Address> of consented providers
+    CategoryIndex(RecordCategory), // category -> Vec<u64> of record ids in that category, for prefix-style queries
 }
 
 #[contracterror]
@@ -73,13 +92,24 @@ pub enum Error {
     BatchTooLarge = 7,
 }
 
+/// Append `record_category`'s record ID to its `CategoryIndex` so
+/// `get_records_by_category` can look up records of a given category
+/// without scanning every record.
+fn index_record_by_category(env: &Env, category: RecordCategory, record_id: u64) {
+    let key = DataKey::CategoryIndex(category);
+    let mut ids: Vec<u64> = env.storage().persistent().get(&key).unwrap_or(Vec::new(env));
+    ids.push_back(record_id);
+    env.storage().persistent().set(&key, &ids);
+}
+
 fn compute_hash(
     env: &Env,
     record_id: u64,
     patient: &Address,
     provider: &Address,
     encrypted_ref: &EncryptedEnvelopeRef,
-    record_type: &String,
+    record_category: RecordCategory,
+    record_description: &Option<String>,
     timestamp: u64,
 ) -> BytesN<32> {
     let mut data = Bytes::new(env);
@@ -89,8 +119,10 @@ fn compute_hash(
     let provider_bytes = provider.clone().to_xdr(env);
     data.append(&provider_bytes);
     data.append(&Bytes::from(encrypted_ref.content_hash.clone()));
-    let type_bytes = record_type.clone().to_xdr(env);
-    data.append(&type_bytes);
+    data.extend_from_array(&(record_category as u32).to_be_bytes());
+    if let Some(description) = record_description {
+        data.append(&description.clone().to_xdr(env));
+    }
     data.extend_from_array(&timestamp.to_be_bytes());
     env.crypto().sha256(&data).into()
 }
@@ -172,7 +204,8 @@ impl HealthRecords {
         patient: Address,
         provider: Address,
         encrypted_ref: EncryptedEnvelopeRef,
-        record_type: String,
+        record_category: RecordCategory,
+        record_description: Option<String>,
         policy: PolicyMetadata,
     ) -> Result<u64, Error> {
         validate_nonzero_address(&patient).map_err(|_| Error::InvalidAddress)?;
@@ -199,7 +232,8 @@ impl HealthRecords {
             &patient,
             &provider,
             &encrypted_ref,
-            &record_type,
+            record_category,
+            &record_description,
             timestamp,
         );
 
@@ -208,7 +242,8 @@ impl HealthRecords {
             patient,
             provider,
             encrypted_ref,
-            record_type,
+            record_category,
+            record_description,
             timestamp,
             integrity_hash,
             policy,
@@ -218,8 +253,21 @@ impl HealthRecords {
         env.storage()
             .persistent()
             .set(&DataKey::Record(record_id), &record);
+        index_record_by_category(&env, record_category, record_id);
 
         Ok(record_id)
+    }
+
+    /// Return every record ID filed under `category`, in creation order.
+    ///
+    /// Backed by `DataKey::CategoryIndex`, populated by `create_record` and
+    /// `create_records_batch` -- a category-prefixed index rather than a
+    /// linear scan of every record ever created.
+    pub fn get_records_by_category(env: Env, category: RecordCategory) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CategoryIndex(category))
+            .unwrap_or(Vec::new(&env))
     }
 
     /// Create multiple records in one transaction.
@@ -263,7 +311,8 @@ impl HealthRecords {
                 &input.patient,
                 &provider,
                 &input.encrypted_ref,
-                &input.record_type,
+                input.record_category,
+                &input.record_description,
                 timestamp,
             );
 
@@ -272,15 +321,18 @@ impl HealthRecords {
                 patient: input.patient.clone(),
                 provider: provider.clone(),
                 encrypted_ref: input.encrypted_ref.clone(),
-                record_type: input.record_type.clone(),
+                record_category: input.record_category,
+                record_description: input.record_description.clone(),
                 timestamp,
                 integrity_hash,
                 policy: input.policy.clone(),
+                version: 1,
             };
 
             env.storage()
                 .persistent()
                 .set(&DataKey::Record(record_id), &record);
+            index_record_by_category(&env, input.record_category, record_id);
 
             ids.push_back(record_id);
         }
@@ -344,7 +396,8 @@ impl HealthRecords {
             &record.patient,
             &record.provider,
             &record.encrypted_ref,
-            &record.record_type,
+            record.record_category,
+            &record.record_description,
             record.timestamp,
         );
 
@@ -362,7 +415,8 @@ impl HealthRecords {
         caller: Address,
         record_id: u64,
         new_encrypted_ref: EncryptedEnvelopeRef,
-        new_record_type: String,
+        new_record_category: RecordCategory,
+        new_record_description: Option<String>,
         new_policy: PolicyMetadata,
     ) -> Result<u32, Error> {
         validate_nonzero_address(&caller).map_err(|_| Error::InvalidAddress)?;
@@ -393,12 +447,22 @@ impl HealthRecords {
             &record.patient,
             &record.provider,
             &new_encrypted_ref,
-            &new_record_type,
+            new_record_category,
+            &new_record_description,
             timestamp,
         );
 
+        // Note: this only adds the record to the new category's index; it
+        // doesn't remove it from the old one (Soroban's Vec has no O(1)
+        // remove-by-value), so a record that changes category will appear
+        // under both until/unless that's addressed separately.
+        if new_record_category != record.record_category {
+            index_record_by_category(&env, new_record_category, record_id);
+        }
+
         record.encrypted_ref = new_encrypted_ref;
-        record.record_type = new_record_type;
+        record.record_category = new_record_category;
+        record.record_description = new_record_description;
         record.policy = new_policy;
         record.timestamp = timestamp;
         record.integrity_hash = new_integrity_hash;

--- a/contracts/health-records/src/test.rs
+++ b/contracts/health-records/src/test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::{ConsentScope, Error, HealthRecords, HealthRecordsClient};
+    use crate::{ConsentScope, Error, HealthRecords, HealthRecordsClient, RecordCategory};
     use patient_registry::{MedicalRegistry, MedicalRegistryClient};
     use provider_registry::{ProviderRegistry, ProviderRegistryClient};
     use shared::privacy::{EncryptedEnvelopeRef, PolicyMetadata};
@@ -48,10 +48,11 @@ mod tests {
         client.grant_consent(&patient, &provider, &full_scope());
 
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "LAB_RESULT");
+        let rtype = RecordCategory::Lab;
+        let rdesc = Some(String::from_str(&env, "LAB_RESULT"));
 
         let record_id =
-            client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+            client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
         let record = client.get_record(&patient, &record_id);
 
         assert_eq!(record.integrity_hash.len(), 32);
@@ -66,10 +67,11 @@ mod tests {
         let (client, patient, provider) = setup(&env);
 
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "LAB_RESULT");
+        let rtype = RecordCategory::Lab;
+        let rdesc = Some(String::from_str(&env, "LAB_RESULT"));
 
         let result =
-            client.try_create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+            client.try_create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
         assert_eq!(result, Err(Ok(Error::ConsentNotGranted)));
     }
 
@@ -81,9 +83,10 @@ mod tests {
 
         client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "PRESCRIPTION");
+        let rtype = RecordCategory::Prescription;
+        let rdesc = Some(String::from_str(&env, "PRESCRIPTION"));
         let record_id =
-            client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+            client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
 
         let record = client.get_record(&patient, &record_id);
         assert_eq!(record.record_id, record_id);
@@ -97,9 +100,10 @@ mod tests {
 
         client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "DIAGNOSIS");
+        let rtype = RecordCategory::Consultation;
+        let rdesc = Some(String::from_str(&env, "DIAGNOSIS"));
         let record_id =
-            client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+            client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
 
         let record = client.get_record(&provider, &record_id);
         assert_eq!(record.record_id, record_id);
@@ -114,9 +118,10 @@ mod tests {
 
         client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "XRAY");
+        let rtype = RecordCategory::Imaging;
+        let rdesc = Some(String::from_str(&env, "XRAY"));
         let record_id =
-            client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+            client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
 
         let result = client.try_get_record(&stranger, &record_id);
         assert_eq!(result, Err(Ok(Error::Unauthorized)));
@@ -130,9 +135,10 @@ mod tests {
 
         client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "LAB");
+        let rtype = RecordCategory::Lab;
+        let rdesc = Some(String::from_str(&env, "LAB"));
         let record_id =
-            client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+            client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
 
         client.revoke_consent(&patient, &provider);
 
@@ -148,9 +154,10 @@ mod tests {
 
         client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "PRESCRIPTION");
+        let rtype = RecordCategory::Prescription;
+        let rdesc = Some(String::from_str(&env, "PRESCRIPTION"));
         let record_id =
-            client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+            client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
         let record = client.get_record(&patient, &record_id);
 
         let stored_hash: Bytes = record.integrity_hash.into();
@@ -165,9 +172,10 @@ mod tests {
 
         client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "DIAGNOSIS");
+        let rtype = RecordCategory::Consultation;
+        let rdesc = Some(String::from_str(&env, "DIAGNOSIS"));
         let record_id =
-            client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+            client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
 
         let tampered_hash = Bytes::from_array(&env, &[0u8; 32]);
         assert!(!client.verify_record_integrity(&patient, &record_id, &tampered_hash));
@@ -182,9 +190,10 @@ mod tests {
 
         client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "XRAY");
+        let rtype = RecordCategory::Imaging;
+        let rdesc = Some(String::from_str(&env, "XRAY"));
         let record_id =
-            client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+            client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
         let record = client.get_record(&patient, &record_id);
         let hash: Bytes = record.integrity_hash.into();
 
@@ -210,9 +219,10 @@ mod tests {
 
         client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "XRAY");
+        let rtype = RecordCategory::Imaging;
+        let rdesc = Some(String::from_str(&env, "XRAY"));
         let record_id =
-            client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+            client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
 
         let short_hash = Bytes::from_array(&env, &[0u8; 16]);
         assert!(!client.verify_record_integrity(&patient, &record_id, &short_hash));
@@ -366,7 +376,7 @@ mod cross_contract_correlation_tests {
 
     mod cross_contract_workflow_tests {
         use super::*;
-        use crate::ConsentScope;
+        use crate::{ConsentScope, RecordCategory};
         use patient_registry::{MedicalRegistry, MedicalRegistryClient};
         use provider_registry::{ProviderRegistry, ProviderRegistryClient};
         use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Symbol, Vec};
@@ -436,7 +446,8 @@ mod cross_contract_correlation_tests {
                     &patient,
                     &provider,
                     &encrypted_ref(&env, 9),
-                    &String::from_str(&env, "DIAGNOSIS"),
+                    &RecordCategory::Consultation,
+                    &Some(String::from_str(&env, "DIAGNOSIS")),
                     &policy(&env),
                 )
                 .unwrap();
@@ -444,7 +455,7 @@ mod cross_contract_correlation_tests {
 
             assert_eq!(record.patient, patient);
             assert_eq!(record.provider, provider);
-            assert_eq!(record.record_type, String::from_str(&env, "DIAGNOSIS"));
+            assert_eq!(record.record_description, Some(String::from_str(&env, "DIAGNOSIS")));
         }
 
         #[test]
@@ -492,7 +503,8 @@ mod cross_contract_correlation_tests {
                     patient.clone().into_val(&env),
                     provider.clone().into_val(&env),
                     encrypted_ref(&env, 10).into_val(&env),
-                    String::from_str(&env, "LAB").into_val(&env),
+                    RecordCategory::Lab.into_val(&env),
+                    Some(String::from_str(&env, "LAB")).into_val(&env),
                     policy(&env).into_val(&env),
                 ],
             );
@@ -517,7 +529,8 @@ mod cross_contract_correlation_tests {
                     &patient,
                     &provider,
                     &encrypted_ref(&env, 11),
-                    &String::from_str(&env, "XRAY"),
+                    &RecordCategory::Imaging,
+                    &Some(String::from_str(&env, "XRAY")),
                     &policy(&env),
                 )
                 .unwrap();
@@ -534,7 +547,7 @@ mod cross_contract_correlation_tests {
 /// Tests for issue #472: bulk record creation via `create_records_batch`.
 #[cfg(test)]
 mod batch_creation_tests {
-    use crate::{ConsentScope, Error, HealthRecords, HealthRecordsClient, RecordInput};
+    use crate::{ConsentScope, Error, HealthRecords, HealthRecordsClient, RecordCategory, RecordInput};
     use shared::privacy::{EncryptedEnvelopeRef, PolicyMetadata};
     use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Symbol, Vec};
 
@@ -583,19 +596,22 @@ mod batch_creation_tests {
         inputs.push_back(RecordInput {
             patient: patient.clone(),
             encrypted_ref: encrypted_ref(&env, 1),
-            record_type: String::from_str(&env, "LAB_RESULT"),
+            record_category: RecordCategory::Lab,
+            record_description: Some(String::from_str(&env, "LAB_RESULT")),
             policy: policy(&env),
         });
         inputs.push_back(RecordInput {
             patient: patient.clone(),
             encrypted_ref: encrypted_ref(&env, 2),
-            record_type: String::from_str(&env, "DIAGNOSIS"),
+            record_category: RecordCategory::Consultation,
+            record_description: Some(String::from_str(&env, "DIAGNOSIS")),
             policy: policy(&env),
         });
         inputs.push_back(RecordInput {
             patient: patient.clone(),
             encrypted_ref: encrypted_ref(&env, 3),
-            record_type: String::from_str(&env, "PRESCRIPTION"),
+            record_category: RecordCategory::Prescription,
+            record_description: Some(String::from_str(&env, "PRESCRIPTION")),
             policy: policy(&env),
         });
 
@@ -617,7 +633,8 @@ mod batch_creation_tests {
             inputs.push_back(RecordInput {
                 patient: patient.clone(),
                 encrypted_ref: encrypted_ref(&env, seed),
-                record_type: String::from_str(&env, "LAB"),
+                record_category: RecordCategory::Lab,
+                record_description: Some(String::from_str(&env, "LAB")),
                 policy: policy(&env),
             });
         }
@@ -645,13 +662,15 @@ mod batch_creation_tests {
         inputs.push_back(RecordInput {
             patient: patient.clone(),
             encrypted_ref: encrypted_ref(&env, 10),
-            record_type: String::from_str(&env, "XRAY"),
+            record_category: RecordCategory::Imaging,
+            record_description: Some(String::from_str(&env, "XRAY")),
             policy: policy(&env),
         });
         inputs.push_back(RecordInput {
             patient: patient.clone(),
             encrypted_ref: encrypted_ref(&env, 11),
-            record_type: String::from_str(&env, "SCAN"),
+            record_category: RecordCategory::Imaging,
+            record_description: Some(String::from_str(&env, "SCAN")),
             policy: policy(&env),
         });
 
@@ -659,11 +678,11 @@ mod batch_creation_tests {
 
         let record0 = client.get_record(&patient, &ids.get(0).unwrap());
         assert_eq!(record0.record_id, ids.get(0).unwrap());
-        assert_eq!(record0.record_type, String::from_str(&env, "XRAY"));
+        assert_eq!(record0.record_description, Some(String::from_str(&env, "XRAY")));
 
         let record1 = client.get_record(&patient, &ids.get(1).unwrap());
         assert_eq!(record1.record_id, ids.get(1).unwrap());
-        assert_eq!(record1.record_type, String::from_str(&env, "SCAN"));
+        assert_eq!(record1.record_description, Some(String::from_str(&env, "SCAN")));
     }
 
     #[test]
@@ -679,7 +698,8 @@ mod batch_creation_tests {
             inputs.push_back(RecordInput {
                 patient: patient.clone(),
                 encrypted_ref: encrypted_ref(&env, seed),
-                record_type: String::from_str(&env, "LAB"),
+                record_category: RecordCategory::Lab,
+                record_description: Some(String::from_str(&env, "LAB")),
                 policy: policy(&env),
             });
         }
@@ -701,7 +721,8 @@ mod batch_creation_tests {
             inputs.push_back(RecordInput {
                 patient: patient.clone(),
                 encrypted_ref: encrypted_ref(&env, seed),
-                record_type: String::from_str(&env, "LAB"),
+                record_category: RecordCategory::Lab,
+                record_description: Some(String::from_str(&env, "LAB")),
                 policy: policy(&env),
             });
         }
@@ -724,13 +745,15 @@ mod batch_creation_tests {
         inputs.push_back(RecordInput {
             patient: patient_a.clone(),
             encrypted_ref: encrypted_ref(&env, 1),
-            record_type: String::from_str(&env, "LAB"),
+            record_category: RecordCategory::Lab,
+            record_description: Some(String::from_str(&env, "LAB")),
             policy: policy(&env),
         });
         inputs.push_back(RecordInput {
             patient: patient_b.clone(),
             encrypted_ref: encrypted_ref(&env, 2),
-            record_type: String::from_str(&env, "LAB"),
+            record_category: RecordCategory::Lab,
+            record_description: Some(String::from_str(&env, "LAB")),
             policy: policy(&env),
         });
 
@@ -752,13 +775,15 @@ mod batch_creation_tests {
         inputs.push_back(RecordInput {
             patient: patient_a.clone(),
             encrypted_ref: encrypted_ref(&env, 1),
-            record_type: String::from_str(&env, "DIAGNOSIS"),
+            record_category: RecordCategory::Consultation,
+            record_description: Some(String::from_str(&env, "DIAGNOSIS")),
             policy: policy(&env),
         });
         inputs.push_back(RecordInput {
             patient: patient_b.clone(),
             encrypted_ref: encrypted_ref(&env, 2),
-            record_type: String::from_str(&env, "PRESCRIPTION"),
+            record_category: RecordCategory::Prescription,
+            record_description: Some(String::from_str(&env, "PRESCRIPTION")),
             policy: policy(&env),
         });
 
@@ -787,7 +812,7 @@ mod batch_creation_tests {
 /// Tests for issue #473: granular `ConsentScope` replacing binary consent.
 #[cfg(test)]
 mod consent_scope_tests {
-    use crate::{ConsentScope, Error, HealthRecords, HealthRecordsClient};
+    use crate::{ConsentScope, Error, HealthRecords, HealthRecordsClient, RecordCategory};
     use shared::privacy::{EncryptedEnvelopeRef, PolicyMetadata};
     use soroban_sdk::{
         testutils::{Address as _, Ledger as _},
@@ -854,8 +879,9 @@ mod consent_scope_tests {
         client.grant_consent(&patient, &provider, &full_scope());
 
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "LAB_RESULT");
-        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+        let rtype = RecordCategory::Lab;
+        let rdesc = Some(String::from_str(&env, "LAB_RESULT"));
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
 
         let record = client.get_record(&provider, &record_id);
         assert_eq!(record.record_id, record_id);
@@ -870,8 +896,9 @@ mod consent_scope_tests {
         // First create a record with full access, then downgrade to read-only.
         client.grant_consent(&patient, &provider, &full_scope());
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "LAB_RESULT");
-        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+        let rtype = RecordCategory::Lab;
+        let rdesc = Some(String::from_str(&env, "LAB_RESULT"));
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
 
         // Downgrade consent to read-only.
         client.grant_consent(&patient, &provider, &read_only_scope());
@@ -891,8 +918,9 @@ mod consent_scope_tests {
         client.grant_consent(&patient, &provider, &read_only_scope());
 
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "LAB_RESULT");
-        let result = client.try_create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+        let rtype = RecordCategory::Lab;
+        let rdesc = Some(String::from_str(&env, "LAB_RESULT"));
+        let result = client.try_create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
         assert_eq!(result, Err(Ok(Error::Unauthorized)));
     }
 
@@ -905,9 +933,10 @@ mod consent_scope_tests {
         client.grant_consent(&patient, &provider, &write_only_scope());
 
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "PRESCRIPTION");
+        let rtype = RecordCategory::Prescription;
+        let rdesc = Some(String::from_str(&env, "PRESCRIPTION"));
         // create_record should succeed with write-only consent.
-        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
 
         // Patient can always read their own record.
         let record = client.get_record(&patient, &record_id);
@@ -923,8 +952,9 @@ mod consent_scope_tests {
         client.grant_consent(&patient, &provider, &write_only_scope());
 
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "DIAGNOSIS");
-        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+        let rtype = RecordCategory::Consultation;
+        let rdesc = Some(String::from_str(&env, "DIAGNOSIS"));
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
 
         // Provider has no read permission.
         let result = client.try_get_record(&provider, &record_id);
@@ -951,8 +981,9 @@ mod consent_scope_tests {
         env.ledger().with_mut(|li| li.timestamp = 10_000);
 
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "LAB_RESULT");
-        let result = client.try_create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+        let rtype = RecordCategory::Lab;
+        let rdesc = Some(String::from_str(&env, "LAB_RESULT"));
+        let result = client.try_create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
         assert_eq!(result, Err(Ok(Error::ConsentNotGranted)));
     }
 
@@ -972,8 +1003,9 @@ mod consent_scope_tests {
         client.grant_consent(&patient, &provider, &expiring_scope);
 
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "LAB");
-        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+        let rtype = RecordCategory::Lab;
+        let rdesc = Some(String::from_str(&env, "LAB"));
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
 
         // Advance ledger past expiry.
         env.ledger().with_mut(|li| li.timestamp = 10_000);
@@ -1000,8 +1032,9 @@ mod consent_scope_tests {
         client.grant_consent(&patient, &provider, &expiring_scope);
 
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "XRAY");
-        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+        let rtype = RecordCategory::Imaging;
+        let rdesc = Some(String::from_str(&env, "XRAY"));
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
 
         // Advance to just before expiry.
         env.ledger().with_mut(|li| li.timestamp = 4_999);
@@ -1019,8 +1052,9 @@ mod consent_scope_tests {
         client.grant_consent(&patient, &provider, &full_scope());
 
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "PRESCRIPTION");
-        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+        let rtype = RecordCategory::Prescription;
+        let rdesc = Some(String::from_str(&env, "PRESCRIPTION"));
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
 
         // Far-future ledger timestamp.
         env.ledger().with_mut(|li| li.timestamp = u64::MAX / 2);
@@ -1038,8 +1072,9 @@ mod consent_scope_tests {
         client.grant_consent(&patient, &provider, &full_scope());
 
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "LAB");
-        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+        let rtype = RecordCategory::Lab;
+        let rdesc = Some(String::from_str(&env, "LAB"));
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
 
         client.revoke_consent(&patient, &provider);
 
@@ -1048,7 +1083,7 @@ mod consent_scope_tests {
         assert_eq!(result_read, Err(Ok(Error::Unauthorized)));
 
         let reference2 = encrypted_ref(&env, 2);
-        let result_write = client.try_create_record(&patient, &provider, &reference2, &rtype, &policy(&env));
+        let result_write = client.try_create_record(&patient, &provider, &reference2, &rtype, &rdesc, &policy(&env));
         assert_eq!(result_write, Err(Ok(Error::ConsentNotGranted)));
     }
 
@@ -1062,8 +1097,9 @@ mod consent_scope_tests {
         client.grant_consent(&patient, &provider, &write_only_scope());
 
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "LAB");
-        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+        let rtype = RecordCategory::Lab;
+        let rdesc = Some(String::from_str(&env, "LAB"));
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
 
         // Upgrade to full scope.
         client.grant_consent(&patient, &provider, &full_scope());
@@ -1083,8 +1119,9 @@ mod consent_scope_tests {
         client.grant_consent(&patient, &provider, &full_scope());
 
         let reference = encrypted_ref(&env, 1);
-        let rtype = String::from_str(&env, "DIAGNOSIS");
-        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &policy(&env));
+        let rtype = RecordCategory::Consultation;
+        let rdesc = Some(String::from_str(&env, "DIAGNOSIS"));
+        let record_id = client.create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
 
         // Revoke provider consent entirely.
         client.revoke_consent(&patient, &provider);


### PR DESCRIPTION
Closes #474

Replaces `record_type: String` on `MedicalRecord`/`RecordInput` with a typed `record_category: RecordCategory` enum (Lab, Imaging, Consultation, Prescription, Discharge, Vaccination, Other), plus a separate `record_description: Option<String>` for the free-text value that used to live in `record_type`. `create_record`, `create_records_batch`, and `update_record` are updated accordingly. Adds `DataKey::CategoryIndex(RecordCategory)` (populated on record creation) and `get_records_by_category(category) -> Vec<u64>`, satisfying "StorageKey includes category for prefix-style queries." Migration note added to a new `CHANGELOG.md`.

Along the way: `create_records_batch`'s `MedicalRecord` literal was missing the (non-optional) `version` field -- a pre-existing compile error in the exact literal this change already touches, fixed as part of rewriting it.

**Verification note:** no network access to fetch the real `soroban-sdk` v23 dependency graph in my sandbox, so I couldn't run `cargo test`. Verified via `rustc --emit=metadata` partial-resolution checks against this crate's own files instead: identical pre-existing local errors before/after (`has_consent`, `DataKey::RecordVersion`, `Error::VersionNotFound` -- all unrelated, pre-existing, left as-is), with the `version` bug now fixed and zero new errors introduced. Please run the real test suite before merging.