### PR TITLE
prescription-management: enforce maximum concurrent active prescriptions per patient

### DIFF
--- a/contracts/prescription-management/src/lib.rs
+++ b/contracts/prescription-management/src/lib.rs
@@ -38,6 +38,12 @@ pub trait ProviderRegistryInterface {
 /// Attempting to exceed this returns `Error::TransferHistoryFull`.
 pub const MAX_TRANSFER_HISTORY: u32 = 100;
 
+/// Maximum number of concurrently active prescriptions a single patient may
+/// hold. "Active" means status is Issued, Active, or PartiallyDispensed
+/// *and* not yet past `valid_until`. Attempting to issue prescription
+/// N+1 beyond this limit returns `Error::TooManyActivePrescriptions`.
+pub const MAX_ACTIVE_PRESCRIPTIONS: u32 = 50;
+
 pub const SECONDS_PER_HOUR: u64 = 3600;
 /// 30-day window used when extending a prescription's validity on refill.
 pub const REFILL_WINDOW_SECS: u64 = 30 * 24 * SECONDS_PER_HOUR;
@@ -137,6 +143,8 @@ pub enum Error {
     CannotRecallDispensed = 27,
     /// Recall reason is required for documentation
     MissingRecallReason = 28,
+    /// Patient already has MAX_ACTIVE_PRESCRIPTIONS active prescriptions
+    TooManyActivePrescriptions = 29,
 }
 
 #[contracttype]
@@ -240,6 +248,12 @@ pub enum DataKey {
     RecallCounter,
     RecallRecord(u64),
     PrescriptionRecall(u64),
+    /// patient -> Vec<u64> of prescription ids issued to them, used to
+    /// enforce MAX_ACTIVE_PRESCRIPTIONS. Pruned of no-longer-active ids
+    /// every time a new prescription is issued (see
+    /// `count_and_prune_active_prescriptions`), so it stays close to the
+    /// patient's actual active count rather than growing unboundedly.
+    PatientPrescriptions(Address),
 }
 
 #[contracttype]
@@ -338,6 +352,53 @@ pub struct RecallRecord {
     pub recall_reason: String,
     pub recall_timestamp: u64,
     pub clinical_justification: String,
+}
+
+/// Whether a prescription still counts as "active" toward
+/// `MAX_ACTIVE_PRESCRIPTIONS`: its status is still actionable (not
+/// dispensed/cancelled/recalled/transferred-away) *and* it hasn't passed
+/// its `valid_until` timestamp. Expiry in this contract is passive (no
+/// stored state transition marks a prescription `Expired`), so it must be
+/// checked against the current ledger time here rather than by status alone.
+fn is_prescription_active(prescription: &Prescription, now: u64) -> bool {
+    matches!(
+        prescription.status,
+        PrescriptionStatus::Issued | PrescriptionStatus::Active | PrescriptionStatus::PartiallyDispensed
+    ) && prescription.valid_until > now
+}
+
+/// Returns the patient's current active-prescription count, and rewrites
+/// `DataKey::PatientPrescriptions(patient)` to drop ids that are no longer
+/// active (dispensed, cancelled, recalled, transferred away, or expired) --
+/// so the index stays close to bounded rather than growing for the
+/// patient's entire history. Called from `issue_prescription` before
+/// enforcing `MAX_ACTIVE_PRESCRIPTIONS`.
+fn count_and_prune_active_prescriptions(env: &Env, patient: &Address) -> u32 {
+    let key = DataKey::PatientPrescriptions(patient.clone());
+    let ids: Vec<u64> = env.storage().persistent().get(&key).unwrap_or(Vec::new(env));
+    let now = env.ledger().timestamp();
+
+    let mut still_active: Vec<u64> = Vec::new(env);
+    for id in ids.iter() {
+        if let Some(prescription) = env.storage().persistent().get::<u64, Prescription>(&id) {
+            if is_prescription_active(&prescription, now) {
+                still_active.push_back(id);
+            }
+        }
+    }
+
+    let count = still_active.len();
+    env.storage().persistent().set(&key, &still_active);
+    count
+}
+
+/// Records `prescription_id` as belonging to `patient` in the
+/// `PatientPrescriptions` index, used by `count_and_prune_active_prescriptions`.
+fn add_patient_prescription(env: &Env, patient: &Address, prescription_id: u64) {
+    let key = DataKey::PatientPrescriptions(patient.clone());
+    let mut ids: Vec<u64> = env.storage().persistent().get(&key).unwrap_or(Vec::new(env));
+    ids.push_back(prescription_id);
+    env.storage().persistent().set(&key, &ids);
 }
 
 #[contract]
@@ -466,6 +527,11 @@ impl PrescriptionContract {
         )
         .map_err(|_| Error::InvalidValidityWindow)?;
 
+        // #478 – cap concurrent active prescriptions per patient.
+        if count_and_prune_active_prescriptions(&env, &patient_id) >= MAX_ACTIVE_PRESCRIPTIONS {
+            return Err(Error::TooManyActivePrescriptions);
+        }
+
         let id = env
             .storage()
             .instance()
@@ -497,6 +563,7 @@ impl PrescriptionContract {
         env.storage()
             .instance()
             .set(&Symbol::new(&env, "ID_COUNTER"), &(id + 1));
+        add_patient_prescription(&env, &prescription.patient_id, id);
 
         Ok(id)
     }

--- a/contracts/prescription-management/src/test.rs
+++ b/contracts/prescription-management/src/test.rs
@@ -112,6 +112,130 @@ fn test_fail_expired_prescription() {
     client.dispense_prescription(&dispense, &pharmacy);
 }
 
+// ── #478: MAX_ACTIVE_PRESCRIPTIONS cap ──────────────────────────────────────
+
+fn max_cap_request(env: &Env, pharmacy: &Address, valid_until: u64) -> IssueRequest {
+    IssueRequest {
+        medication_name: String::from_str(env, "Amoxicillin"),
+        ndc_code: String::from_str(env, "0501-1234-01"),
+        dosage: String::from_str(env, "500mg"),
+        quantity: 30,
+        days_supply: 10,
+        refills_allowed: 0,
+        instructions_hash: BytesN::from_array(env, &[0u8; 32]),
+        is_controlled: false,
+        schedule: None,
+        valid_until,
+        substitution_allowed: true,
+        pharmacy_id: Some(pharmacy.clone()),
+        bypass_allergy_check: false,
+        dea_number: None,
+    }
+}
+
+#[test]
+fn test_issuing_beyond_max_active_prescriptions_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(PrescriptionContract, ());
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+    let pharmacy = Address::generate(&env);
+
+    for _ in 0..MAX_ACTIVE_PRESCRIPTIONS {
+        let req = max_cap_request(&env, &pharmacy, 10_000_000);
+        client.issue_prescription(&provider, &patient, &req);
+    }
+
+    // The (MAX_ACTIVE_PRESCRIPTIONS + 1)th prescription for the same patient is rejected.
+    let req = max_cap_request(&env, &pharmacy, 10_000_000);
+    let result = client.try_issue_prescription(&provider, &patient, &req);
+    assert_eq!(result, Err(Ok(Error::TooManyActivePrescriptions)));
+
+    // A different patient is unaffected by this patient's cap.
+    let other_patient = Address::generate(&env);
+    let req = max_cap_request(&env, &pharmacy, 10_000_000);
+    client.issue_prescription(&provider, &other_patient, &req);
+}
+
+#[test]
+fn test_issuing_succeeds_after_a_prescription_is_fully_dispensed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(PrescriptionContract, ());
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+    let pharmacy = Address::generate(&env);
+
+    let mut first_id = 0u64;
+    for i in 0..MAX_ACTIVE_PRESCRIPTIONS {
+        let req = max_cap_request(&env, &pharmacy, 10_000_000);
+        let id = client.issue_prescription(&provider, &patient, &req);
+        if i == 0 {
+            first_id = id;
+        }
+    }
+
+    // At the cap: the next issuance is rejected.
+    let req = max_cap_request(&env, &pharmacy, 10_000_000);
+    let result = client.try_issue_prescription(&provider, &patient, &req);
+    assert_eq!(result, Err(Ok(Error::TooManyActivePrescriptions)));
+
+    // Fully dispense one existing prescription, freeing a slot.
+    client.dispense_prescription(
+        &DispenseRequest {
+            prescription_id: first_id,
+            quantity: 30,
+            lot: String::from_str(&env, "LOT-FULL"),
+            expires_at: 20_000_000,
+            ndc_code: String::from_str(&env, "0501-1234-01"),
+        },
+        &pharmacy,
+    );
+
+    // A new prescription can now be issued for the same patient.
+    let req = max_cap_request(&env, &pharmacy, 10_000_000);
+    client.issue_prescription(&provider, &patient, &req);
+}
+
+#[test]
+fn test_issuing_succeeds_after_a_prescription_expires() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(PrescriptionContract, ());
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+    let pharmacy = Address::generate(&env);
+
+    // One prescription with a short validity window; the rest valid for a long time.
+    let short_req = max_cap_request(&env, &pharmacy, 100);
+    client.issue_prescription(&provider, &patient, &short_req);
+    for _ in 1..MAX_ACTIVE_PRESCRIPTIONS {
+        let req = max_cap_request(&env, &pharmacy, 10_000_000);
+        client.issue_prescription(&provider, &patient, &req);
+    }
+
+    // At the cap: the next issuance is rejected.
+    let req = max_cap_request(&env, &pharmacy, 10_000_000);
+    let result = client.try_issue_prescription(&provider, &patient, &req);
+    assert_eq!(result, Err(Ok(Error::TooManyActivePrescriptions)));
+
+    // Advance past the short prescription's valid_until (expiry is exclusive: expired at >=).
+    env.ledger().with_mut(|li| {
+        li.timestamp = 100;
+    });
+
+    // A new prescription can now be issued: the expired one no longer counts.
+    let req = max_cap_request(&env, &pharmacy, 10_000_000);
+    client.issue_prescription(&provider, &patient, &req);
+}
+
 #[test]
 fn test_multi_drug_interactions_with_severity() {
     let env = Env::default();


### PR DESCRIPTION
Closes #478

Adds `MAX_ACTIVE_PRESCRIPTIONS: u32 = 50` and `Error::TooManyActivePrescriptions`. `issue_prescription` now counts the patient's active prescriptions (status Issued/Active/PartiallyDispensed **and** not yet past `valid_until` -- expiry in this contract is passive, never a stored status transition) before issuing, rejecting at the cap.

Adds `DataKey::PatientPrescriptions(Address)` tracking each patient's issued prescription ids. The count/check helper prunes ids that are no longer active every time it runs, so the index stays close to bounded by the cap rather than growing for the patient's entire history. `issue_prescription`'s signature is unchanged -- no existing call sites needed updates.

Tests cover: cap enforcement, a second patient unaffected by the first's cap, a freed slot after a full dispense, and a freed slot after a short-validity prescription expires (ledger time advanced past `valid_until`).

**Verification note:** no network access to fetch the dependency graph in my sandbox. Verified via `rustc --emit=metadata` partial-resolution checks: identical pre-existing local-resolution errors before/after, plus exactly the 3 new references expected from the 3 new test functions -- no new error categories introduced. Please run the real test suite before merging.