### PR TITLE
patient-registry: add Merkle-proof API for record integrity verification

### DIFF
--- a/contracts/patient-registry/src/lib.rs
+++ b/contracts/patient-registry/src/lib.rs
@@ -1728,6 +1728,50 @@ impl MedicalRegistry {
         merkle::verify_membership(&env, record_id, &proof, &root)
     }
 
+    /// Generate a Merkle membership proof for the record at `record_index`
+    /// (0-based position within `PatientRecordIds`, insertion order -- not
+    /// a record ID) in `patient`'s record tree.
+    ///
+    /// The returned proof, together with `hash_leaf(env, record_id)`, can be
+    /// passed to `verify_record_membership`; or pass the leaf hash directly
+    /// to `verify_record_proof`. Returns `ContractError::RecordNotFound` if
+    /// `record_index` is out of bounds.
+    pub fn get_record_proof(
+        env: Env,
+        patient: Address,
+        record_index: u32,
+    ) -> Result<Vec<BytesN<32>>, ContractError> {
+        let ids_key = DataKey::PatientRecordIds(patient);
+        let record_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&ids_key)
+            .unwrap_or(Vec::new(&env));
+
+        if record_index >= record_ids.len() {
+            return Err(ContractError::RecordNotFound);
+        }
+
+        Ok(merkle::generate_proof(&env, &record_ids, record_index))
+    }
+
+    /// Returns true iff `proof` is a valid Merkle membership proof for
+    /// `leaf_hash` under this patient's root.
+    ///
+    /// Like `verify_record_membership` but takes the leaf hash directly
+    /// rather than a raw record ID -- pair with `get_record_proof` and
+    /// `merkle::hash_leaf` when the caller already has (or only needs) the
+    /// hash.
+    pub fn verify_record_proof(
+        env: Env,
+        patient: Address,
+        leaf_hash: BytesN<32>,
+        proof: Vec<BytesN<32>>,
+    ) -> bool {
+        let root = Self::get_merkle_root(env.clone(), patient);
+        merkle::verify_leaf_membership(&env, leaf_hash, &proof, &root)
+    }
+
     /// Returns all records for `patient` whose `record_type` matches the given symbol.
     /// Access control: caller must be the patient, their guardian, or an authorized doctor.
     /// Returns an empty vec (not an error) when no records match.

--- a/contracts/patient-registry/src/merkle.rs
+++ b/contracts/patient-registry/src/merkle.rs
@@ -88,6 +88,62 @@ pub fn compute_merkle_root(env: &Env, record_ids: &Vec<u64>) -> BytesN<32> {
     layer.get(0).unwrap_or_else(|| panic_with_error!(env, crate::ContractError::NotFound))
 }
 
+// ─── proof generation ───────────────────────────────────────────────────────
+
+/// Generate a Merkle membership proof for the leaf at `target_index` within
+/// `record_ids` (insertion order, matching `compute_merkle_root`).
+///
+/// Returns one sibling hash per tree level (leaf level → root), in the same
+/// shape `verify_membership` / `verify_leaf_membership` expect. Returns an
+/// empty `Vec` if `target_index` is out of bounds.
+///
+/// Mirrors `compute_merkle_root`'s layer-by-layer reduction (same pairing
+/// and odd-node-self-pairing rules) while tracking which sibling pairs with
+/// the target leaf at each level. Because `hash_pair` sorts its two inputs
+/// before hashing, the proof never needs to record left/right position.
+pub fn generate_proof(env: &Env, record_ids: &Vec<u64>, target_index: u32) -> Vec<BytesN<32>> {
+    let mut proof: Vec<BytesN<32>> = Vec::new(env);
+    let n = record_ids.len();
+    if target_index >= n {
+        return proof;
+    }
+
+    let mut layer: Vec<BytesN<32>> = Vec::new(env);
+    for id in record_ids.iter() {
+        layer.push_back(hash_leaf(env, id));
+    }
+
+    let mut idx = target_index;
+    while layer.len() > 1 {
+        let len = layer.len();
+        let mut next: Vec<BytesN<32>> = Vec::new(env);
+        let mut i = 0u32;
+        while i + 1 < len {
+            let left = layer.get(i).unwrap_or_else(|| panic_with_error!(env, crate::ContractError::NotFound));
+            let right = layer.get(i + 1).unwrap_or_else(|| panic_with_error!(env, crate::ContractError::NotFound));
+            if idx == i {
+                proof.push_back(right.clone());
+            } else if idx == i + 1 {
+                proof.push_back(left.clone());
+            }
+            next.push_back(hash_pair(env, left, right));
+            i += 2;
+        }
+        // Odd node: pair with itself; if it's our target, the "sibling" is itself.
+        if len % 2 == 1 {
+            let last = layer.get(len - 1).unwrap_or_else(|| panic_with_error!(env, crate::ContractError::NotFound));
+            if idx == len - 1 {
+                proof.push_back(last.clone());
+            }
+            next.push_back(hash_pair(env, last.clone(), last));
+        }
+        idx /= 2;
+        layer = next;
+    }
+
+    proof
+}
+
 // ─── membership verification ───────────────────────────────────────────────
 
 /// Verify that `record_id` belongs to the tree with the given `root`.
@@ -100,7 +156,19 @@ pub fn verify_membership(
     proof: &Vec<BytesN<32>>,
     root: &BytesN<32>,
 ) -> bool {
-    let mut current = hash_leaf(env, record_id);
+    verify_leaf_membership(env, hash_leaf(env, record_id), proof, root)
+}
+
+/// Verify that a precomputed leaf hash belongs to the tree with the given
+/// `root`, given a sibling proof. Same as `verify_membership` but for
+/// callers that already have the leaf hash rather than the raw record ID.
+pub fn verify_leaf_membership(
+    env: &Env,
+    leaf_hash: BytesN<32>,
+    proof: &Vec<BytesN<32>>,
+    root: &BytesN<32>,
+) -> bool {
+    let mut current = leaf_hash;
     for sibling in proof.iter() {
         current = hash_pair(env, current, sibling);
     }

--- a/contracts/patient-registry/src/test.rs
+++ b/contracts/patient-registry/src/test.rs
@@ -4221,3 +4221,135 @@ fn test_grant_access_allows_registered_provider() {
     let authorized = client.get_authorized_doctors(&patient);
     assert_eq!(authorized.len(), 1);
 }
+
+// ── #469: Merkle-proof API (get_record_proof / verify_record_proof) ────────
+
+/// Registers a patient, authorizes `doctor`, and adds `n` medical records.
+/// Returns `(client, patient, record_ids)` in insertion order, matching
+/// `PatientRecordIds` / the Merkle leaf order.
+fn setup_patient_with_records(
+    env: &Env,
+    n: u32,
+) -> (MedicalRegistryClient<'static>, Address, Address, Vec<u64>) {
+    let contract_id = env.register(MedicalRegistry, ());
+    let client = MedicalRegistryClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    let treasury = Address::generate(env);
+    let fee_token = Address::generate(env);
+    let patient = Address::generate(env);
+    let doctor = Address::generate(env);
+    let v1 = BytesN::from_array(env, &[1u8; 32]);
+
+    env.mock_all_auths();
+
+    client.initialize(&admin, &treasury, &fee_token);
+    client.register_patient(
+        &patient,
+        &String::from_str(env, "Test Patient"),
+        &631152000,
+        &encrypted_ref(env, 1),
+        &policy(env),
+    );
+    client.publish_consent_version(&v1);
+    client.acknowledge_consent(&patient, &patient, &v1);
+    client.grant_access(&patient, &patient, &doctor);
+
+    let mut record_ids: Vec<u64> = Vec::new(env);
+    for i in 0..n {
+        let id = client.add_medical_record(
+            &patient,
+            &doctor,
+            &encrypted_ref(env, (i + 20) as u8),
+            &Symbol::new(env, "LAB"),
+            &policy(env),
+        );
+        record_ids.push_back(id);
+    }
+
+    (client, patient, doctor, record_ids)
+}
+
+#[test]
+fn test_get_record_proof_roundtrip_verifies_true() {
+    let env = Env::default();
+    // Five records: exercises an odd-length layer (self-pairing) at the leaf level.
+    let (client, patient, _doctor, record_ids) = setup_patient_with_records(&env, 5);
+
+    for (index, record_id) in record_ids.iter().enumerate() {
+        let proof = client.get_record_proof(&patient, &(index as u32));
+
+        // Verify via the existing record-id-based entry point.
+        assert!(client.verify_record_membership(&patient, &record_id, &proof));
+
+        // Verify via the new leaf-hash-based entry point.
+        let leaf_hash = merkle::hash_leaf(&env, record_id);
+        assert!(client.verify_record_proof(&patient, &leaf_hash, &proof));
+    }
+}
+
+#[test]
+fn test_get_record_proof_out_of_bounds_index_fails() {
+    let env = Env::default();
+    let (client, patient, _doctor, record_ids) = setup_patient_with_records(&env, 3);
+
+    let result = client.try_get_record_proof(&patient, &(record_ids.len()));
+    assert_eq!(result, Err(Ok(ContractError::RecordNotFound)));
+}
+
+#[test]
+fn test_verify_record_proof_fails_when_leaf_hash_altered() {
+    let env = Env::default();
+    let (client, patient, _doctor, record_ids) = setup_patient_with_records(&env, 4);
+
+    let target_index = 1u32;
+    let target_id = record_ids.get(target_index).unwrap();
+    let proof = client.get_record_proof(&patient, &target_index);
+
+    // Sanity: the real leaf hash verifies.
+    let real_leaf_hash = merkle::hash_leaf(&env, target_id);
+    assert!(client.verify_record_proof(&patient, &real_leaf_hash, &proof));
+
+    // A leaf hash for a *different* record (simulating an altered/substituted
+    // record hash) must NOT verify against the same proof.
+    let other_id = record_ids.get(0).unwrap();
+    assert_ne!(other_id, target_id);
+    let altered_leaf_hash = merkle::hash_leaf(&env, other_id);
+    assert!(!client.verify_record_proof(&patient, &altered_leaf_hash, &proof));
+}
+
+#[test]
+fn test_verify_record_proof_fails_with_tampered_sibling() {
+    let env = Env::default();
+    let (client, patient, _doctor, record_ids) = setup_patient_with_records(&env, 4);
+
+    let target_index = 2u32;
+    let target_id = record_ids.get(target_index).unwrap();
+    let proof = client.get_record_proof(&patient, &target_index);
+    assert!(!proof.is_empty());
+
+    // Rebuild the proof with its first sibling hash's first byte flipped.
+    let mut tampered_proof: Vec<BytesN<32>> = Vec::new(&env);
+    for (i, sibling) in proof.iter().enumerate() {
+        if i == 0 {
+            let mut bytes = sibling.to_array();
+            bytes[0] ^= 0xFF;
+            tampered_proof.push_back(BytesN::from_array(&env, &bytes));
+        } else {
+            tampered_proof.push_back(sibling);
+        }
+    }
+
+    let leaf_hash = merkle::hash_leaf(&env, target_id);
+    assert!(!client.verify_record_proof(&patient, &leaf_hash, &tampered_proof));
+}
+
+#[test]
+fn test_get_record_proof_single_record_tree() {
+    let env = Env::default();
+    let (client, patient, _doctor, record_ids) = setup_patient_with_records(&env, 1);
+
+    let record_id = record_ids.get(0).unwrap();
+    let proof = client.get_record_proof(&patient, &0u32);
+    assert!(client.verify_record_membership(&patient, &record_id, &proof));
+}


### PR DESCRIPTION
Closes #469

`merkle.rs` already had `compute_merkle_root` / `verify_membership` but no way for an external caller to generate a proof, and no way to verify a proof against a leaf hash directly. Adds:

- `merkle::generate_proof(env, record_ids, target_index) -> Vec<BytesN<32>>`: mirrors `compute_merkle_root`'s layer-by-layer reduction (same pairing and odd-node-self-pairing rules) while tracking which sibling pairs with the target leaf at each level. No position bits needed in the proof since `hash_pair` sorts its inputs before hashing.
- `merkle::verify_leaf_membership(env, leaf_hash, proof, root) -> bool`: the same verification loop as `verify_membership`, factored out to take a precomputed leaf hash; `verify_membership` now just calls it with `hash_leaf(record_id)`.
- Contract functions `get_record_proof(patient, record_index) -> Result<Vec<BytesN<32>>, ContractError>` (`RecordNotFound` if out of bounds) and `verify_record_proof(patient, leaf_hash, proof) -> bool`, alongside the existing `get_merkle_root` / `verify_record_membership`. No access control, matching those existing sibling functions -- a Merkle root/proof doesn't expose record contents.

Tests: round-trip (5 leaves, exercises the odd-length self-pairing case), out-of-bounds index, altered-leaf-hash, tampered-sibling, and a single-record (n=1) tree.

**Verification note:** no network access to fetch the dependency graph in my sandbox. Verified via `rustc --emit=metadata` partial-resolution checks: identical pre-existing local-resolution error profile before/after, plus exactly the +2 references expected from the one new test helper -- no new error categories introduced. Please run the real test suite before merging.