### PR TITLE
feat(health-records): enforce provider registry check on record creation

### DIFF
--- a/contracts/health-records/src/lib.rs
+++ b/contracts/health-records/src/lib.rs
@@ -77,6 +77,8 @@ pub enum DataKey {
     Consent(Address, Address),     // (patient, provider) -> ConsentScope
     PatientProviders(Address),     // patient -> Vec<Address> of consented providers
     CategoryIndex(RecordCategory), // category -> Vec<u64> of record ids in that category, for prefix-style queries
+    ProviderRegistry,
+    RecordVersion(u64, u32),
 }
 
 #[contracterror]
@@ -90,6 +92,13 @@ pub enum Error {
     InvalidPolicyMetadata = 5,
     InvalidAddress = 6,
     BatchTooLarge = 7,
+    ProviderNotRegistered = 8,
+    VersionNotFound = 9,
+}
+
+#[soroban_sdk::contractclient(name = "ProviderRegistryClient")]
+pub trait ProviderRegistryInterface {
+    fn is_provider(env: Env, provider: Address) -> bool;
 }
 
 /// Append `record_category`'s record ID to its `CategoryIndex` so
@@ -143,11 +152,23 @@ fn get_active_consent(env: &Env, patient: &Address, provider: &Address) -> Optio
     })
 }
 
+fn has_consent(env: &Env, patient: &Address, provider: &Address) -> bool {
+    get_active_consent(env, patient, provider).is_some()
+}
+
 #[contract]
 pub struct HealthRecords;
 
 #[contractimpl]
 impl HealthRecords {
+    /// Initialize the contract with the provider registry address.
+    pub fn initialize(env: Env, provider_registry: Address) {
+        if env.storage().instance().has(&DataKey::ProviderRegistry) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&DataKey::ProviderRegistry, &provider_registry);
+    }
+
     /// Patient grants a provider scoped consent to act on their records.
     ///
     /// `scope.expires_at == 0` means the consent never expires.
@@ -214,6 +235,12 @@ impl HealthRecords {
         provider.require_auth();
         validate_encrypted_ref(&encrypted_ref).map_err(|_| Error::InvalidEncryptedEnvelope)?;
         validate_policy_metadata(&policy).map_err(|_| Error::InvalidPolicyMetadata)?;
+
+        let registry_addr: Address = env.storage().instance().get(&DataKey::ProviderRegistry).unwrap();
+        let provider_client = ProviderRegistryClient::new(&env, &registry_addr);
+        if !provider_client.is_provider(&provider) {
+            return Err(Error::ProviderNotRegistered);
+        }
 
         match get_active_consent(&env, &patient, &provider) {
             None => return Err(Error::ConsentNotGranted),
@@ -282,6 +309,12 @@ impl HealthRecords {
     ) -> Result<Vec<u64>, Error> {
         validate_nonzero_address(&provider).map_err(|_| Error::InvalidAddress)?;
         provider.require_auth();
+
+        let registry_addr: Address = env.storage().instance().get(&DataKey::ProviderRegistry).unwrap();
+        let provider_client = ProviderRegistryClient::new(&env, &registry_addr);
+        if !provider_client.is_provider(&provider) {
+            return Err(Error::ProviderNotRegistered);
+        }
 
         if records.len() > MAX_BATCH_SIZE {
             return Err(Error::BatchTooLarge);

--- a/contracts/health-records/src/test.rs
+++ b/contracts/health-records/src/test.rs
@@ -1,3 +1,18 @@
+#[soroban_sdk::contract]
+pub struct MockProviderRegistry;
+
+#[soroban_sdk::contractimpl]
+impl MockProviderRegistry {
+    pub fn is_provider(env: Env, provider: Address) -> bool {
+        let key = soroban_sdk::Symbol::new(&env, "is_prov");
+        env.storage().instance().get(&key).unwrap_or(true)
+    }
+    pub fn set_is_provider(env: Env, val: bool) {
+        let key = soroban_sdk::Symbol::new(&env, "is_prov");
+        env.storage().instance().set(&key, &val);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{ConsentScope, Error, HealthRecords, HealthRecordsClient, RecordCategory};
@@ -23,8 +38,10 @@ mod tests {
     }
 
     fn setup(env: &Env) -> (HealthRecordsClient<'static>, Address, Address) {
+        let mock_pr_id = env.register(crate::test::MockProviderRegistry, ());
         let contract_id = env.register(HealthRecords, ());
         let client = HealthRecordsClient::new(env, &contract_id);
+        client.initialize(&mock_pr_id);
         let patient = Address::generate(env);
         let provider = Address::generate(env);
         (client, patient, provider)
@@ -227,6 +244,62 @@ mod tests {
         let short_hash = Bytes::from_array(&env, &[0u8; 16]);
         assert!(!client.verify_record_integrity(&patient, &record_id, &short_hash));
     }
+
+    #[test]
+    fn test_create_record_fails_if_provider_not_registered() {
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let mock_pr_id = env.register(crate::test::MockProviderRegistry, ());
+        let mock_pr_client = crate::test::MockProviderRegistryClient::new(&env, &mock_pr_id);
+        mock_pr_client.set_is_provider(&false);
+        
+        let contract_id = env.register(HealthRecords, ());
+        let client = HealthRecordsClient::new(&env, &contract_id);
+        client.initialize(&mock_pr_id);
+        
+        let patient = Address::generate(&env);
+        let provider = Address::generate(&env);
+        
+        client.grant_consent(&patient, &provider, &full_scope());
+        let reference = encrypted_ref(&env, 1);
+        let rtype = RecordCategory::Imaging;
+        let rdesc = Some(String::from_str(&env, "XRAY"));
+        
+        let result = client.try_create_record(&patient, &provider, &reference, &rtype, &rdesc, &policy(&env));
+        assert_eq!(result, Err(Ok(Error::ProviderNotRegistered)));
+    }
+
+    #[test]
+    fn test_create_records_batch_fails_if_provider_not_registered() {
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let mock_pr_id = env.register(crate::test::MockProviderRegistry, ());
+        let mock_pr_client = crate::test::MockProviderRegistryClient::new(&env, &mock_pr_id);
+        mock_pr_client.set_is_provider(&false);
+        
+        let contract_id = env.register(HealthRecords, ());
+        let client = HealthRecordsClient::new(&env, &contract_id);
+        client.initialize(&mock_pr_id);
+        
+        let patient = Address::generate(&env);
+        let provider = Address::generate(&env);
+        
+        client.grant_consent(&patient, &provider, &full_scope());
+        
+        let mut records = soroban_sdk::Vec::new(&env);
+        records.push_back(crate::BatchRecordEntry {
+            patient: patient.clone(),
+            encrypted_ref: encrypted_ref(&env, 1),
+            record_category: RecordCategory::Imaging,
+            description: Some(String::from_str(&env, "XRAY")),
+            policy: policy(&env),
+        });
+        
+        let result = client.try_create_records_batch(&provider, &records);
+        assert_eq!(result, Err(Ok(Error::ProviderNotRegistered)));
+    }
 }
 
 #[cfg(test)]
@@ -245,10 +318,13 @@ mod cross_contract_correlation_tests {
         HealthRecordsClient<'static>,
         MedicalRegistryClient<'static>,
     ) {
+        let mock_pr_id = env.register(crate::test::MockProviderRegistry, ());
         let hr_id = env.register(HealthRecords, ());
         let pr_id = env.register(MedicalRegistry, ());
+        let hr_client = HealthRecordsClient::new(env, &hr_id);
+        hr_client.initialize(&mock_pr_id);
         (
-            HealthRecordsClient::new(env, &hr_id),
+            hr_client,
             MedicalRegistryClient::new(env, &pr_id),
         )
     }
@@ -552,8 +628,10 @@ mod batch_creation_tests {
     use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Symbol, Vec};
 
     fn setup(env: &Env) -> (HealthRecordsClient<'static>, Address, Address) {
+        let mock_pr_id = env.register(crate::test::MockProviderRegistry, ());
         let contract_id = env.register(HealthRecords, ());
         let client = HealthRecordsClient::new(env, &contract_id);
+        client.initialize(&mock_pr_id);
         let patient = Address::generate(env);
         let provider = Address::generate(env);
         (client, patient, provider)
@@ -820,8 +898,10 @@ mod consent_scope_tests {
     };
 
     fn setup(env: &Env) -> (HealthRecordsClient<'static>, Address, Address) {
+        let mock_pr_id = env.register(crate::test::MockProviderRegistry, ());
         let contract_id = env.register(HealthRecords, ());
         let client = HealthRecordsClient::new(env, &contract_id);
+        client.initialize(&mock_pr_id);
         let patient = Address::generate(env);
         let provider = Address::generate(env);
         (client, patient, provider)


### PR DESCRIPTION
Closes #475

## PR Description

Currently, `create_record` and `create_records_batch` do not verify that the calling address is a registered and active provider. This allows any address to attribute records to itself without authorization.

To fix this, we integrated the `ProviderRegistry` contract. The `HealthRecords` contract now performs a cross-contract invocation (`is_provider`) against the registry before allowing a record to be created. If the caller is not registered, the call reverts with `Error::ProviderNotRegistered`. 

This change ensures that health records can only be registered by validated medical providers, preserving the integrity of the data store.

## Changes Made
- `contracts/health-records/src/lib.rs`:
  - Added `DataKey::ProviderRegistry` for storing the registry address.
  - Added the `initialize` method to store the registry address.
  - Added the `ProviderRegistryInterface` trait client to perform the cross-contract calls.
  - Enforced `is_provider` checks on the caller in both `create_record` and `create_records_batch`.
  - Added `Error::ProviderNotRegistered` to handle unauthorized caller attempts.
  - Resolved pre-existing compilation issues (`RecordVersion` data key, `VersionNotFound` error, and `has_consent` helper).
- `contracts/health-records/src/test.rs`:
  - Implemented `MockProviderRegistry` to mock the provider check.
  - Updated all test setup configurations to initialize the contract with the mock registry address.
  - Added test cases `test_create_record_fails_if_provider_not_registered` and `test_create_records_batch_fails_if_provider_not_registered` to verify correct revert behavior.

## Testing
To verify the contract logic compiles:
```bash
cargo check -p health-records
```
Output:
The command completed successfully with warnings on unused code from other crates.

## Scope Notes
- Contract-only change (logic restricted to `health-records` crate).
- No external dependency changes.