### PR TITLE
feat: implement issues #500 #501 #502 #503 (healthcare-analytics + upgrade-governance)

### DIFF
--- a/contracts/healthcare-analytics/src/lib.rs
+++ b/contracts/healthcare-analytics/src/lib.rs
@@ -102,6 +102,14 @@ pub enum DataKey {
     Admin,
     /// Stores the `ResultQuality` for a report job accepted under a degraded policy.
     JobResultQuality(u64),
+    /// Cumulative CPU units consumed by a specific requester across completed jobs.
+    RequesterCpuUsed(Address),
+    /// Cumulative memory units consumed by a specific requester across completed jobs.
+    RequesterMemoryUsed(Address),
+    /// Admin-configurable per-requester CPU cap. Defaults to u64::MAX (no limit).
+    RequesterCpuLimit,
+    /// Admin-configurable per-requester memory cap. Defaults to u64::MAX (no limit).
+    RequesterMemoryLimit,
 }
 
 /// --------------------
@@ -122,6 +130,10 @@ pub enum Error {
     ResourceOverrun = 8,
     JobFailure = 9,
     ArithmeticOverflow = 10,
+    /// `throttle_threshold_pct` must be in the range [0, 100].
+    InvalidThreshold = 11,
+    /// This requester has exceeded their per-requester CPU or memory quota.
+    RequesterThrottled = 12,
 }
 
 #[contract]
@@ -160,6 +172,33 @@ impl HealthcareAnalytics {
         degradation_mode: DegradationPolicy,
     ) -> Result<ReportJobAccepted, Error> {
         requester.require_auth();
+
+        // Per-requester throttle check — enforced independently of the global budget.
+        let req_cpu_used: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RequesterCpuUsed(requester.clone()))
+            .unwrap_or(0);
+        let req_mem_used: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RequesterMemoryUsed(requester.clone()))
+            .unwrap_or(0);
+        let req_cpu_limit: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RequesterCpuLimit)
+            .unwrap_or(u64::MAX);
+        let req_mem_limit: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RequesterMemoryLimit)
+            .unwrap_or(u64::MAX);
+        if req_cpu_used.saturating_add(estimated_cpu) > req_cpu_limit
+            || req_mem_used.saturating_add(estimated_memory) > req_mem_limit
+        {
+            return Err(Error::RequesterThrottled);
+        }
 
         let throttled = should_throttle_job(&env);
 
@@ -327,6 +366,26 @@ impl HealthcareAnalytics {
             let _ = attach_evidence(&env, incident_id, EvidenceType::ContextData, hash, job.requested_by);
         }
 
+        // Update per-requester cumulative usage.
+        let req_cpu: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RequesterCpuUsed(job.requested_by.clone()))
+            .unwrap_or(0);
+        let req_mem: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RequesterMemoryUsed(job.requested_by.clone()))
+            .unwrap_or(0);
+        env.storage().persistent().set(
+            &DataKey::RequesterCpuUsed(job.requested_by.clone()),
+            &(req_cpu + cpu_used),
+        );
+        env.storage().persistent().set(
+            &DataKey::RequesterMemoryUsed(job.requested_by.clone()),
+            &(req_mem + memory_used),
+        );
+
         env.events()
             .publish((symbol_short!("job_done"), job_id), (cpu_used, memory_used));
 
@@ -410,6 +469,10 @@ impl HealthcareAnalytics {
             return Err(Error::Unauthorized);
         }
 
+        if throttle_percent > 100 {
+            return Err(Error::InvalidThreshold);
+        }
+
         set_system_limits(
             &env,
             shared::resource_management::SystemResourceLimits {
@@ -420,6 +483,75 @@ impl HealthcareAnalytics {
             },
         );
 
+        Ok(())
+    }
+
+    /// Configure per-requester CPU and memory caps (admin only).
+    pub fn set_requester_limits(
+        env: Env,
+        admin: Address,
+        cpu_limit: u64,
+        memory_limit: u64,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::RequesterCpuLimit, &cpu_limit);
+        env.storage()
+            .instance()
+            .set(&DataKey::RequesterMemoryLimit, &memory_limit);
+        Ok(())
+    }
+
+    /// Return cumulative resource usage for a specific requester.
+    pub fn get_requester_usage(env: Env, requester: Address) -> ResourceUsage {
+        let cpu_used: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RequesterCpuUsed(requester.clone()))
+            .unwrap_or(0);
+        let memory_used: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RequesterMemoryUsed(requester.clone()))
+            .unwrap_or(0);
+        ResourceUsage {
+            cpu_used,
+            memory_used,
+            start_time: 0,
+            end_time: 0,
+        }
+    }
+
+    /// Reset per-requester usage counters (admin only).
+    pub fn reset_requester_usage(
+        env: Env,
+        admin: Address,
+        requester: Address,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .persistent()
+            .remove(&DataKey::RequesterCpuUsed(requester.clone()));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::RequesterMemoryUsed(requester.clone()));
         Ok(())
     }
     /// Privacy is preserved by accepting only pre-anonymized, aggregate-ready

--- a/contracts/upgrade-governance/src/lib.rs
+++ b/contracts/upgrade-governance/src/lib.rs
@@ -113,6 +113,9 @@ pub struct UpgradeProposal {
     /// Minimum on-chain schema version the new WASM is compatible with.
     /// `execute_upgrade` rejects proposals where this exceeds the stored `SchemaVersion`.
     pub min_compatible_schema: u32,
+    /// When true this is an emergency fast-track: requires 100 % signer approval
+    /// and skips the timelock delay at execution time.
+    pub is_emergency: bool,
 }
 
 #[contracttype]
@@ -190,6 +193,7 @@ impl UpgradeGovernance {
             status: ProposalStatus::Active,
             domain_tag,
             min_compatible_schema,
+            is_emergency: false,
         };
 
         env.storage()
@@ -201,6 +205,84 @@ impl UpgradeGovernance {
 
         env.events()
             .publish((symbol_short!("proposed"), proposal_id), new_wasm_hash);
+
+        Ok(proposal_id)
+    }
+
+    /// Propose an emergency upgrade that bypasses the timelock and requires unanimous signer approval.
+    ///
+    /// Emergency proposals are identical to standard proposals except:
+    /// - All signers must vote (`100 %` threshold) before execution is allowed.
+    /// - `execute_upgrade` skips the `TIMELOCK_DELAY` for these proposals.
+    /// - A distinct `emrg_prop` audit event is emitted.
+    pub fn propose_emergency_upgrade(
+        env: Env,
+        proposer: Address,
+        new_wasm_hash: BytesN<32>,
+        release_metadata: ReleaseMetadata,
+        artifact_metadata_hash: BytesN<32>,
+        min_compatible_schema: u32,
+    ) -> Result<u64, Error> {
+        Self::assert_initialized(&env)?;
+        proposer.require_auth();
+        Self::assert_signer(&env, &proposer)?;
+        Self::validate_release_metadata(&env, &release_metadata, &artifact_metadata_hash)?;
+
+        let current_schema: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SchemaVersion)
+            .unwrap_or(1);
+        if min_compatible_schema > current_schema {
+            return Err(Error::IncompatibleSchemaVersion);
+        }
+
+        let proposal_id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NextId)
+            .ok_or(Error::NotInitialized)?;
+
+        let domain_tag = Self::compute_domain_tag(&env, proposal_id);
+
+        let mut votes: Vec<Address> = Vec::new(&env);
+        votes.push_back(proposer.clone());
+
+        let signers: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Signers)
+            .ok_or(Error::NotInitialized)?;
+
+        // Auto-approve if the proposer is the sole signer (100 % met immediately).
+        let (status, approved_at) = if votes.len() >= signers.len() {
+            (ProposalStatus::Approved, env.ledger().timestamp())
+        } else {
+            (ProposalStatus::Active, 0)
+        };
+
+        let proposal = UpgradeProposal {
+            new_wasm_hash: new_wasm_hash.clone(),
+            release_metadata,
+            artifact_metadata_hash,
+            votes,
+            proposed_at: env.ledger().timestamp(),
+            approved_at,
+            status,
+            domain_tag,
+            min_compatible_schema,
+            is_emergency: true,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(proposal_id), &proposal);
+        env.storage()
+            .persistent()
+            .set(&DataKey::NextId, &(proposal_id + 1));
+
+        env.events()
+            .publish((symbol_short!("emrg_prop"), proposal_id), new_wasm_hash);
 
         Ok(proposal_id)
     }
@@ -245,7 +327,19 @@ impl UpgradeGovernance {
             .get(&DataKey::Threshold)
             .ok_or(Error::NotInitialized)?;
 
-        if proposal.status == ProposalStatus::Active && proposal.votes.len() >= threshold {
+        // Emergency proposals require unanimous (100 %) approval.
+        let effective_threshold = if proposal.is_emergency {
+            let signers: Vec<Address> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Signers)
+                .ok_or(Error::NotInitialized)?;
+            signers.len()
+        } else {
+            threshold
+        };
+
+        if proposal.status == ProposalStatus::Active && proposal.votes.len() >= effective_threshold {
             proposal.status = ProposalStatus::Approved;
             proposal.approved_at = env.ledger().timestamp();
             env.events().publish(
@@ -286,10 +380,13 @@ impl UpgradeGovernance {
             return Err(Error::Expired);
         }
 
-        // Enforce timelock: must wait TIMELOCK_DELAY after approval.
-        if env.ledger().timestamp() < proposal.approved_at + TIMELOCK_DELAY {
+        // Enforce timelock for standard proposals; emergency proposals skip it.
+        if !proposal.is_emergency
+            && env.ledger().timestamp() < proposal.approved_at + TIMELOCK_DELAY
+        {
             return Err(Error::TimelockActive);
         }
+
         let approved = env
             .storage()
             .persistent()
@@ -306,6 +403,16 @@ impl UpgradeGovernance {
             &proposal.artifact_metadata_hash,
         )?;
 
+        // Schema compatibility check: reject if on-chain schema is below what the new WASM requires.
+        let current_schema: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SchemaVersion)
+            .unwrap_or(1);
+        if current_schema < proposal.min_compatible_schema {
+            return Err(Error::IncompatibleSchemaVersion);
+        }
+
         proposal.status = ProposalStatus::Executed;
         env.storage()
             .persistent()
@@ -314,10 +421,23 @@ impl UpgradeGovernance {
         env.deployer()
             .update_current_contract_wasm(proposal.new_wasm_hash.clone());
 
-        env.events().publish(
-            (symbol_short!("ct_upgrad"), proposal_id),
-            proposal.new_wasm_hash,
-        );
+        // Advance the schema version to reflect the newly deployed WASM.
+        env.storage()
+            .persistent()
+            .set(&DataKey::SchemaVersion, &(current_schema + 1));
+
+        // Emit a distinct event tag for emergency vs standard upgrades.
+        if proposal.is_emergency {
+            env.events().publish(
+                (symbol_short!("emrg_upg"), proposal_id),
+                proposal.new_wasm_hash,
+            );
+        } else {
+            env.events().publish(
+                (symbol_short!("ct_upgrad"), proposal_id),
+                proposal.new_wasm_hash,
+            );
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Closes #500 
closes #501 
closes #502 
closes #503 

### #500 — `set_resource_limits`: validate `throttle_threshold_pct ≤ 100`
- Added `Error::InvalidThreshold = 11` to the analytics `Error` enum
- `set_resource_limits` now returns `Err(Error::InvalidThreshold)` when `throttle_percent > 100`
- Values 0 and 100 are accepted (valid edge cases per spec)

### #501 — per-requester CPU/memory quota tracking
- Added `DataKey::RequesterCpuUsed(Address)` and `DataKey::RequesterMemoryUsed(Address)` to accumulate per-requester actual usage on `complete_report`
- Added `Error::RequesterThrottled = 12`
- `request_report` checks per-requester caps independently before the global throttle — a high-volume requester is blocked without affecting others
- New public functions: `set_requester_limits(admin, cpu, memory)`, `get_requester_usage(requester)`, `reset_requester_usage(admin, requester)`

### #502 — emergency fast-track upgrade bypassing timelock
- Added `is_emergency: bool` field to `UpgradeProposal`
- New `propose_emergency_upgrade(...)` function; emits `emrg_prop` event
- `vote_upgrade` uses `signers.len()` (100 %) as effective threshold for emergency proposals
- `execute_upgrade` skips `TIMELOCK_DELAY` for emergency proposals; emits `emrg_upg` instead of `ct_upgrad`

### #503 — schema compatibility check before executing upgrade
- `execute_upgrade` asserts `deployed_schema >= proposal.min_compatible_schema`; returns `Error::IncompatibleSchemaVersion` on failure
- Schema version is auto-incremented by 1 after every successful upgrade

## Test plan
- [ ] CI passes for both `healthcare-analytics` and `upgrade-governance`
- [ ] `set_resource_limits` with `throttle_percent = 101` returns `InvalidThreshold`; `0` and `100` succeed
- [ ] Per-requester throttle fires after cumulative usage exceeds configured limit; other requesters unaffected
- [ ] Admin can reset per-requester counters via `reset_requester_usage`
- [ ] Emergency proposal with only standard-threshold approvals cannot execute (status stays `Active`)
- [ ] Emergency proposal with 100 % approvals executes immediately (no timelock wait)
- [ ] Standard upgrade emits `ct_upgrad`; emergency emits `emrg_upg`
- [ ] `execute_upgrade` rejects proposal when `deployed_schema < min_compatible_schema`
- [ ] Schema version increments after successful upgrade
