### PR TITLE
security: overflow protection, Vec limits, admin rotation, proof expiry (#508 #509 #510 #511)

### DIFF
--- a/contracts/access-control/src/lib.rs
+++ b/contracts/access-control/src/lib.rs
@@ -37,7 +37,14 @@ pub enum ContractError {
     RoleAlreadyGranted = 21,
     RoleNotFound = 22,
     RateLimitExceeded = 23,
+    /// A Vec parameter or accumulator exceeds its maximum allowed length.
+    InputTooLarge = 24,
 }
+
+/// Maximum number of access permissions a single grantee may accumulate.
+pub const MAX_ACCESS_LIST_LEN: u32 = 200;
+/// Maximum number of addresses authorized for a single resource.
+pub const MAX_RESOURCE_AUTHORIZED: u32 = 200;
 
 /// --------------------
 /// Role Types (RBAC)
@@ -531,6 +538,9 @@ impl AccessControl {
             .get(&access_key)
             .unwrap_or(Vec::new(&env));
 
+        if access_list.len() >= MAX_ACCESS_LIST_LEN {
+            return Err(ContractError::InputTooLarge);
+        }
         access_list.push_back(permission);
         env.storage().persistent().set(&access_key, &access_list);
 
@@ -544,6 +554,9 @@ impl AccessControl {
             .persistent()
             .get(&resource_key)
             .unwrap_or(Vec::new(&env));
+        if authorized.len() >= MAX_RESOURCE_AUTHORIZED {
+            return Err(ContractError::InputTooLarge);
+        }
         authorized.push_back(grantee.clone());
         env.storage().persistent().set(&resource_key, &authorized);
 

--- a/contracts/clinical-trial/src/lib.rs
+++ b/contracts/clinical-trial/src/lib.rs
@@ -100,7 +100,18 @@ pub enum Error {
     SiteNotFound = 26,
     /// The site has reached its per-site enrollment quota
     SiteEnrollmentFull = 27,
+    /// A Vec parameter exceeds its maximum allowed length.
+    InputTooLarge = 28,
 }
+
+/// Maximum number of inclusion or exclusion criteria rules per trial.
+pub const MAX_CRITERIA_RULES: u32 = 64;
+/// Maximum number of evidence items per eligibility check.
+pub const MAX_EVIDENCE_ITEMS: u32 = 32;
+/// Maximum number of DSMB members per trial.
+pub const MAX_DSMB_MEMBERS: u32 = 20;
+/// Maximum number of adverse events per study visit.
+pub const MAX_ADVERSE_EVENTS_PER_VISIT: u32 = 50;
 
 #[contract]
 pub struct ClinicalTrialContract;
@@ -187,6 +198,12 @@ impl ClinicalTrialContract {
         exclusion_criteria: Vec<CriteriaRule>,
     ) -> Result<(), Error> {
         principal_investigator.require_auth();
+        if inclusion_criteria.len() > MAX_CRITERIA_RULES {
+            return Err(Error::InputTooLarge);
+        }
+        if exclusion_criteria.len() > MAX_CRITERIA_RULES {
+            return Err(Error::InputTooLarge);
+        }
 
         // Verify trial exists and PI is authorized
         let trial = storage::get_trial(&env, trial_record_id)?;
@@ -214,6 +231,9 @@ impl ClinicalTrialContract {
         claim_evidence: Vec<EligibilityClaimEvidence>,
     ) -> Result<EligibilityResult, Error> {
         patient_id.require_auth();
+        if claim_evidence.len() > MAX_EVIDENCE_ITEMS {
+            return Err(Error::InputTooLarge);
+        }
 
         // Verify trial exists
         let _trial = storage::get_trial(&env, trial_record_id)?;
@@ -356,6 +376,9 @@ impl ClinicalTrialContract {
         data_collected_hash: BytesN<32>,
         adverse_events: Vec<AdverseEvent>,
     ) -> Result<(), Error> {
+        if adverse_events.len() > MAX_ADVERSE_EVENTS_PER_VISIT {
+            return Err(Error::InputTooLarge);
+        }
         // Verify enrollment exists
         let enrollment = storage::get_enrollment(&env, enrollment_id)?;
         enrollment.patient_id.require_auth();
@@ -674,6 +697,9 @@ impl ClinicalTrialContract {
         members: Vec<Address>,
     ) -> Result<(), Error> {
         principal_investigator.require_auth();
+        if members.len() > MAX_DSMB_MEMBERS {
+            return Err(Error::InputTooLarge);
+        }
 
         let trial = storage::get_trial(&env, trial_record_id)?;
         if trial.principal_investigator != principal_investigator {

--- a/contracts/governance-voting/src/lib.rs
+++ b/contracts/governance-voting/src/lib.rs
@@ -8,6 +8,7 @@ use soroban_sdk::{
 };
 
 const MAX_PROPOSALS: u32 = 100;
+const ADMIN_ROTATION_WINDOW: u64 = 86_400;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -21,6 +22,10 @@ pub enum Error {
     ProposalClosed    = 6,
     ProposalExpired   = 7,
     InvalidQuorum     = 8,
+    RotationPending   = 9,
+    NoRotationPending = 10,
+    RotationExpired   = 11,
+    NotPendingAdmin   = 12,
 }
 
 #[contracttype]
@@ -51,6 +56,8 @@ pub enum DataKey {
     NextId,
     Proposal(u64),
     Vote(u64, Address),  // (proposal_id, voter) → VoteChoice
+    PendingAdmin,
+    RotationExpiry,
 }
 
 #[contract]
@@ -170,6 +177,53 @@ impl GovernanceVotingContract {
 
     pub fn has_voted(env: Env, proposal_id: u64, voter: Address) -> bool {
         env.storage().persistent().has(&DataKey::Vote(proposal_id, voter))
+    }
+
+    /// Propose transferring admin to `new_admin`. Must be confirmed within 24 hours.
+    pub fn propose_admin_rotation(env: Env, admin: Address, new_admin: Address) -> Result<(), Error> {
+        admin.require_auth();
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        if admin != stored {
+            return Err(Error::Unauthorized);
+        }
+        if env.storage().instance().has(&DataKey::PendingAdmin) {
+            return Err(Error::RotationPending);
+        }
+        let expiry = env.ledger().timestamp() + ADMIN_ROTATION_WINDOW;
+        env.storage().instance().set(&DataKey::PendingAdmin, &new_admin);
+        env.storage().instance().set(&DataKey::RotationExpiry, &expiry);
+        Ok(())
+    }
+
+    /// New admin confirms the rotation proposed by the current admin.
+    pub fn accept_admin_rotation(env: Env, new_admin: Address) -> Result<(), Error> {
+        new_admin.require_auth();
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(Error::NoRotationPending)?;
+        if new_admin != pending {
+            return Err(Error::NotPendingAdmin);
+        }
+        let expiry: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RotationExpiry)
+            .unwrap_or(0);
+        if env.ledger().timestamp() > expiry {
+            env.storage().instance().remove(&DataKey::PendingAdmin);
+            env.storage().instance().remove(&DataKey::RotationExpiry);
+            return Err(Error::RotationExpired);
+        }
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+        env.storage().instance().remove(&DataKey::PendingAdmin);
+        env.storage().instance().remove(&DataKey::RotationExpiry);
+        Ok(())
     }
 }
 

--- a/contracts/healthcare-analytics/src/lib.rs
+++ b/contracts/healthcare-analytics/src/lib.rs
@@ -102,11 +102,15 @@ pub enum DataKey {
     Admin,
     /// Stores the `ResultQuality` for a report job accepted under a degraded policy.
     JobResultQuality(u64),
+    PendingAdmin,
+    RotationExpiry,
 }
 
 /// --------------------
 /// Errors
 /// --------------------
+
+pub const ADMIN_ROTATION_WINDOW: u64 = 86_400;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -122,6 +126,10 @@ pub enum Error {
     ResourceOverrun = 8,
     JobFailure = 9,
     ArithmeticOverflow = 10,
+    RotationPending = 11,
+    NoRotationPending = 12,
+    RotationExpired = 13,
+    NotPendingAdmin = 14,
 }
 
 #[contract]
@@ -422,6 +430,54 @@ impl HealthcareAnalytics {
 
         Ok(())
     }
+
+    /// Propose transferring admin to `new_admin`. Must be confirmed within 24 hours.
+    pub fn propose_admin_rotation(env: Env, admin: Address, new_admin: Address) -> Result<(), Error> {
+        admin.require_auth();
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored {
+            return Err(Error::Unauthorized);
+        }
+        if env.storage().instance().has(&DataKey::PendingAdmin) {
+            return Err(Error::RotationPending);
+        }
+        let expiry = env.ledger().timestamp() + ADMIN_ROTATION_WINDOW;
+        env.storage().instance().set(&DataKey::PendingAdmin, &new_admin);
+        env.storage().instance().set(&DataKey::RotationExpiry, &expiry);
+        Ok(())
+    }
+
+    /// New admin confirms the rotation proposed by the current admin.
+    pub fn accept_admin_rotation(env: Env, new_admin: Address) -> Result<(), Error> {
+        new_admin.require_auth();
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(Error::NoRotationPending)?;
+        if new_admin != pending {
+            return Err(Error::NotPendingAdmin);
+        }
+        let expiry: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RotationExpiry)
+            .unwrap_or(0);
+        if env.ledger().timestamp() > expiry {
+            env.storage().instance().remove(&DataKey::PendingAdmin);
+            env.storage().instance().remove(&DataKey::RotationExpiry);
+            return Err(Error::RotationExpired);
+        }
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+        env.storage().instance().remove(&DataKey::PendingAdmin);
+        env.storage().instance().remove(&DataKey::RotationExpiry);
+        Ok(())
+    }
+
     /// Privacy is preserved by accepting only pre-anonymized, aggregate-ready
     /// values with an optional metadata hash instead of raw patient data.
     pub fn record_metric(

--- a/contracts/liquidity-pool/src/lib.rs
+++ b/contracts/liquidity-pool/src/lib.rs
@@ -17,7 +17,14 @@ pub enum Error {
     SlippageExceeded = 5,
     InsufficientShares = 6,
     Unauthorized = 7,
+    ArithmeticOverflow = 8,
+    RotationPending = 9,
+    NoRotationPending = 10,
+    RotationExpired = 11,
+    NotPendingAdmin = 12,
 }
+
+const ADMIN_ROTATION_WINDOW: u64 = 86_400;
 
 #[contracttype]
 pub enum DataKey {
@@ -26,6 +33,8 @@ pub enum DataKey {
     ReserveB,
     TotalShares,
     Shares(Address),
+    PendingAdmin,
+    RotationExpiry,
 }
 
 #[contracttype]
@@ -81,11 +90,12 @@ impl LiquidityPoolContract {
 
         let shares = if total == 0 {
             // First deposit: geometric mean as initial share supply
-            sqrt(amount_a * amount_b)
+            let product = amount_a.checked_mul(amount_b).ok_or(Error::ArithmeticOverflow)?;
+            sqrt(product)
         } else {
             // Pro-rata: min of both ratios to prevent dilution
-            let s_a = amount_a * total / reserve_a;
-            let s_b = amount_b * total / reserve_b;
+            let s_a = amount_a.checked_mul(total).ok_or(Error::ArithmeticOverflow)? / reserve_a;
+            let s_b = amount_b.checked_mul(total).ok_or(Error::ArithmeticOverflow)? / reserve_b;
             s_a.min(s_b)
         };
 
@@ -196,8 +206,14 @@ impl LiquidityPoolContract {
         }
 
         // Constant-product AMM with fee: (x + dx*(1-fee)) * (y - dy) = x * y
-        let amount_in_with_fee = amount_in * (10_000 - POOL_FEE_BPS) / 10_000;
-        let amount_out = reserve_b * amount_in_with_fee / (reserve_a + amount_in_with_fee);
+        let amount_in_with_fee = amount_in
+            .checked_mul(10_000 - POOL_FEE_BPS)
+            .ok_or(Error::ArithmeticOverflow)?
+            / 10_000;
+        let amount_out = reserve_b
+            .checked_mul(amount_in_with_fee)
+            .ok_or(Error::ArithmeticOverflow)?
+            / (reserve_a + amount_in_with_fee);
 
         if amount_out < min_out {
             return Err(Error::SlippageExceeded);
@@ -213,6 +229,54 @@ impl LiquidityPoolContract {
         env.events()
             .publish((symbol_short!("SWAP"), trader), (amount_in, amount_out));
         Ok(amount_out)
+    }
+
+    /// Propose transferring admin to `new_admin`. Must be confirmed by `new_admin`
+    /// within 24 hours via `accept_admin_rotation`.
+    pub fn propose_admin_rotation(env: Env, admin: Address, new_admin: Address) -> Result<(), Error> {
+        admin.require_auth();
+        let stored: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        if admin != stored {
+            return Err(Error::Unauthorized);
+        }
+        if env.storage().instance().has(&DataKey::PendingAdmin) {
+            return Err(Error::RotationPending);
+        }
+        let expiry = env.ledger().timestamp() + ADMIN_ROTATION_WINDOW;
+        env.storage().instance().set(&DataKey::PendingAdmin, &new_admin);
+        env.storage().instance().set(&DataKey::RotationExpiry, &expiry);
+        Ok(())
+    }
+
+    /// New admin confirms the rotation proposed by the current admin.
+    pub fn accept_admin_rotation(env: Env, new_admin: Address) -> Result<(), Error> {
+        new_admin.require_auth();
+        let pending: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(Error::NoRotationPending)?;
+        if new_admin != pending {
+            return Err(Error::NotPendingAdmin);
+        }
+        let expiry: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RotationExpiry)
+            .unwrap_or(0);
+        if env.ledger().timestamp() > expiry {
+            env.storage().instance().remove(&DataKey::PendingAdmin);
+            env.storage().instance().remove(&DataKey::RotationExpiry);
+            return Err(Error::RotationExpired);
+        }
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+        env.storage().instance().remove(&DataKey::PendingAdmin);
+        env.storage().instance().remove(&DataKey::RotationExpiry);
+        Ok(())
     }
 
     pub fn get_stats(env: Env) -> PoolStats {

--- a/contracts/patient-registry/src/lib.rs
+++ b/contracts/patient-registry/src/lib.rs
@@ -291,6 +291,8 @@ pub enum ContractError {
     NoHistoryFound = 26,
     InvalidAddress = 27,
     ProviderNotRegistered = 28,
+    /// A Vec parameter or accumulator exceeds its maximum allowed length.
+    InputTooLarge = 29,
 }
 
 pub fn validate_cid(cid: &Bytes) -> Result<(), ContractError> {
@@ -471,6 +473,9 @@ pub const MAX_PAGE_SIZE: u32 = 50;
 
 /// Maximum number of entries allowed in a single batch registration call.
 pub const MAX_BATCH_SIZE: u32 = 50;
+
+/// Maximum number of authorized doctors a single patient may have.
+pub const MAX_AUTHORIZED_DOCTORS: u32 = 50;
 
 /// Input entry for `batch_register_patients`.
 #[contracttype]
@@ -1313,6 +1318,9 @@ impl MedicalRegistry {
             .unwrap_or(Map::new(&env));
 
         if !map.contains_key(doctor.clone()) {
+            if map.len() >= MAX_AUTHORIZED_DOCTORS {
+                return Err(ContractError::InputTooLarge);
+            }
             let total_access_grants: u64 = env
                 .storage()
                 .instance()

--- a/contracts/provider-registry/src/lib.rs
+++ b/contracts/provider-registry/src/lib.rs
@@ -13,6 +13,8 @@ mod test;
 
 /// Maximum entries per batch call.
 pub const MAX_BATCH_SIZE: u32 = 50;
+/// Admin rotation confirmation window (24 hours in seconds).
+pub const ADMIN_ROTATION_WINDOW: u64 = 86_400;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -25,6 +27,10 @@ pub enum Error {
     RecordNotFound     = 5,
     BatchTooLarge      = 6,
     InvalidAddress     = 7,
+    RotationPending    = 8,
+    NoRotationPending  = 9,
+    RotationExpired    = 10,
+    NotPendingAdmin    = 11,
 }
 
 /// Input entry for `batch_register_providers`.
@@ -88,6 +94,8 @@ pub enum DataKey {
     ProviderRate(Address),
     ProviderReputation(Address),
     ProviderRatingByPatient(Address, Address),
+    PendingAdmin,
+    RotationExpiry,
 }
 
 // ── Contract ──────────────────────────────────────────────────────────────────
@@ -266,6 +274,47 @@ impl ProviderRegistry {
             .persistent()
             .get(&DataKey::Record(record_id))
             .ok_or(Error::RecordNotFound)
+    }
+
+    /// Propose transferring admin to `new_admin`. Must be confirmed within 24 hours.
+    pub fn propose_admin_rotation(env: Env, admin: Address, new_admin: Address) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        Self::assert_admin(&env, &admin)?;
+        if env.storage().persistent().has(&DataKey::PendingAdmin) {
+            return Err(Error::RotationPending);
+        }
+        let expiry = env.ledger().timestamp() + ADMIN_ROTATION_WINDOW;
+        env.storage().persistent().set(&DataKey::PendingAdmin, &new_admin);
+        env.storage().persistent().set(&DataKey::RotationExpiry, &expiry);
+        Ok(())
+    }
+
+    /// New admin confirms the rotation proposed by the current admin.
+    pub fn accept_admin_rotation(env: Env, new_admin: Address) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        new_admin.require_auth();
+        let pending: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(Error::NoRotationPending)?;
+        if new_admin != pending {
+            return Err(Error::NotPendingAdmin);
+        }
+        let expiry: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RotationExpiry)
+            .unwrap_or(0);
+        if env.ledger().timestamp() > expiry {
+            env.storage().persistent().remove(&DataKey::PendingAdmin);
+            env.storage().persistent().remove(&DataKey::RotationExpiry);
+            return Err(Error::RotationExpired);
+        }
+        env.storage().persistent().set(&DataKey::Admin, &new_admin);
+        env.storage().persistent().remove(&DataKey::PendingAdmin);
+        env.storage().persistent().remove(&DataKey::RotationExpiry);
+        Ok(())
     }
 
     // ── guards ────────────────────────────────────────────────────────────────

--- a/contracts/zk-eligibility/src/lib.rs
+++ b/contracts/zk-eligibility/src/lib.rs
@@ -33,6 +33,10 @@ mod test;
 pub const MAX_PUBLIC_INPUTS: u32 = 16;
 /// Maximum proof byte length accepted (Groth16 ~192 bytes; give headroom).
 pub const MAX_PROOF_BYTES: u32 = 512;
+/// Admin rotation confirmation window (24 hours in seconds).
+pub const ADMIN_ROTATION_WINDOW: u64 = 86_400;
+/// Index of the expiry timestamp within `public_inputs` (big-endian u64 in first 8 bytes).
+pub const EXPIRY_INPUT_IDX: u32 = 0;
 
 // ── Errors ────────────────────────────────────────────────────────────────────
 
@@ -49,6 +53,11 @@ pub enum Error {
     TooManyPublicInputs  = 7,
     ProofAlreadyUsed     = 8,
     VerificationFailed   = 9,
+    ProofExpired         = 10,
+    RotationPending      = 11,
+    NoRotationPending    = 12,
+    RotationExpired      = 13,
+    NotPendingAdmin      = 14,
 }
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
@@ -63,6 +72,8 @@ pub enum DataKey {
     Nullifier(BytesN<32>),
     /// Cached subject eligibility after a successful proof.
     Eligibility(Address),
+    PendingAdmin,
+    RotationExpiry,
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -183,6 +194,16 @@ impl ZkEligibility {
             return Err(Error::TooManyPublicInputs);
         }
 
+        // ── Expiry check (public_inputs[0] = big-endian u64 expiry timestamp) ─
+        let expiry_input = bundle
+            .public_inputs
+            .get(EXPIRY_INPUT_IDX)
+            .ok_or(Error::ProofExpired)?;
+        let expiry = Self::decode_expiry_u64(&expiry_input);
+        if expiry <= env.ledger().timestamp() {
+            return Err(Error::ProofExpired);
+        }
+
         // ── Verifier key lookup ───────────────────────────────────────────────
         let vk_entry: VerifierKeyEntry = env
             .storage()
@@ -278,6 +299,56 @@ impl ZkEligibility {
             return Err(Error::Unauthorized);
         }
         Ok(())
+    }
+
+    /// Propose transferring admin to `new_admin`. Must be confirmed within 24 hours.
+    pub fn propose_admin_rotation(env: Env, admin: Address, new_admin: Address) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        Self::assert_admin(&env, &admin)?;
+        if env.storage().persistent().has(&DataKey::PendingAdmin) {
+            return Err(Error::RotationPending);
+        }
+        let expiry = env.ledger().timestamp() + ADMIN_ROTATION_WINDOW;
+        env.storage().persistent().set(&DataKey::PendingAdmin, &new_admin);
+        env.storage().persistent().set(&DataKey::RotationExpiry, &expiry);
+        Ok(())
+    }
+
+    /// New admin confirms the rotation proposed by the current admin.
+    pub fn accept_admin_rotation(env: Env, new_admin: Address) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        new_admin.require_auth();
+        let pending: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingAdmin)
+            .ok_or(Error::NoRotationPending)?;
+        if new_admin != pending {
+            return Err(Error::NotPendingAdmin);
+        }
+        let expiry: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RotationExpiry)
+            .unwrap_or(0);
+        if env.ledger().timestamp() > expiry {
+            env.storage().persistent().remove(&DataKey::PendingAdmin);
+            env.storage().persistent().remove(&DataKey::RotationExpiry);
+            return Err(Error::RotationExpired);
+        }
+        env.storage().persistent().set(&DataKey::Admin, &new_admin);
+        env.storage().persistent().remove(&DataKey::PendingAdmin);
+        env.storage().persistent().remove(&DataKey::RotationExpiry);
+        Ok(())
+    }
+
+    /// Decode a big-endian u64 from the first 8 bytes of a public input scalar.
+    fn decode_expiry_u64(input: &BytesN<32>) -> u64 {
+        let mut ts: u64 = 0;
+        for i in 0..8u32 {
+            ts = (ts << 8) | (input.get(i).unwrap_or(0) as u64);
+        }
+        ts
     }
 
     /// Cryptographic verification stub.


### PR DESCRIPTION
## Summary

Addresses four security issues in a single PR:

- **#511 — liquidity-pool integer overflow**: Replaced unchecked `i128` multiplications in `swap` and `add_liquidity` with `checked_mul`, returning `Error::ArithmeticOverflow` on overflow. Covers the geometric-mean initial share calculation, the pro-rata share ratios, the fee-adjusted swap input, and the constant-product output.

- **#508 — zk-eligibility proof expiry**: Established a public-input convention where `public_inputs[0]`'s first 8 bytes encode a big-endian u64 expiry timestamp. `verify_eligibility` now rejects proofs where `expiry <= env.ledger().timestamp()` with `Error::ProofExpired`.

- **#509 — unbounded Vec parameters**: Added per-parameter `MAX_*` constants and early-return `InputTooLarge` guards across affected contracts:
  - `clinical-trial`: `define_eligibility_criteria` (inclusion/exclusion criteria), `check_patient_eligibility` (evidence), `appoint_dsmb` (members), `record_study_visit` (adverse events)
  - `access-control`: `grant_access` access-list and resource-authorized accumulators
  - `patient-registry`: `grant_access` authorized-doctors map

- **#510 — admin rotation**: Added a two-step rotation mechanism to all single-admin contracts (`liquidity-pool`, `zk-eligibility`, `governance-voting`, `healthcare-analytics`, `provider-registry`):
  - `propose_admin_rotation(admin, new_admin)` — stores pending rotation with a 24-hour window
  - `accept_admin_rotation(new_admin)` — new admin confirms within window; expired rotations are cancelled

## Test plan

- [ ] Build all affected contracts and verify no compile errors
- [ ] liquidity-pool: swap/add_liquidity with extreme values returns ArithmeticOverflow
- [ ] zk-eligibility: expired timestamp in public_inputs[0] returns ProofExpired; valid timestamp passes
- [ ] clinical-trial/access-control/patient-registry: oversized Vec inputs return InputTooLarge
- [ ] Admin rotation: propose → accept within window succeeds; accept after 24h returns RotationExpired; wrong pending admin returns NotPendingAdmin

Closes #508 
closes #509 
closes  #510 
closes #511 
