### PR TITLE
feat(zk-eligibility): schema migration path for verifier key rotation

### DIFF
--- a/contracts/zk-eligibility/src/lib.rs
+++ b/contracts/zk-eligibility/src/lib.rs
@@ -86,6 +86,11 @@ pub struct VerifierKeyEntry {
     pub schema_version: u32,
     /// Whether this key is still active (admin can deprecate old versions).
     pub active: bool,
+    /// When non-zero, this deprecated schema was migrated to `migrated_to`.
+    /// Nullifiers recorded under this schema remain valid after migration.
+    /// When zero the schema was deprecated without migration; its nullifiers
+    /// are treated as expired so subjects can re-verify under a new schema.
+    pub migrated_to: u32,
 }
 
 /// Nullifier record stored on successful proof verification.
@@ -157,6 +162,7 @@ impl ZkEligibility {
             vk,
             schema_version,
             active: true,
+            migrated_to: 0,
         };
         env.storage().persistent().set(&key, &entry);
         env.events()
@@ -185,6 +191,56 @@ impl ZkEligibility {
         env.storage().persistent().set(&key, &entry);
         env.events()
             .publish((symbol_short!("vk_dep"), schema_version), symbol_short!("ok"));
+        Ok(())
+    }
+
+    /// Migrate a deprecated schema to a new version, carrying nullifiers forward.
+    ///
+    /// After a successful migration:
+    /// - `old_version` is marked `deprecated-migrated`; its nullifiers remain
+    ///   valid, preventing replay under the new schema.
+    /// - Nullifiers from schemas deprecated WITHOUT migration are treated as
+    ///   invalid, allowing subjects to re-verify under the new key.
+    ///
+    /// `migration_proof` is verified against the new schema's verifier key.
+    pub fn migrate_schema(
+        env: Env,
+        admin: Address,
+        old_version: u32,
+        new_version: u32,
+        migration_proof: Bytes,
+    ) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        Self::assert_admin(&env, &admin)?;
+
+        let old_key = DataKey::VerifierKey(old_version);
+        let mut old_entry: VerifierKeyEntry = env
+            .storage()
+            .persistent()
+            .get(&old_key)
+            .ok_or(Error::SchemaNotFound)?;
+
+        let new_entry: VerifierKeyEntry = env
+            .storage()
+            .persistent()
+            .get(&DataKey::VerifierKey(new_version))
+            .ok_or(Error::SchemaNotFound)?;
+
+        if !new_entry.active {
+            return Err(Error::SchemaNotFound);
+        }
+
+        if !Self::run_verification(&env, &new_entry.vk, &migration_proof, &Vec::new(&env)) {
+            return Err(Error::VerificationFailed);
+        }
+
+        old_entry.migrated_to = new_version;
+        env.storage().persistent().set(&old_key, &old_entry);
+
+        env.events().publish(
+            (symbol_short!("sch_migr"), old_version),
+            (new_version,),
+        );
         Ok(())
     }
 
@@ -300,6 +356,12 @@ impl ZkEligibility {
 
     // ── internal helpers ──────────────────────────────────────────────────────
 
+    /// Returns `true` when the nullifier for `proof_hash` is active:
+    /// - The record exists and has not yet reached its `expires_at_ledger`.
+    /// - The schema it was recorded against is either still active or was
+    ///   migrated to a new version (deprecated-migrated). Non-migrated
+    ///   deprecated schemas have their nullifiers invalidated so subjects
+    ///   can re-verify under the new key.
     fn nullifier_active(env: &Env, proof_hash: &BytesN<32>) -> bool {
         let record: NullifierRecord = match env
             .storage()
@@ -309,7 +371,19 @@ impl ZkEligibility {
             Some(r) => r,
             None => return false,
         };
-        env.ledger().sequence() < record.expires_at_ledger
+
+        if env.ledger().sequence() >= record.expires_at_ledger {
+            return false;
+        }
+
+        match env
+            .storage()
+            .persistent()
+            .get::<DataKey, VerifierKeyEntry>(&DataKey::VerifierKey(record.schema_version))
+        {
+            Some(entry) => entry.active || entry.migrated_to > 0,
+            None => false,
+        }
     }
 
     fn store_nullifier(env: &Env, proof_hash: &BytesN<32>, schema_version: u32) {

--- a/contracts/zk-eligibility/src/lib.rs
+++ b/contracts/zk-eligibility/src/lib.rs
@@ -35,6 +35,8 @@ mod test;
 pub const MAX_PUBLIC_INPUTS: u32 = 16;
 /// Maximum proof byte length accepted (Groth16 ~192 bytes; give headroom).
 pub const MAX_PROOF_BYTES: u32 = 512;
+/// Maximum subjects/bundles accepted in a single batch call.
+pub const MAX_BATCH_SIZE: u32 = 10;
 /// Default nullifier TTL in ledgers when not explicitly configured (~1 day at 5s/ledger).
 pub const DEFAULT_NULLIFIER_TTL_LEDGERS: u32 = 17_280;
 
@@ -53,6 +55,7 @@ pub enum Error {
     TooManyPublicInputs  = 7,
     ProofAlreadyUsed     = 8,
     VerificationFailed   = 9,
+    BatchTooLarge        = 10,
 }
 
 // ── Storage keys ──────────────────────────────────────────────────────────────
@@ -245,6 +248,35 @@ impl ZkEligibility {
         Ok(())
     }
 
+    /// Verify eligibility for a batch of up to `MAX_BATCH_SIZE` subjects.
+    ///
+    /// Returns a `Vec<bool>` of the same length as the inputs. A failure at
+    /// index N (invalid proof, expired nullifier, unknown schema, etc.) sets
+    /// that entry to `false` and does not affect other indices.
+    /// Batch sizes exceeding `MAX_BATCH_SIZE` return `Error::BatchTooLarge`.
+    pub fn verify_eligibility_batch(
+        env: Env,
+        subjects: Vec<Address>,
+        bundles: Vec<ProofBundle>,
+    ) -> Result<Vec<bool>, Error> {
+        Self::assert_initialized(&env)?;
+
+        let len = subjects.len();
+        if len > MAX_BATCH_SIZE || bundles.len() > MAX_BATCH_SIZE || len != bundles.len() {
+            return Err(Error::BatchTooLarge);
+        }
+
+        let mut results: Vec<bool> = Vec::new(&env);
+        for i in 0..len {
+            let subject = subjects.get(i).unwrap();
+            let bundle = bundles.get(i).unwrap();
+            subject.require_auth();
+            let ok = Self::try_verify_single(&env, &subject, &bundle);
+            results.push_back(ok);
+        }
+        Ok(results)
+    }
+
     /// Read a verifier key entry (public view).
     pub fn get_verifier_key(env: Env, schema_version: u32) -> Result<VerifierKeyEntry, Error> {
         env.storage()
@@ -291,6 +323,47 @@ impl ZkEligibility {
             &DataKey::Nullifier(proof_hash.clone()),
             &NullifierRecord { schema_version, expires_at_ledger: expires_at },
         );
+    }
+
+    /// Inner verification logic for a single (subject, bundle) pair that
+    /// returns `bool` instead of `Result` so batch calls can collect partial
+    /// successes without aborting the entire transaction.
+    fn try_verify_single(env: &Env, subject: &Address, bundle: &ProofBundle) -> bool {
+        if bundle.proof.len() > MAX_PROOF_BYTES || bundle.public_inputs.len() > MAX_PUBLIC_INPUTS {
+            return false;
+        }
+
+        let vk_entry: VerifierKeyEntry = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::VerifierKey(bundle.schema_version))
+        {
+            Some(e) => e,
+            None => return false,
+        };
+        if !vk_entry.active {
+            return false;
+        }
+
+        let proof_hash: BytesN<32> = env.crypto().sha256(&bundle.proof).into();
+        if Self::nullifier_active(env, &proof_hash) {
+            return false;
+        }
+
+        if !Self::run_verification(env, &vk_entry.vk, &bundle.proof, &bundle.public_inputs) {
+            return false;
+        }
+
+        Self::store_nullifier(env, &proof_hash, bundle.schema_version);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Eligibility(subject.clone()), &true);
+
+        env.events().publish(
+            (symbol_short!("zk_ok"), subject.clone(), bundle.schema_version),
+            proof_hash,
+        );
+        true
     }
 
     // ── guards ────────────────────────────────────────────────────────────────

--- a/contracts/zk-eligibility/src/lib.rs
+++ b/contracts/zk-eligibility/src/lib.rs
@@ -16,7 +16,9 @@
 //! - Verification cost is bounded: public_inputs length is capped at
 //!   MAX_PUBLIC_INPUTS and proof length at MAX_PROOF_BYTES.
 //! - A successful verification is recorded on-chain (nullifier pattern) so
-//!   the same proof cannot be replayed.
+//!   the same proof cannot be replayed within the TTL window.
+//! - Nullifiers expire after `nullifier_ttl_ledgers` ledgers; expired
+//!   nullifiers allow re-verification with the same proof.
 //! - Integration point: other contracts call `verify_eligibility` and receive
 //!   a typed `Ok(())` / `Err(Error)` they can gate their own logic on.
 
@@ -33,6 +35,8 @@ mod test;
 pub const MAX_PUBLIC_INPUTS: u32 = 16;
 /// Maximum proof byte length accepted (Groth16 ~192 bytes; give headroom).
 pub const MAX_PROOF_BYTES: u32 = 512;
+/// Default nullifier TTL in ledgers when not explicitly configured (~1 day at 5s/ledger).
+pub const DEFAULT_NULLIFIER_TTL_LEDGERS: u32 = 17_280;
 
 // ── Errors ────────────────────────────────────────────────────────────────────
 
@@ -59,10 +63,12 @@ pub enum DataKey {
     Admin,
     /// Verifier key for a given schema version.
     VerifierKey(u32),
-    /// Nullifier: proof hash → bool (prevents replay).
+    /// Nullifier: proof hash → NullifierRecord (schema version + expiry ledger).
     Nullifier(BytesN<32>),
     /// Cached subject eligibility after a successful proof.
     Eligibility(Address),
+    /// Configurable TTL (in ledgers) for nullifier entries.
+    NullifierTtlLedgers,
 }
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -77,6 +83,16 @@ pub struct VerifierKeyEntry {
     pub schema_version: u32,
     /// Whether this key is still active (admin can deprecate old versions).
     pub active: bool,
+}
+
+/// Nullifier record stored on successful proof verification.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NullifierRecord {
+    /// Schema version the proof was verified against.
+    pub schema_version: u32,
+    /// Ledger sequence number at which this nullifier expires.
+    pub expires_at_ledger: u32,
 }
 
 /// Proof submission bundle.
@@ -104,6 +120,16 @@ impl ZkEligibility {
         admin.require_auth();
         env.storage().persistent().set(&DataKey::Admin, &admin);
         env.storage().persistent().set(&DataKey::Initialized, &true);
+        Ok(())
+    }
+
+    /// Set the nullifier TTL in ledgers. Admin only.
+    pub fn set_nullifier_ttl(env: Env, admin: Address, ttl_ledgers: u32) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        Self::assert_admin(&env, &admin)?;
+        env.storage()
+            .persistent()
+            .set(&DataKey::NullifierTtlLedgers, &ttl_ledgers);
         Ok(())
     }
 
@@ -162,7 +188,8 @@ impl ZkEligibility {
     /// Verify a ZK proof of eligibility.
     ///
     /// On success the proof nullifier is stored so the proof cannot be
-    /// replayed. Returns `Ok(())` which callers use to gate their own logic.
+    /// replayed within the TTL window. Returns `Ok(())` which callers use
+    /// to gate their own logic.
     ///
     /// `subject` is the address whose eligibility is being proven; it must
     /// sign the call so the proof cannot be submitted on behalf of another
@@ -196,27 +223,17 @@ impl ZkEligibility {
 
         // ── Nullifier check ───────────────────────────────────────────────────
         let proof_hash: BytesN<32> = env.crypto().sha256(&bundle.proof).into();
-        let nullifier_key = DataKey::Nullifier(proof_hash.clone());
-        if env.storage().persistent().has(&nullifier_key) {
+        if Self::nullifier_active(&env, &proof_hash) {
             return Err(Error::ProofAlreadyUsed);
         }
 
         // ── Verification ──────────────────────────────────────────────────────
-        // On Soroban there is no native pairing-based ZK verifier built into
-        // the host. The canonical production approach is to use a Soroban host
-        // function once it is available, or to call an external verifier
-        // contract whose address is stored in the VK entry.
-        //
-        // Here we implement the verification gate that all production code
-        // paths must pass through. The actual cryptographic check is delegated
-        // to `run_verification` which can be swapped for a real verifier
-        // without changing any caller code.
         if !Self::run_verification(&env, &vk_entry.vk, &bundle.proof, &bundle.public_inputs) {
             return Err(Error::VerificationFailed);
         }
 
         // ── Record nullifier ──────────────────────────────────────────────────
-        env.storage().persistent().set(&nullifier_key, &true);
+        Self::store_nullifier(&env, &proof_hash, bundle.schema_version);
         env.storage()
             .persistent()
             .set(&DataKey::Eligibility(subject.clone()), &true);
@@ -236,11 +253,9 @@ impl ZkEligibility {
             .ok_or(Error::SchemaNotFound)
     }
 
-    /// Check whether a proof (identified by its hash) has already been used.
+    /// Check whether a proof (identified by its hash) has an active, unexpired nullifier.
     pub fn is_nullified(env: Env, proof_hash: BytesN<32>) -> bool {
-        env.storage()
-            .persistent()
-            .has(&DataKey::Nullifier(proof_hash))
+        Self::nullifier_active(&env, &proof_hash)
     }
 
     /// Check whether a subject has a cached successful eligibility proof.
@@ -249,6 +264,33 @@ impl ZkEligibility {
             .persistent()
             .get(&DataKey::Eligibility(subject))
             .unwrap_or(false)
+    }
+
+    // ── internal helpers ──────────────────────────────────────────────────────
+
+    fn nullifier_active(env: &Env, proof_hash: &BytesN<32>) -> bool {
+        let record: NullifierRecord = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::Nullifier(proof_hash.clone()))
+        {
+            Some(r) => r,
+            None => return false,
+        };
+        env.ledger().sequence() < record.expires_at_ledger
+    }
+
+    fn store_nullifier(env: &Env, proof_hash: &BytesN<32>, schema_version: u32) {
+        let ttl: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NullifierTtlLedgers)
+            .unwrap_or(DEFAULT_NULLIFIER_TTL_LEDGERS);
+        let expires_at = env.ledger().sequence().saturating_add(ttl);
+        env.storage().persistent().set(
+            &DataKey::Nullifier(proof_hash.clone()),
+            &NullifierRecord { schema_version, expires_at_ledger: expires_at },
+        );
     }
 
     // ── guards ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `migrate_schema(admin, old_version, new_version, migration_proof)` to transition a deprecated schema to a new version with a signed migration attestation
- `VerifierKeyEntry` gains `migrated_to: u32` (0 = not migrated; nonzero = the version it was migrated to)
- `nullifier_active` gates on schema migration status in addition to TTL:
  - **Active schema** → nullifier valid (prevents replay)
  - **Deprecated-migrated** (`migrated_to > 0`) → nullifier still valid (prevents cross-schema replay during key rotation)
  - **Deprecated non-migrated** (`migrated_to == 0`) → nullifier invalid (allows re-verification under the new key)
- Old schema is marked `deprecated-migrated`, not just `deprecated`

> **Depends on:** #505 (nullifier TTL) and #506 (batch) — must merge those first

## Test plan
- [ ] Full rotation cycle: register v1, verify proof, deprecate v1, register v2, `migrate_schema(v1 → v2)`, confirm v1 nullifier still active
- [ ] Non-migrated deprecated schema: nullifier becomes inactive, re-verification succeeds
- [ ] Invalid migration proof returns `VerificationFailed`
- [ ] Migrating to inactive new schema returns `SchemaNotFound`

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)