### PR TITLE
feat: bulk role assignment, commit-reveal expiry, credential expiry guards, revocation reason (#491 #492 #493 #494)

### DIFF
--- a/contracts/access-control/src/lib.rs
+++ b/contracts/access-control/src/lib.rs
@@ -39,12 +39,20 @@ pub enum ContractError {
     RateLimitExceeded = 23,
     /// A Vec parameter or accumulator exceeds its maximum allowed length.
     InputTooLarge = 24,
+    /// A commit-reveal commit has expired (older than COMMIT_EXPIRY_SECS).
+    CommitExpired = 25,
+    /// The batch of role assignments exceeds the maximum allowed size.
+    BatchTooLarge = 26,
 }
 
 /// Maximum number of access permissions a single grantee may accumulate.
 pub const MAX_ACCESS_LIST_LEN: u32 = 200;
 /// Maximum number of addresses authorized for a single resource.
 pub const MAX_RESOURCE_AUTHORIZED: u32 = 200;
+/// Maximum entries in a grant_roles_batch call.
+pub const BATCH_SIZE_LIMIT: u32 = 20;
+/// Commit-reveal window: commits older than this many seconds are rejected.
+pub const COMMIT_EXPIRY_SECS: u64 = 3600;
 
 /// --------------------
 /// Role Types (RBAC)
@@ -69,6 +77,16 @@ pub struct RoleAssignment {
     pub granted_by: Address,
     pub granted_at: u64,
     pub expires_at: u64,
+}
+
+/// Entry in a bulk role-assignment batch (#491).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoleBatchEntry {
+    pub entity: Address,
+    pub role: Role,
+    /// Role lifetime in seconds from the time of the batch call; 0 = no expiry.
+    pub duration_secs: u64,
 }
 
 /// --------------------
@@ -1268,8 +1286,66 @@ impl AccessControl {
             return Err(ContractError::CommitAlreadyUsed);
         }
 
+        if env.ledger().timestamp() > commit.committed_at + COMMIT_EXPIRY_SECS {
+            return Err(ContractError::CommitExpired);
+        }
+
         commit.used = true;
         env.storage().temporary().set(&key, &commit);
+        Ok(())
+    }
+
+    /// Grant a role to multiple entities in a single atomic call (#491).
+    ///
+    /// # Arguments
+    /// * `admin`       - Must hold the `Admin` role.
+    /// * `assignments` - Vec of `RoleBatchEntry`; capped at `BATCH_SIZE_LIMIT`.
+    pub fn grant_roles_batch(
+        env: Env,
+        admin: Address,
+        assignments: Vec<RoleBatchEntry>,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        Self::require_role(&env, &admin, &Role::Admin)?;
+
+        if assignments.len() > BATCH_SIZE_LIMIT {
+            return Err(ContractError::BatchTooLarge);
+        }
+
+        let now = env.ledger().timestamp();
+
+        // Validate all entries before writing any (atomicity guarantee).
+        for i in 0..assignments.len() {
+            let entry = assignments.get(i).unwrap();
+            let key = DataKey::RoleAssignment(entry.entity.clone(), entry.role.clone());
+            if env.storage().persistent().has(&key) {
+                if Self::load_active_role(&env, &entry.entity, &entry.role).is_some() {
+                    return Err(ContractError::RoleAlreadyGranted);
+                }
+            }
+        }
+
+        // Write phase.
+        for i in 0..assignments.len() {
+            let entry = assignments.get(i).unwrap();
+            let expires_at = if entry.duration_secs == 0 {
+                0u64
+            } else {
+                now + entry.duration_secs
+            };
+            let key = DataKey::RoleAssignment(entry.entity.clone(), entry.role.clone());
+            let assignment = RoleAssignment {
+                granted_by: admin.clone(),
+                granted_at: now,
+                expires_at,
+            };
+            env.storage().persistent().set(&key, &assignment);
+            env.events().publish(
+                (symbol_short!("role_grt"), entry.entity, entry.role),
+                symbol_short!("batch"),
+            );
+        }
+
         Ok(())
     }
 }

--- a/contracts/insurer-registry/src/lib.rs
+++ b/contracts/insurer-registry/src/lib.rs
@@ -4,7 +4,7 @@
 use shared::privacy::validate_nonzero_address;
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
-    String, Vec,
+    String, Symbol, Vec,
 };
 
 /// --------------------
@@ -21,6 +21,7 @@ pub enum Error {
     NoReviewersFound = 5,
     NotAuthorized = 6,
     InvalidAddress = 7,
+    CredentialExpired = 8,
 }
 
 #[contracttype]
@@ -43,6 +44,8 @@ pub struct CredentialAnchor {
     pub expires_at: u64,
     pub revocation_reference: BytesN<32>,
     pub revoked_at: Option<u64>,
+    pub revocation_reason: Option<Symbol>,
+    pub revoked_by: Option<Address>,
 }
 
 #[contracttype]
@@ -98,6 +101,8 @@ impl InsurerRegistry {
                 expires_at,
                 revocation_reference,
                 revoked_at: None,
+                revocation_reason: None,
+                revoked_by: None,
             },
         };
 
@@ -128,6 +133,8 @@ impl InsurerRegistry {
             .get(&key)
             .ok_or(Error::InsurerNotFound)?;
 
+        Self::assert_credential_valid(&env, &insurer)?;
+
         insurer.metadata = metadata;
         env.storage()
             .persistent()
@@ -157,6 +164,8 @@ impl InsurerRegistry {
             .persistent()
             .get(&key)
             .ok_or(Error::InsurerNotFound)?;
+
+        Self::assert_credential_valid(&env, &insurer)?;
 
         insurer.contact_details = contact_details;
         env.storage()
@@ -189,6 +198,8 @@ impl InsurerRegistry {
             .persistent()
             .get(&key)
             .ok_or(Error::InsurerNotFound)?;
+
+        Self::assert_credential_valid(&env, &insurer)?;
 
         insurer.coverage_policies = coverage_policies;
         env.storage()
@@ -225,15 +236,13 @@ impl InsurerRegistry {
         }
     }
 
-    fn assert_active_insurer(env: &Env, wallet: &Address) -> Result<(), Error> {
-        let key = DataKey::Insurer(wallet.clone());
-        let insurer: InsurerData = env
-            .storage()
-            .persistent()
-            .get(&key)
-            .ok_or(Error::InsurerNotFound)?;
+    fn assert_credential_valid(env: &Env, insurer: &InsurerData) -> Result<(), Error> {
+        let now = env.ledger().timestamp();
+        if insurer.credential.expires_at != 0 && now >= insurer.credential.expires_at {
+            return Err(Error::CredentialExpired);
+        }
         if insurer.credential.revoked_at.is_some() {
-            return Err(Error::InsurerNotFound);
+            return Err(Error::NotAuthorized);
         }
         Ok(())
     }
@@ -256,11 +265,14 @@ impl InsurerRegistry {
         validate_nonzero_address(&reviewer_wallet).map_err(|_| Error::InvalidAddress)?;
         insurer_wallet.require_auth();
 
-        // Verify insurer exists
+        // Verify insurer exists and credential is valid
         let insurer_key = DataKey::Insurer(insurer_wallet.clone());
-        if !env.storage().persistent().has(&insurer_key) {
-            return Err(Error::InsurerNotFound);
-        }
+        let insurer: InsurerData = env
+            .storage()
+            .persistent()
+            .get(&insurer_key)
+            .ok_or(Error::InsurerNotFound)?;
+        Self::assert_credential_valid(&env, &insurer)?;
 
         let reviewers_key = DataKey::ClaimsReviewers(insurer_wallet.clone());
         let mut reviewers: Vec<Address> = env
@@ -299,7 +311,14 @@ impl InsurerRegistry {
         validate_nonzero_address(&insurer_wallet).map_err(|_| Error::InvalidAddress)?;
         validate_nonzero_address(&reviewer_wallet).map_err(|_| Error::InvalidAddress)?;
         insurer_wallet.require_auth();
-        Self::assert_active_insurer(&env, &insurer_wallet)?;
+
+        let rm_insurer_key = DataKey::Insurer(insurer_wallet.clone());
+        let rm_insurer: InsurerData = env
+            .storage()
+            .persistent()
+            .get(&rm_insurer_key)
+            .ok_or(Error::InsurerNotFound)?;
+        Self::assert_credential_valid(&env, &rm_insurer)?;
 
         let reviewers_key = DataKey::ClaimsReviewers(insurer_wallet.clone());
         let reviewers: Vec<Address> = env
@@ -331,6 +350,53 @@ impl InsurerRegistry {
         env.events().publish(
             (symbol_short!("rm_rev"), insurer_wallet, reviewer_wallet),
             symbol_short!("success"),
+        );
+        Ok(())
+    }
+
+    /// Revoke an insurer's credential, recording the reason and revoking authority (#494).
+    ///
+    /// Only the credential's original issuer may call this; the insurer cannot self-revoke.
+    ///
+    /// # Arguments
+    /// * `admin`  - Must be the issuer stored in the credential.
+    /// * `wallet` - The insurer whose credential is being revoked.
+    /// * `reason` - A short symbol code describing the revocation reason.
+    pub fn revoke_credential(
+        env: Env,
+        admin: Address,
+        wallet: Address,
+        reason: Symbol,
+    ) -> Result<(), Error> {
+        validate_nonzero_address(&admin).map_err(|_| Error::InvalidAddress)?;
+        validate_nonzero_address(&wallet).map_err(|_| Error::InvalidAddress)?;
+        admin.require_auth();
+
+        let key = DataKey::Insurer(wallet.clone());
+        let mut insurer: InsurerData = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(Error::InsurerNotFound)?;
+
+        // Only the credential issuer is authorised to revoke.
+        if admin != insurer.credential.issuer {
+            return Err(Error::NotAuthorized);
+        }
+        // Insurer cannot self-revoke.
+        if admin == wallet {
+            return Err(Error::NotAuthorized);
+        }
+
+        let now = env.ledger().timestamp();
+        insurer.credential.revoked_at = Some(now);
+        insurer.credential.revocation_reason = Some(reason.clone());
+        insurer.credential.revoked_by = Some(admin.clone());
+        env.storage().persistent().set(&key, &insurer);
+
+        env.events().publish(
+            (symbol_short!("cred_rev"), wallet, admin),
+            reason,
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary


---

### closes #491 — access-control: bulk role assignment for institution onboarding

**Problem:** Onboarding a hospital with 50 staff required 50 individual `grant_role` calls — expensive and tedious.

**Changes (`contracts/access-control/src/lib.rs`):**
- New `RoleBatchEntry` struct: `{ entity: Address, role: Role, duration_secs: u64 }` — duration in seconds from call time; `0` means no expiry.
- New `grant_roles_batch(admin, assignments: Vec<RoleBatchEntry>)` function:
  - Requires caller to hold the `Admin` role.
  - Caps batch at `BATCH_SIZE_LIMIT = 20`; returns `BatchTooLarge` if exceeded.
  - **Two-phase**: validates all entries (no active duplicate roles) before writing any — guarantees all-or-nothing semantics.
  - Emits a `role_grt` event per assignment.
- `BatchTooLarge = 26` added to `ContractError`.

---

### closes #492 — access-control: enforce reveal deadline on commit-reveal flow

**Problem:** A commit could be revealed indefinitely, enabling delayed front-running attacks.

**Changes (`contracts/access-control/src/lib.rs`):**
- `COMMIT_EXPIRY_SECS: u64 = 3600` constant defines the 1-hour window.
- `CommitExpired = 25` added to `ContractError`.
- `verify_and_consume_commit` now checks `env.ledger().timestamp() > committed_at + COMMIT_EXPIRY_SECS` and returns `CommitExpired` if the deadline has passed. The check is placed after the `used` guard so replayed commits are rejected before the expiry path.

Note: `committed_at` was already stored in `PendingCommit`; this change activates its enforcement.

---

### closes #493 — insurer-registry: enforce credential expiry on all write paths

**Problem:** `update_insurer`, `update_coverage_policies`, `add_claims_reviewer`, and `remove_claims_reviewer` did not check `expires_at`, allowing an insurer with an expired credential to mutate its data.

**Changes (`contracts/insurer-registry/src/lib.rs`):**
- `CredentialExpired = 8` added to `Error`.
- `assert_active_insurer` replaced by `assert_credential_valid(env, &insurer: &InsurerData)`:
  - Returns `CredentialExpired` when `expires_at != 0 && now >= expires_at`.
  - Returns `NotAuthorized` when `revoked_at.is_some()`.
- Called at the top of every write function: `update_insurer`, `update_contact_details`, `update_coverage_policies`, `add_claims_reviewer`, `remove_claims_reviewer`.
- Read-only functions (`get_insurer`, `is_insurer_active`) are unaffected.

---

### closes #494 — insurer-registry: credential revocation with reason code

**Problem:** Revocation recorded `revoked_at` but not *why* or *by whom*, leaving regulators without an audit trail.

**Changes (`contracts/insurer-registry/src/lib.rs`):**
- `Symbol` added to SDK imports.
- `CredentialAnchor` gains two new fields:
  - `revocation_reason: Option<Symbol>` — short reason code (e.g. `fraud`, `expired_license`).
  - `revoked_by: Option<Address>` — the address that performed the revocation.
- New `revoke_credential(admin: Address, wallet: Address, reason: Symbol)` function:
  - `admin` must authenticate and must equal `credential.issuer` — the credential authority is the only party that can revoke.
  - `admin == wallet` is explicitly rejected (insurer cannot self-revoke).
  - Sets `revoked_at`, `revocation_reason`, and `revoked_by` atomically.
  - Emits a `cred_rev` event carrying the reason for off-chain audit systems.
- `register_insurer` initialises the two new fields to `None`.

## Test plan

- [ ] `grant_roles_batch` with ≤ 20 entries grants all roles; each is individually readable via `get_role_assignment`.
- [ ] `grant_roles_batch` with 21 entries returns `BatchTooLarge`.
- [ ] `grant_roles_batch` with a duplicate active role in the batch returns `RoleAlreadyGranted` and writes nothing.
- [ ] `grant_access` with a commit older than 3600 s returns `CommitExpired`.
- [ ] `grant_access` with a fresh commit succeeds as before.
- [ ] Calling any insurer write function after `expires_at` returns `CredentialExpired`.
- [ ] `revoke_credential` called by the issuer stores reason and revoking address.
- [ ] `revoke_credential` called by a non-issuer returns `NotAuthorized`.
- [ ] `revoke_credential` where `admin == wallet` returns `NotAuthorized`.