### PR TITLE
feat(healthcare-analytics): implement report job cancellation 

### DIFF
--- a/contracts/healthcare-analytics/src/lib.rs
+++ b/contracts/healthcare-analytics/src/lib.rs
@@ -104,6 +104,10 @@ pub enum DataKey {
     JobResultQuality(u64),
     PendingAdmin,
     RotationExpiry,
+    RequesterCpuUsed(Address),
+    RequesterMemoryUsed(Address),
+    RequesterCpuLimit,
+    RequesterMemoryLimit,
 }
 
 /// --------------------
@@ -130,6 +134,9 @@ pub enum Error {
     NoRotationPending = 12,
     RotationExpired = 13,
     NotPendingAdmin = 14,
+    RequesterThrottled = 15,
+    InvalidThreshold = 16,
+    JobAlreadyExecuting = 17,
 }
 
 #[contract]
@@ -359,7 +366,7 @@ impl HealthcareAnalytics {
             let hash: Bytes = env.crypto().sha256(
                 &Bytes::from_slice(&env, b"resource_usage_exceeded_quota")
             ).into();
-            let _ = attach_evidence(&env, incident_id, EvidenceType::ContextData, hash, job.requested_by);
+            let _ = attach_evidence(&env, incident_id, EvidenceType::ContextData, hash, job.requested_by.clone());
         }
 
         // Update per-requester cumulative usage.
@@ -397,7 +404,7 @@ impl HealthcareAnalytics {
         env.storage().persistent().set(&ResourceKey::ReportJob(job_id), &job);
 
         // Remove from running jobs
-        let mut running: Vec<u64> = env
+        let running: Vec<u64> = env
             .storage()
             .persistent()
             .get(&ResourceKey::RunningJobs)
@@ -486,15 +493,6 @@ impl HealthcareAnalytics {
     pub fn propose_admin_rotation(env: Env, admin: Address, new_admin: Address) -> Result<(), Error> {
         admin.require_auth();
         let stored: Address = env
-    /// Configure per-requester CPU and memory caps (admin only).
-    pub fn set_requester_limits(
-        env: Env,
-        admin: Address,
-        cpu_limit: u64,
-        memory_limit: u64,
-    ) -> Result<(), Error> {
-        admin.require_auth();
-        let stored_admin: Address = env
             .storage()
             .instance()
             .get(&DataKey::Admin)
@@ -538,6 +536,19 @@ impl HealthcareAnalytics {
         Ok(())
     }
 
+    /// Configure per-requester CPU and memory caps (admin only).
+    pub fn set_requester_limits(
+        env: Env,
+        admin: Address,
+        cpu_limit: u64,
+        memory_limit: u64,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
         if admin != stored_admin {
             return Err(Error::Unauthorized);
         }
@@ -790,6 +801,33 @@ impl HealthcareAnalytics {
         }
 
         Ok(results)
+    }
+
+    /// Cancel a queued report job.
+    pub fn cancel_report(env: Env, requester: Address, job_id: u64) -> Result<(), Error> {
+        requester.require_auth();
+
+        let job = get_job(&env, job_id).map_err(|_| Error::JobNotFound)?;
+
+        if job.requested_by != requester {
+            return Err(Error::Unauthorized);
+        }
+
+        if job.state == JobState::Running {
+            return Err(Error::JobAlreadyExecuting);
+        }
+
+        if job.state != JobState::Queued {
+            return Err(Error::JobNotFound);
+        }
+
+        shared::resource_management::cancel_queued_job(&env, job_id)
+            .map_err(|_| Error::JobNotFound)?;
+
+        env.events()
+            .publish((symbol_short!("rep_canc"), requester), job_id);
+
+        Ok(())
     }
 }
 

--- a/contracts/healthcare-analytics/src/test.rs
+++ b/contracts/healthcare-analytics/src/test.rs
@@ -691,8 +691,7 @@ fn test_request_report_full_quality_when_not_throttled() {
             &500_000,
             &50_000,
             &DegradationPolicy::Fail,
-        )
-        .unwrap();
+        );
 
     assert_eq!(accepted.result_quality, ResultQuality::Full);
     assert_eq!(
@@ -708,8 +707,10 @@ fn test_request_report_fail_policy_when_throttled() {
 
     // throttle_threshold = 0 means always throttled
     client
-        .set_resource_limits(&admin, &1, &1, &1, &0)
-        .unwrap();
+        .set_resource_limits(&admin, &1, &1, &1, &0);
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(&shared::resource_management::ResourceKey::TotalCpuUsed, &1u64);
+    });
 
     let result = client.try_request_report(
         &requester,
@@ -729,8 +730,10 @@ fn test_request_report_approximate_policy_when_throttled() {
     let requester = Address::generate(&env);
 
     client
-        .set_resource_limits(&admin, &1, &1, &1, &0)
-        .unwrap();
+        .set_resource_limits(&admin, &1, &1, &1, &0);
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(&shared::resource_management::ResourceKey::TotalCpuUsed, &1u64);
+    });
 
     let accepted = client
         .request_report(
@@ -740,8 +743,7 @@ fn test_request_report_approximate_policy_when_throttled() {
             &1_000_000,
             &100_000,
             &DegradationPolicy::Approximate,
-        )
-        .unwrap();
+        );
 
     assert_eq!(accepted.result_quality, ResultQuality::Truncated);
     assert_eq!(
@@ -756,8 +758,10 @@ fn test_request_report_sample_policy_when_throttled() {
     let requester = Address::generate(&env);
 
     client
-        .set_resource_limits(&admin, &1, &1, &1, &0)
-        .unwrap();
+        .set_resource_limits(&admin, &1, &1, &1, &0);
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(&shared::resource_management::ResourceKey::TotalCpuUsed, &1u64);
+    });
 
     let accepted = client
         .request_report(
@@ -767,14 +771,16 @@ fn test_request_report_sample_policy_when_throttled() {
             &1_000_000,
             &100_000,
             &DegradationPolicy::Sample,
-        )
-        .unwrap();
+        );
 
     assert_eq!(accepted.result_quality, ResultQuality::Sampled);
     assert_eq!(
         client.get_job_result_quality(&accepted.job_id),
         ResultQuality::Sampled
     );
+}
+
+#[test]
 fn test_cpu_quota_accumulates_across_jobs() {
     let (env, client, admin) = setup_with_admin();
     let requester = Address::generate(&env);
@@ -789,7 +795,8 @@ fn test_cpu_quota_accumulates_across_jobs() {
         &JobPriority::Normal,
         &400,
         &50,
-    );
+        &DegradationPolicy::Fail,
+    ).unwrap().unwrap().job_id;
     client.execute_next_report();
     client.complete_report(&job1, &400, &50);
 
@@ -800,7 +807,8 @@ fn test_cpu_quota_accumulates_across_jobs() {
         &JobPriority::Normal,
         &400,
         &50,
-    );
+        &DegradationPolicy::Fail,
+    ).unwrap().unwrap().job_id;
     client.execute_next_report();
     client.complete_report(&job2, &400, &50);
 
@@ -812,7 +820,8 @@ fn test_cpu_quota_accumulates_across_jobs() {
         &JobPriority::Normal,
         &1,
         &1,
-    );
+        &DegradationPolicy::Fail,
+    ).unwrap().unwrap().job_id;
     client.execute_next_report();
     client.complete_report(&job3, &1, &1);
 
@@ -824,7 +833,8 @@ fn test_cpu_quota_accumulates_across_jobs() {
         &JobPriority::Normal,
         &100,
         &1,
-    );
+        &DegradationPolicy::Fail,
+    ).unwrap().unwrap().job_id;
     client.execute_next_report();
     client.complete_report(&job4, &100, &1);
 
@@ -835,6 +845,67 @@ fn test_cpu_quota_accumulates_across_jobs() {
         &JobPriority::Normal,
         &10,
         &10,
+        &DegradationPolicy::Fail,
     );
     assert_eq!(result, Err(Ok(Error::JobThrottled)));
+}
+
+#[test]
+fn test_cancel_report_queued() {
+    let (env, client, _admin) = setup_with_admin();
+    let requester = Address::generate(&env);
+
+    let accepted = client
+        .request_report(
+            &requester,
+            &String::from_str(&env, "quality_metrics"),
+            &shared::resource_management::JobPriority::Normal,
+            &500_000,
+            &50_000,
+            &DegradationPolicy::Fail,
+        );
+
+    let job_id = accepted.job_id;
+
+    // Only the original requester may cancel
+    let non_requester = Address::generate(&env);
+    let err_unauthorized = client.try_cancel_report(&non_requester, &job_id);
+    assert_eq!(err_unauthorized, Err(Ok(Error::Unauthorized)));
+
+    // Queued job can be cancelled by its requester
+    client.cancel_report(&requester, &job_id);
+
+    // Verify it cannot be cancelled again / is no longer in Queued state
+    let err_not_found = client.try_cancel_report(&requester, &job_id);
+    assert_eq!(err_not_found, Err(Ok(Error::JobNotFound)));
+
+    // Cancelled job ID cannot be re-executed
+    let next_job = client.execute_next_report();
+    assert_eq!(next_job, None);
+}
+
+#[test]
+fn test_cancel_report_executing() {
+    let (env, client, _admin) = setup_with_admin();
+    let requester = Address::generate(&env);
+
+    let accepted = client
+        .request_report(
+            &requester,
+            &String::from_str(&env, "quality_metrics"),
+            &shared::resource_management::JobPriority::Normal,
+            &500_000,
+            &50_000,
+            &DegradationPolicy::Fail,
+        );
+
+    let job_id = accepted.job_id;
+
+    // Start executing the job
+    let executed_id = client.execute_next_report().unwrap();
+    assert_eq!(executed_id, job_id);
+
+    // Executing job cancellation returns Error::JobAlreadyExecuting
+    let err_executing = client.try_cancel_report(&requester, &job_id);
+    assert_eq!(err_executing, Err(Ok(Error::JobAlreadyExecuting)));
 }

--- a/contracts/shared/src/resource_management.rs
+++ b/contracts/shared/src/resource_management.rs
@@ -40,6 +40,7 @@ pub enum JobState {
     Completed,
     Failed,
     Throttled,
+    Cancelled,
 }
 
 /// Report job descriptor
@@ -368,4 +369,42 @@ pub fn get_next_job_for_execution(env: &Env) -> Option<u64> {
     }
 
     best_job.map(|(job_id, _)| job_id)
+}
+
+/// Cancel a queued job, transitioning its state to Cancelled and removing it from the queue
+pub fn cancel_queued_job(env: &Env, job_id: u64) -> Result<(), ()> {
+    let mut job: ReportJob = env
+        .storage()
+        .persistent()
+        .get(&ResourceKey::ReportJob(job_id))
+        .ok_or(())?;
+
+    if job.state != JobState::Queued {
+        return Err(());
+    }
+
+    job.state = JobState::Cancelled;
+    env.storage()
+        .persistent()
+        .set(&ResourceKey::ReportJob(job_id), &job);
+
+    // Remove from QueuedJobs
+    let queued: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&ResourceKey::QueuedJobs)
+        .unwrap_or(Vec::new(env));
+    let mut new_queued = Vec::new(env);
+    for i in 0..queued.len() {
+        if let Some(id) = queued.get(i) {
+            if id != job_id {
+                new_queued.push_back(id);
+            }
+        }
+    }
+    env.storage()
+        .persistent()
+        .set(&ResourceKey::QueuedJobs, &new_queued);
+
+    Ok(())
 }


### PR DESCRIPTION
closes #497 
## Summary
This PR implements the report job cancellation feature for the `healthcare-analytics` contract. Requesters can now cancel report jobs that are still in the `Queued` state, freeing resources and preventing the execution of unneeded jobs.

##  Changes
- **Shared Crate (`contracts/shared/src/resource_management.rs`)**:
  - Added `JobState::Cancelled` variant to the job state enum.
  - Implemented `cancel_queued_job` to transition a job's state to `Cancelled` and remove its ID from the `QueuedJobs` storage list.
- **Analytics Contract (`contracts/healthcare-analytics/src/lib.rs`)**:
  - Added `cancel_report(env: Env, requester: Address, job_id: u64)` endpoint.
  - Enforced authentication, requester ownership checks, and validation that running/executing or completed jobs cannot be cancelled.
  - Published the `rep_canc` event on successful job cancellation.
- **Integration Tests (`contracts/healthcare-analytics/src/test.rs`)**:
  - Added `test_cancel_report_queued` to verify normal queue cancellation, owner verification, and execution avoidance.
  - Added `test_cancel_report_executing` to verify that executing jobs reject cancellation with `JobAlreadyExecuting`.
  - Fixed compile signatures and throttling checks in existing tests.

## Verification
- Verified by running all unit tests in the `healthcare-analytics` crate:
  ```bash
  cargo test -p healthcare-analytics
  ```
  Result: `ok. 30 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out`
```
