### PR TITLE
Document retention policies and wire insurer-registry integrations.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Changelog
+
+- [ ] I have updated `CHANGELOG.md` for any user-facing contract API change (new functions, breaking changes, deprecations, or security fixes).
+
+## Test plan
+
+- [ ] Unit / integration tests added or updated
+- [ ] `cargo test` passes locally (if applicable)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to contracts in this workspace are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### prior-authorization
+
+#### Added
+- `initialize(insurer_registry_id)` stores the insurer-registry contract used for coverage validation (#526).
+- `ServiceNotCovered` error when requested procedure codes are absent from all active insurer coverage plans.
+
+#### Changed
+- **BREAKING:** `submit_prior_authorization` now requires `insurer_wallet: Address` and must be called only after `initialize`.
+- Authorization submission cross-checks `InsurerRegistryInterface::get_coverage_plans` before accepting a request (#526).
+
+### medical-claims
+
+#### Added
+- `InsurerNotActive` error when submitting a claim against an insurer with expired or revoked credentials (#527).
+- `initialize` now accepts `insurer_registry_id` for on-chain credential verification.
+
+#### Changed
+- **BREAKING:** `initialize` signature extended with `insurer_registry_id: Address` (#527).
+- `submit_claim` calls `InsurerRegistryInterface::is_insurer_active` before creating a claim record.
+
+### insurer-registry
+
+#### Added
+- `CoveragePlan` struct and `CoveragePlans` persistent storage key.
+- `set_coverage_plans` / `get_coverage_plans` for structured benefit allowlists consumed by prior-authorization (#526).
+
+### patient-registry
+
+#### Changed
+- TTL extension delegates to `ttl-config` critical/operational helpers based on `RetentionClass` (Clinical/Financial → critical, Administrative → operational).
+
+### pacs-integration
+
+#### Changed
+- All persistent imaging keys use critical-class TTL bump constants from `ttl-config`.
+
+### allergy-management
+
+#### Changed
+- All allergy and access-control persistent keys use `extend_critical_ttl` helpers from `ttl-config`.
+
+## [2026-03-01]
+
+### access-control
+
+#### Added
+- `check_consent` cross-contract API consumed by medical-claims for HIPAA consent verification (#300).
+
+### medical-claims
+
+#### Added
+- Payment reconciliation with financial-records contract (#392).
+- Consent gate on `submit_claim` via access-control integration (#300).

--- a/DATA_RETENTION.md
+++ b/DATA_RETENTION.md
@@ -1,0 +1,888 @@
+# On-Chain Data Retention Policies
+
+This document records per-contract storage retention decisions for the Healthy-Stellar healthcare contract workspace. Constants are defined in `contracts/ttl-config/src/lib.rs` and summarized in `TTL_POLICY.md`.
+
+## Retention Classes
+
+| Class | Bump (ledgers) | Threshold (ledgers) | ~Calendar equivalence* | Bump policy |
+|-------|----------------|---------------------|------------------------|-------------|
+| **Critical** | 535,680 | 518,400 | ~31 days | Bump on every write; bump on read for active clinical records |
+| **Operational** | 120,960 | 60,480 | ~7 days | Bump on write; optional bump on read |
+| **Ephemeral** | 17,280 | 8,640 | ~1 day | Bump on write only |
+
+*Assumes ~5 seconds per ledger, per `ttl-config` documentation.
+
+## HIPAA Alignment Summary
+
+| Class | Justification |
+|-------|---------------|
+| Critical | PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment. |
+| Operational | Workflow, billing, and audit-adjacent records: retain through adjudication cycles; shorter rolling window limits stale operational PHI exposure. |
+| Ephemeral | Non-clinical counters and caches; no PHI; minimal retention reduces attack surface and storage rent. |
+
+## Contract Summary
+
+| Contract | Retention class | Bump amount | Threshold | TTL helper | Status |
+|----------|-----------------|-------------|-----------|------------|--------|
+| `access-control` | Operational | 120,960 (~7.0d) | 60,480 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `allergy-management` | Critical | 535,680 (~31.0d) | 518,400 | `extend_critical_ttl / extend_critical_ttl_if_exists` | Implemented |
+| `allergy-tracking` | Operational | 120,960 (~7.0d) | 60,480 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `care-plan` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `clinical-guideline` | Operational | 120,960 (~7.0d) | 60,480 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `clinical-trial` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `dental-records` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `doctor-registry` | Operational | 120,960 (~7.0d) | 60,480 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `emergency-medical-info` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `financial-records` | Operational | 120,960 (~7.0d) | 60,480 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `governance-voting` | Ephemeral | 17,280 (~1.0d) | 8,640 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `hai-tracking` | Operational | 120,960 (~7.0d) | 60,480 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `health-records` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `healthcare-analytics` | Ephemeral | 17,280 (~1.0d) | 8,640 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `healthcare-credentialing` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `hospital-discharge-management` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `hospital-registry` | Operational | 120,960 (~7.0d) | 60,480 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `imaging-radiology` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `immunization-registry` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `insurer-registry` | Operational | 120,960 (~7.0d) | 60,480 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `lab-management` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `liquidity-pool` | Ephemeral | 17,280 (~1.0d) | 8,640 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `medical-claims` | Operational | 120,960 (~7.0d) | 60,480 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `medical-device-tracking` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `mental-health` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `multisig-governance` | Ephemeral | 17,280 (~1.0d) | 8,640 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `nft-badges` | Ephemeral | 17,280 (~1.0d) | 8,640 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `nutrition-care-management` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `pacs-integration` | Critical | 535,680 (~31.0d) | 518,400 | `extend_ttl with critical constants` | Implemented |
+| `patient-registry` | Critical + Operational | 535,680 (~31.0d) | 518,400 | `extend_critical_ttl_if_exists / extend_operational_ttl_if_exists` | Implemented |
+| `patient-vitals` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `prenatal-pediatric` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `prescription-management` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `prior-authorization` | Operational | 120,960 (~7.0d) | 60,480 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `provider-registry` | Operational | 120,960 (~7.0d) | 60,480 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `referral` | Operational | 120,960 (~7.0d) | 60,480 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `rehabilitation-services` | Critical | 535,680 (~31.0d) | 518,400 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `scholarship-fund` | Ephemeral | 17,280 (~1.0d) | 8,640 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `telemedicine` | Operational | 120,960 (~7.0d) | 60,480 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `upgrade-governance` | Ephemeral | 17,280 (~1.0d) | 8,640 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `zk-eligibility` | Ephemeral | 17,280 (~1.0d) | 8,640 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+| `zk-eligibility-verifier` | Operational | 120,960 (~7.0d) | 60,480 | `Not yet implemented — follow TTL_POLICY.md migration guide` | Recommended |
+
+## Per-Contract Persistent Storage Keys
+
+### `access-control`
+
+- **Retention class:** Operational
+- **Bump / threshold:** 120,960 / 60,480 ledgers
+- **HIPAA note:** Workflow, billing, and audit-adjacent records: retain through adjudication cycles; shorter rolling window limits stale operational PHI exposure.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Admin` | Persistent storage entry |
+| `Entity(Address)` | Persistent storage entry |
+| `AccessList(Address)` | Entity -> Vec<AccessPermission> |
+| `ResourceAccess(String)` | Resource -> Vec<Address> (authorized parties) |
+| `Did(Address)` | Persistent storage entry |
+| `GrantIndex(Address, Address, String)` | Persistent storage entry |
+| `OpCounter` | Persistent storage entry |
+| `Commit(BytesN<32>)` | Persistent storage entry |
+| `Consent(Address, Address, String)` | Persistent storage entry |
+| `SubjectConsents(Address)` | Persistent storage entry |
+| `RoleAssignment(Address, Role)` | Persistent storage entry |
+| `RateLimit(Address, u32)` | Persistent storage entry |
+| `EmergencyAccess(Address, Address)` | Persistent storage entry |
+
+### `allergy-management`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Admin` | Persistent storage entry |
+| `AllergyCounter` | Persistent storage entry |
+| `Allergy(u64)` | Persistent storage entry |
+| `PatientAllergies(Address)` | Persistent storage entry |
+| `AccessControl(Address, Address)` | (patient, provider) |
+| `CrossSensitivity(String, String)` | (allergen1, allergen2) |
+| `PatientRegistry` | Persistent storage entry |
+| `ProviderRegistry` | Persistent storage entry |
+| `HospitalRegistry` | Persistent storage entry |
+| `InsurerRegistry` | Persistent storage entry |
+
+### `allergy-tracking`
+
+- **Retention class:** Operational
+- **Bump / threshold:** 120,960 / 60,480 ledgers
+- **HIPAA note:** Workflow, billing, and audit-adjacent records: retain through adjudication cycles; shorter rolling window limits stale operational PHI exposure.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Admin` | Persistent storage entry |
+| `AllergyCounter` | Persistent storage entry |
+| `Allergy(u64)` | Persistent storage entry |
+| `PatientAllergies(Address)` | Persistent storage entry |
+| `SeverityHistory(u64)` | Persistent storage entry |
+| `DrugCrossSensitivity(String)` | Persistent storage entry |
+
+### `care-plan`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `CarePlanCounter` | Persistent storage entry |
+| `GoalCounter` | Persistent storage entry |
+| `InterventionCounter` | Persistent storage entry |
+| `BarrierCounter` | Persistent storage entry |
+| `ReviewCounter` | Persistent storage entry |
+| `CarePlan(u64)` | Persistent storage entry |
+| `Goal(u64)` | Persistent storage entry |
+| `Intervention(u64)` | Persistent storage entry |
+| `Barrier(u64)` | Persistent storage entry |
+| `Review(u64)` | Persistent storage entry |
+| `PlanGoals(u64)` | Persistent storage entry |
+| `PlanInterventions(u64)` | Persistent storage entry |
+| `PlanBarriers(u64)` | Persistent storage entry |
+| `PlanReviews(u64)` | Persistent storage entry |
+| `PlanCareTeam(u64)` | Persistent storage entry |
+| `PatientPlans(Address)` | Persistent storage entry |
+
+### `clinical-guideline`
+
+- **Retention class:** Operational
+- **Bump / threshold:** 120,960 / 60,480 ledgers
+- **HIPAA note:** Workflow, billing, and audit-adjacent records: retain through adjudication cycles; shorter rolling window limits stale operational PHI exposure.
+
+_No `DataKey` enum found; contract may use inline keys or instance storage only._
+
+### `clinical-trial`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Admin` | Persistent storage entry |
+| `TrialCounter` | Persistent storage entry |
+| `EnrollmentCounter` | Persistent storage entry |
+| `EventCounter` | Persistent storage entry |
+| `Trial(u64)` | Persistent storage entry |
+| `Criteria(u64)` | Persistent storage entry |
+| `Enrollment(u64)` | Persistent storage entry |
+| `TrialEnrollments(u64)` | Persistent storage entry |
+| `PatientEnrollments(Address)` | Persistent storage entry |
+| `StudyVisit(u64, u32)` | Persistent storage entry |
+| `AdverseEvent(u64)` | Persistent storage entry |
+| `ProtocolDeviation(u64, u64)` | Persistent storage entry |
+| `SafetyReport(u64, u64)` | Persistent storage entry |
+| `PatientRegistry` | Persistent storage entry |
+| `DsmBoard(u64)` | Persistent storage entry |
+| `SafetyHalt(u64)` | Persistent storage entry |
+| `SiteCounter(u64)` | Persistent storage entry |
+| `Site(u64, u64)` | Persistent storage entry |
+| `TrialSites(u64)` | Persistent storage entry |
+| `TrialPhaseProtocol(u64)` | Persistent storage entry |
+
+### `dental-records`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `ChartCount` | Persistent storage entry |
+| `Chart(u64)` | chart_id |
+| `ToothCond(u64, String)` | chart_id, tooth_number |
+| `Perio(u64, String, Symbol)` | chart_id, tooth_number, site |
+| `PlanCount` | Persistent storage entry |
+| `Plan(u64)` | treatment_plan_id |
+| `AppointmentCount` | Persistent storage entry |
+| `Appt(u64)` | appointment_id |
+| `ProcedureLog(u64)` | appointment_id -> log |
+| `RadiographCount` | Persistent storage entry |
+| `Radio(u64)` | radiograph_id |
+| `OrthoCount` | Persistent storage entry |
+| `Ortho(u64)` | ortho_treatment_id |
+| `OrthoAdj(u64, u64)` | ortho_treatment_id, adjustment_date |
+| `RxCount` | Persistent storage entry |
+| `Rx(u64)` | rx_id |
+| `Consent(BytesN<32>)` | Persistent storage entry |
+
+### `doctor-registry`
+
+- **Retention class:** Operational
+- **Bump / threshold:** 120,960 / 60,480 ledgers
+- **HIPAA note:** Workflow, billing, and audit-adjacent records: retain through adjudication cycles; shorter rolling window limits stale operational PHI exposure.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Admin` | Persistent storage entry |
+| `Doctor(Address)` | Persistent storage entry |
+
+### `emergency-medical-info`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `EmergencyProfile(Address)` | Persistent storage entry |
+| `CriticalAlerts(Address)` | Persistent storage entry |
+| `EmergencyAccessLog(Address)` | Persistent storage entry |
+| `DNROrder(Address)` | Persistent storage entry |
+| `EmergencyNotifications(Address)` | Persistent storage entry |
+| `RecoveryConfig(Address)` | Persistent storage entry |
+| `RecoveryProposal(Address)` | Persistent storage entry |
+
+### `financial-records`
+
+- **Retention class:** Operational
+- **Bump / threshold:** 120,960 / 60,480 ledgers
+- **HIPAA note:** Workflow, billing, and audit-adjacent records: retain through adjudication cycles; shorter rolling window limits stale operational PHI exposure.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Record(Address, u32)` | (owner, idx) -> FinancialRecord |
+| `RecordCount(Address)` | owner -> u32 |
+| `Access(Address, Address)` | (owner, authorized) -> bool |
+| `TypeIndex(Address, u32, u32)` | (owner, record_type as u32, seq) -> record idx |
+| `TypeCount(Address, u32)` | (owner, record_type as u32) -> u32 |
+| `DateIndex(Address, u32)` | (owner, seq) -> record idx  (insertion order) |
+| `DateCount(Address)` | owner -> u32 |
+
+### `governance-voting`
+
+- **Retention class:** Ephemeral
+- **Bump / threshold:** 17,280 / 8,640 ledgers
+- **HIPAA note:** Non-clinical counters and caches; no PHI; minimal retention reduces attack surface and storage rent.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Admin` | Persistent storage entry |
+| `NextId` | Persistent storage entry |
+| `Proposal(u64)` | Persistent storage entry |
+| `Vote(u64, Address)` | (proposal_id, voter) → VoteChoice |
+| `PendingAdmin` | Persistent storage entry |
+| `RotationExpiry` | Persistent storage entry |
+
+### `hai-tracking`
+
+- **Retention class:** Operational
+- **Bump / threshold:** 120,960 / 60,480 ledgers
+- **HIPAA note:** Workflow, billing, and audit-adjacent records: retain through adjudication cycles; shorter rolling window limits stale operational PHI exposure.
+
+| Storage key | Notes |
+|-------------|-------|
+| `InfectionCase(u64)` | Persistent storage entry |
+| `OutbreakCluster(u64)` | Persistent storage entry |
+| `IsolationPrecaution(u64)` | Persistent storage entry |
+| `HandHygieneRecord(u64)` | Persistent storage entry |
+| `StewardshipRecord(u64)` | Persistent storage entry |
+| `NhsnReport(u64)` | Persistent storage entry |
+| `InfectionIds` | Persistent storage entry |
+| `OutbreakIds` | Persistent storage entry |
+| `PrecautionIds` | Persistent storage entry |
+| `WardRateConfig(Address, String, Symbol)` | Persistent storage entry |
+
+### `health-records`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Record(u64)` | Persistent storage entry |
+| `RecordCounter` | Persistent storage entry |
+| `Consent(Address, Address)` | (patient, provider) -> ConsentScope |
+| `PatientProviders(Address)` | patient -> Vec<Address> of consented providers |
+| `CategoryIndex(RecordCategory)` | category -> Vec<u64> of record ids in that category, for prefix-style queries |
+| `ProviderRegistry` | Persistent storage entry |
+| `RecordVersion(u64, u32)` | Persistent storage entry |
+
+### `healthcare-analytics`
+
+- **Retention class:** Ephemeral
+- **Bump / threshold:** 17,280 / 8,640 ledgers
+- **HIPAA note:** Non-clinical counters and caches; no PHI; minimal retention reduces attack surface and storage rent.
+
+| Storage key | Notes |
+|-------------|-------|
+| `MetricCounter` | Persistent storage entry |
+| `Metric(u64)` | Persistent storage entry |
+| `MetricsByType(Symbol)` | Persistent storage entry |
+| `QualityMetricCounter` | Persistent storage entry |
+| `QualityMetric(u64)` | Persistent storage entry |
+| `QualityMetricsByProvider(Address)` | Persistent storage entry |
+| `Admin` | Persistent storage entry |
+| `JobResultQuality(u64)` | Persistent storage entry |
+| `PendingAdmin` | Persistent storage entry |
+| `RotationExpiry` | Persistent storage entry |
+
+### `healthcare-credentialing`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `CaseCounter` | Persistent storage entry |
+| `Case(u64)` | Persistent storage entry |
+| `ProviderFacilityCase(Address, Address)` | Persistent storage entry |
+| `CaseDocuments(u64)` | Persistent storage entry |
+| `CaseVerifications(u64)` | Persistent storage entry |
+| `CaseSanctions(u64)` | Persistent storage entry |
+| `CasePeerReferences(u64)` | Persistent storage entry |
+| `PrivilegeCounter` | Persistent storage entry |
+| `ProviderFacilityPrivileges(Address, Address)` | Persistent storage entry |
+| `ProvisionalCounter` | Persistent storage entry |
+| `ProvisionalRequest(u64)` | Persistent storage entry |
+| `ProviderFacilityProvisional(Address, Address)` | Persistent storage entry |
+| `ProviderFacilityActivities(Address, Address)` | Persistent storage entry |
+| `FocusedReviewCounter` | Persistent storage entry |
+| `FocusedReview(u64)` | Persistent storage entry |
+| `RecredentialingCounter` | Persistent storage entry |
+| `Recredentialing(u64)` | Persistent storage entry |
+| `ProviderFacilityRecredentialings(Address, Address)` | Persistent storage entry |
+| `ProviderFacilitySuspensions(Address, Address)` | Persistent storage entry |
+| `ProviderFacilityReinstatements(Address, Address)` | Persistent storage entry |
+| `ActiveRecredentialingCases(Address, Address)` | Persistent storage entry |
+
+### `hospital-discharge-management`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+_No `DataKey` enum found; contract may use inline keys or instance storage only._
+
+### `hospital-registry`
+
+- **Retention class:** Operational
+- **Bump / threshold:** 120,960 / 60,480 ledgers
+- **HIPAA note:** Workflow, billing, and audit-adjacent records: retain through adjudication cycles; shorter rolling window limits stale operational PHI exposure.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Hospital(Address)` | Persistent storage entry |
+| `HospitalConfig(Address)` | Persistent storage entry |
+
+### `imaging-radiology`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `OrderCounter` | Persistent storage entry |
+| `ImagingOrder(u64)` | Persistent storage entry |
+| `ImagingSchedule(u64)` | Persistent storage entry |
+| `DicomImages(u64)` | Persistent storage entry |
+| `PreliminaryReport(u64)` | Persistent storage entry |
+| `FinalReport(u64)` | Persistent storage entry |
+| `PeerReview(u64)` | Persistent storage entry |
+| `PatientOrdersPage(Address, u32)` | Persistent storage entry |
+| `PatientOrdersHead(Address)` | Persistent storage entry |
+| `PatientOrdersTotal(Address)` | Persistent storage entry |
+| `ProviderOrdersPage(Address, u32)` | Persistent storage entry |
+| `ProviderOrdersHead(Address)` | Persistent storage entry |
+| `ProviderOrdersTotal(Address)` | Persistent storage entry |
+
+### `immunization-registry`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `ImmunizationCounter` | Persistent storage entry |
+| `PatientImmunizations(Address)` | List of IDs (u64) |
+| `ImmunizationRecord(u64)` | Persistent storage entry |
+| `AdverseEvents(u64)` | List of AdverseEvent |
+| `PatientVaccineSeries(Address)` | List of VaccineSeries |
+
+### `insurer-registry`
+
+- **Retention class:** Operational
+- **Bump / threshold:** 120,960 / 60,480 ledgers
+- **HIPAA note:** Workflow, billing, and audit-adjacent records: retain through adjudication cycles; shorter rolling window limits stale operational PHI exposure.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Insurer(Address)` | Persistent storage entry |
+| `ClaimsReviewers(Address)` | Persistent storage entry |
+| `CoveragePlans(Address)` | Persistent storage entry |
+
+### `lab-management`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `LabOrder(u64)` | Persistent storage entry |
+| `LabCounter` | Persistent storage entry |
+
+### `liquidity-pool`
+
+- **Retention class:** Ephemeral
+- **Bump / threshold:** 17,280 / 8,640 ledgers
+- **HIPAA note:** Non-clinical counters and caches; no PHI; minimal retention reduces attack surface and storage rent.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Admin` | Persistent storage entry |
+| `ReserveA` | Persistent storage entry |
+| `ReserveB` | Persistent storage entry |
+| `TotalShares` | Persistent storage entry |
+| `Shares(Address)` | Persistent storage entry |
+| `PendingAdmin` | Persistent storage entry |
+| `RotationExpiry` | Persistent storage entry |
+
+### `medical-claims`
+
+- **Retention class:** Operational
+- **Bump / threshold:** 120,960 / 60,480 ledgers
+- **HIPAA note:** Workflow, billing, and audit-adjacent records: retain through adjudication cycles; shorter rolling window limits stale operational PHI exposure.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Admin` | Persistent storage entry |
+| `Insurer(Address)` | insurer_id -> bool |
+| `ClaimCounter` | Persistent storage entry |
+| `Claim(u64)` | Persistent storage entry |
+| `DenialInfos(u64)` | Persistent storage entry |
+| `ApprovedLines(u64)` | Persistent storage entry |
+| `ProviderClaims(Address)` | Persistent storage entry |
+| `PatientClaims(Address)` | Persistent storage entry |
+| `ClaimPayment(u64)` | Persistent storage entry |
+| `PatientPayment(u64)` | Persistent storage entry |
+| `AccessControlId` | Persistent storage entry |
+| `FinancialRecordsId` | Persistent storage entry |
+| `ReconciliationThreshold` | configurable threshold in seconds for unreconciled claims |
+| `InsurerUnreconciledClaims(Address)` | insurer_id -> Vec<u64> of claim_ids |
+| `InsurerRegistryId` | Persistent storage entry |
+
+### `medical-device-tracking`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Regulator` | Persistent storage entry |
+| `DeviceCounter` | Persistent storage entry |
+| `ImplantCounter` | Persistent storage entry |
+| `DmeCounter` | Persistent storage entry |
+| `RecallCounter` | Persistent storage entry |
+| `MaintenanceCounter` | Persistent storage entry |
+| `WarrantyCounter` | Persistent storage entry |
+| `DeviceRecord(u64)` | Persistent storage entry |
+| `ImplantRecord(u64)` | Persistent storage entry |
+| `DmeRecord(u64)` | Persistent storage entry |
+| `RecallInfo(u64)` | Persistent storage entry |
+| `MaintenanceRecord(u64)` | Persistent storage entry |
+| `WarrantyRecord(u64)` | Persistent storage entry |
+| `PatientImplants(Address)` | Persistent storage entry |
+| `DeviceImplants(u64)` | Persistent storage entry |
+| `DeviceRecalls(u64)` | Persistent storage entry |
+| `DeviceWarranties(u64)` | Persistent storage entry |
+| `PerformanceReports(u64)` | Persistent storage entry |
+
+### `mental-health`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `AssessmentCounter` | Persistent storage entry |
+| `PlanCounter` | Persistent storage entry |
+| `HospitalizationCounter` | Persistent storage entry |
+| `ScreeningCounter` | Persistent storage entry |
+| `Assessment(u64)` | Persistent storage entry |
+| `TreatmentPlan(u64)` | Persistent storage entry |
+| `Hospitalization(u64)` | Persistent storage entry |
+| `SafetyPlan(u64)` | Persistent storage entry |
+| `Screening(u64)` | Persistent storage entry |
+| `PrivacyFlag(Address, Symbol)` | Persistent storage entry |
+| `Session(u64, u64)` | Persistent storage entry |
+| `Symptom(Address, Symbol, u64)` | Persistent storage entry |
+| `Outcomes(u64, u64)` | Persistent storage entry |
+| `Consent(Address, Symbol, Address)` | Persistent storage entry |
+
+### `multisig-governance`
+
+- **Retention class:** Ephemeral
+- **Bump / threshold:** 17,280 / 8,640 ledgers
+- **HIPAA note:** Non-clinical counters and caches; no PHI; minimal retention reduces attack surface and storage rent.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Initialized` | Persistent storage entry |
+| `Signers` | Persistent storage entry |
+| `Threshold` | Persistent storage entry |
+| `Ttl` | Persistent storage entry |
+| `QuorumMin` | Persistent storage entry |
+| `Proposal(Symbol)` | Persistent storage entry |
+| `SignerProposal` | Persistent storage entry |
+| `ProposalIds` | Persistent storage entry |
+
+### `nft-badges`
+
+- **Retention class:** Ephemeral
+- **Bump / threshold:** 17,280 / 8,640 ledgers
+- **HIPAA note:** Non-clinical counters and caches; no PHI; minimal retention reduces attack surface and storage rent.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Admin` | Persistent storage entry |
+| `NextId` | Persistent storage entry |
+| `Badge(u64)` | Persistent storage entry |
+| `OwnerBadges(Address)` | Persistent storage entry |
+
+### `nutrition-care-management`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `AssessmentCounter` | Persistent storage entry |
+| `CarePlanCounter` | Persistent storage entry |
+| `DietOrderCounter` | Persistent storage entry |
+| `OutcomeCounter` | Persistent storage entry |
+| `Assessment(u64)` | Persistent storage entry |
+| `ComputedNeeds(u64)` | Persistent storage entry |
+| `CarePlan(u64)` | Persistent storage entry |
+| `DietOrder(u64)` | Persistent storage entry |
+| `Interventions(u64)` | Persistent storage entry |
+| `FoodIntake(Address)` | Persistent storage entry |
+| `WeightHistory(Address)` | Persistent storage entry |
+| `MalnutritionScreening(u64)` | Persistent storage entry |
+| `Supplements(u64)` | Persistent storage entry |
+| `OutcomeEvaluation(u64)` | Persistent storage entry |
+| `PatientAssessments(Address)` | Persistent storage entry |
+| `PatientDietOrders(Address)` | Persistent storage entry |
+| `PlanOutcomes(u64)` | Persistent storage entry |
+| `ClinicalOutcome(u64)` | Persistent storage entry |
+| `PlanVersion(u64)` | Persistent storage entry |
+| `AuthorizedProviders(u64)` | Persistent storage entry |
+
+### `pacs-integration`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `StudyCounter` | Persistent storage entry |
+| `CdCounter` | Persistent storage entry |
+| `Study(u64)` | Persistent storage entry |
+| `SeriesList(u64)` | Persistent storage entry |
+| `Report(u64)` | Persistent storage entry |
+| `AccessList(u64)` | Persistent storage entry |
+| `PatientStudies(Address)` | Persistent storage entry |
+| `ViewLog(u64)` | Persistent storage entry |
+| `ViewerLastViewTs(u64, Address)` | Persistent storage entry |
+| `ViewerViewChainHead(u64, Address)` | Persistent storage entry |
+| `QcReview(u64)` | Persistent storage entry |
+| `AnonymizedStudy(u64, u32)` | Persistent storage entry |
+| `CdRecord(u64)` | Persistent storage entry |
+| `AnonSalt` | Persistent storage entry |
+
+### `patient-registry`
+
+- **Retention class:** Critical + Operational
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** Clinical identifiers use Critical class; administrative indexes use Operational class per patient-registry policy.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Admin` | Persistent storage entry |
+| `Patient(Address)` | Persistent storage entry |
+| `Doctor(Address)` | Persistent storage entry |
+| `Institution(Address)` | Persistent storage entry |
+| `MedicalRecords(Address)` | Persistent storage entry |
+| `AuthorizedDoctors(Address)` | Persistent storage entry |
+| `RegulatoryHold(Address)` | Persistent storage entry |
+| `ConsentVersion` | Persistent storage entry |
+| `ConsentAck(Address)` | Persistent storage entry |
+| `Guardian(Address)` | Persistent storage entry |
+| `PatientList` | Persistent storage entry |
+| `DoctorList` | Persistent storage entry |
+| `LastSnapshotLedger` | Persistent storage entry |
+| `RecordFee` | Persistent storage entry |
+| `Treasury` | Persistent storage entry |
+| `FeeToken` | Persistent storage entry |
+| `TotalPatients` | Persistent storage entry |
+| `TotalRecordsCreated` | Persistent storage entry |
+| `TotalProviders` | Persistent storage entry |
+| `TotalAccessGrants` | Persistent storage entry |
+| `ShareNonce(Address)` | Persistent storage entry |
+| `ExportNonce(Address)` | Persistent storage entry |
+| `ShareLink(BytesN<32>)` | Persistent storage entry |
+| `Deregistered(Address)` | Persistent storage entry |
+| `Frozen` | Persistent storage entry |
+| `RecordCounter` | Persistent storage entry |
+| `PatientRecordIds(Address)` | Persistent storage entry |
+| `MedicalRecord(u64)` | Persistent storage entry |
+| `FieldAccess(Address, Address, u64)` | Persistent storage entry |
+| `GlobalTypeIndex(Symbol)` | Persistent storage entry |
+| `DeletedRecord(u64)` | Persistent storage entry |
+| `ArchivedRecord(u64)` | Persistent storage entry |
+| `MerkleRoot(Address)` | Persistent storage entry |
+| `ProviderRegistry` | Persistent storage entry |
+
+### `patient-vitals`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `VitalsHistory(Address)` | map to Vec<VitalReading> |
+| `MonitoringParams(Address, Symbol)` | map to MonitoringParameters |
+| `DeviceReg(Address, String)` | map to DeviceRegistration |
+| `VitalsAlerts(Address, Symbol)` | map to Vec<VitalAlert> |
+| `RawWindow(Address, u64)` | Persistent storage entry |
+| `AggWindow(Address, u64)` | Persistent storage entry |
+| `LatestRawWindow(Address)` | Persistent storage entry |
+| `LastAlertTime(Address, Symbol)` | Persistent storage entry |
+
+### `prenatal-pediatric`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Pregnancy(u64)` | Persistent storage entry |
+| `PrenatalVisit(u64)` | Persistent storage entry |
+| `PrenatalScreening(u64)` | Persistent storage entry |
+| `Ultrasound(u64)` | Persistent storage entry |
+| `Labor(u64)` | Persistent storage entry |
+| `Delivery(u64)` | Persistent storage entry |
+| `Newborn(Address)` | Persistent storage entry |
+| `NewbornScreening(u64)` | Persistent storage entry |
+| `Growth(u64)` | Persistent storage entry |
+| `GrowthByAge(Address, u32)` | Persistent storage entry |
+| `Milestone(Address, u32)` | Persistent storage entry |
+| `WellChildVisit(Address, u64)` | Persistent storage entry |
+
+### `prescription-management`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Medication(String)` | Persistent storage entry |
+| `MedicationCatalog` | Persistent storage entry |
+| `InteractionCounter` | Persistent storage entry |
+| `InteractionById(u64)` | Persistent storage entry |
+| `InteractionPair(String, String)` | Persistent storage entry |
+| `InteractionCatalog` | Persistent storage entry |
+| `PatientAllergies(Address)` | Persistent storage entry |
+| `PatientConditions(Address)` | Persistent storage entry |
+| `MedicationContraindications(String)` | Persistent storage entry |
+| `InteractionOverride(u64, Address)` | Persistent storage entry |
+| `RegistryAdmin` | Persistent storage entry |
+| `RegistryWriter(Address)` | Persistent storage entry |
+| `RegistryProposalCounter` | Persistent storage entry |
+| `RegistryProposal(u64)` | Persistent storage entry |
+| `SnapshotCounter` | Persistent storage entry |
+| `CatalogSnapshot(u64)` | Persistent storage entry |
+| `ProviderRegistry` | Persistent storage entry |
+| `AllergyRegistry` | Persistent storage entry |
+| `Admin` | Persistent storage entry |
+| `AllergyStrictMode` | Persistent storage entry |
+| `RecallCounter` | Persistent storage entry |
+| `RecallRecord(u64)` | Persistent storage entry |
+| `PrescriptionRecall(u64)` | Persistent storage entry |
+| `PatientPrescriptions(Address)` | Persistent storage entry |
+
+### `prior-authorization`
+
+- **Retention class:** Operational
+- **Bump / threshold:** 120,960 / 60,480 ledgers
+- **HIPAA note:** Workflow, billing, and audit-adjacent records: retain through adjudication cycles; shorter rolling window limits stale operational PHI exposure.
+
+| Storage key | Notes |
+|-------------|-------|
+| `AuthCounter` | Persistent storage entry |
+| `AppealCounter` | Persistent storage entry |
+| `ReviewCounter` | Persistent storage entry |
+| `AuthRequest(u64)` | Persistent storage entry |
+| `Documents(u64)` | Persistent storage entry |
+| `PeerToPeer(u64)` | Persistent storage entry |
+| `Appeals(u64)` | Persistent storage entry |
+| `Appeal(u64)` | Persistent storage entry |
+| `ReviewHistory(u64)` | Persistent storage entry |
+| `Review(u64)` | Persistent storage entry |
+| `Extension(u64)` | Persistent storage entry |
+| `UsageRecords(u64)` | Persistent storage entry |
+| `ProviderAuths(Address)` | Persistent storage entry |
+| `PatientAuths(Address)` | Persistent storage entry |
+| `Reviewer(Address)` | Persistent storage entry |
+| `InsurerReviewers(Address)` | Persistent storage entry |
+| `SLAConfig(Symbol)` | Persistent storage entry |
+| `OverdueAuths` | Persistent storage entry |
+| `InsurerRegistryId` | Persistent storage entry |
+
+### `provider-registry`
+
+- **Retention class:** Operational
+- **Bump / threshold:** 120,960 / 60,480 ledgers
+- **HIPAA note:** Workflow, billing, and audit-adjacent records: retain through adjudication cycles; shorter rolling window limits stale operational PHI exposure.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Initialized` | Persistent storage entry |
+| `Admin` | Persistent storage entry |
+| `Provider(Address)` | Persistent storage entry |
+| `Record(String)` | Persistent storage entry |
+| `ProviderRecords(Address)` | Persistent storage entry |
+| `ProviderRecordCount(Address)` | Persistent storage entry |
+| `RateLimitConfig` | Persistent storage entry |
+| `ProviderRate(Address)` | Persistent storage entry |
+| `ProviderReputation(Address)` | Persistent storage entry |
+| `ProviderRatingByPatient(Address, Address)` | Persistent storage entry |
+| `PendingAdmin` | Persistent storage entry |
+| `RotationExpiry` | Persistent storage entry |
+
+### `referral`
+
+- **Retention class:** Operational
+- **Bump / threshold:** 120,960 / 60,480 ledgers
+- **HIPAA note:** Workflow, billing, and audit-adjacent records: retain through adjudication cycles; shorter rolling window limits stale operational PHI exposure.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Referral(u64)` | Persistent storage entry |
+| `ReferralCount` | Persistent storage entry |
+
+### `rehabilitation-services`
+
+- **Retention class:** Critical
+- **Bump / threshold:** 535,680 / 518,400 ledgers
+- **HIPAA note:** PHI/ePHI and clinical artifacts require rolling retention to satisfy HIPAA minimum necessary and 6-year record-keeping expectations without silent ledger expiry during active treatment.
+
+| Storage key | Notes |
+|-------------|-------|
+| `EvaluationCounter` | Persistent storage entry |
+| `Evaluation(u64)` | Persistent storage entry |
+| `ROMAssessments(u64)` | Persistent storage entry |
+| `StrengthAssessments(u64)` | Persistent storage entry |
+| `BalanceMobilityAssessments(u64)` | Persistent storage entry |
+| `TreatmentPlanCounter` | Persistent storage entry |
+| `TreatmentPlan(u64)` | Persistent storage entry |
+| `TherapySessions(u64)` | Persistent storage entry |
+| `PainMeasurements(u64)` | Persistent storage entry |
+| `FunctionalOutcomes(u64)` | Persistent storage entry |
+| `AuthorizationCounter` | Persistent storage entry |
+| `Authorization(u64)` | Persistent storage entry |
+| `ProgressNotes(u64)` | Persistent storage entry |
+| `Discharge(u64)` | Persistent storage entry |
+| `GoalCounter` | Persistent storage entry |
+| `MeasurableGoal(u64)` | Persistent storage entry |
+| `GoalProgressList(u64)` | Persistent storage entry |
+
+### `scholarship-fund`
+
+- **Retention class:** Ephemeral
+- **Bump / threshold:** 17,280 / 8,640 ledgers
+- **HIPAA note:** Non-clinical counters and caches; no PHI; minimal retention reduces attack surface and storage rent.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Admin,PoolBalance,Deposit(Address)` | Persistent storage entry |
+
+### `telemedicine`
+
+- **Retention class:** Operational
+- **Bump / threshold:** 120,960 / 60,480 ledgers
+- **HIPAA note:** Workflow, billing, and audit-adjacent records: retain through adjudication cycles; shorter rolling window limits stale operational PHI exposure.
+
+| Storage key | Notes |
+|-------------|-------|
+| `VirtualVisit(u64)` | Persistent storage entry |
+| `VisitCount` | Persistent storage entry |
+| `SessionNonce` | Persistent storage entry |
+| `Session(u64)` | Persistent storage entry |
+| `LicenseRegistry(Address, String)` | Persistent storage entry |
+| `JurisdictionPolicy(String)` | Persistent storage entry |
+
+### `upgrade-governance`
+
+- **Retention class:** Ephemeral
+- **Bump / threshold:** 17,280 / 8,640 ledgers
+- **HIPAA note:** Non-clinical counters and caches; no PHI; minimal retention reduces attack surface and storage rent.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Initialized` | Persistent storage entry |
+| `Signers` | Persistent storage entry |
+| `Threshold` | Persistent storage entry |
+| `NextId` | Persistent storage entry |
+| `Proposal(u64)` | Persistent storage entry |
+| `ApprovedArtifactMetadata(BytesN<32>)` | Persistent storage entry |
+| `SignerProposal` | Persistent storage entry |
+| `SchemaVersion` | Persistent storage entry |
+
+### `zk-eligibility`
+
+- **Retention class:** Ephemeral
+- **Bump / threshold:** 17,280 / 8,640 ledgers
+- **HIPAA note:** Non-clinical counters and caches; no PHI; minimal retention reduces attack surface and storage rent.
+
+| Storage key | Notes |
+|-------------|-------|
+| `Initialized` | Persistent storage entry |
+| `Admin` | Persistent storage entry |
+| `VerifierKey(u32)` | Persistent storage entry |
+| `Nullifier(BytesN<32>)` | Persistent storage entry |
+| `Eligibility(Address)` | Persistent storage entry |
+| `PendingAdmin` | Persistent storage entry |
+| `RotationExpiry` | Persistent storage entry |
+
+### `zk-eligibility-verifier`
+
+- **Retention class:** Operational
+- **Bump / threshold:** 120,960 / 60,480 ledgers
+- **HIPAA note:** Workflow, billing, and audit-adjacent records: retain through adjudication cycles; shorter rolling window limits stale operational PHI exposure.
+
+| Storage key | Notes |
+|-------------|-------|
+| `ZkEligibilityContract` | Persistent storage entry |
+
+
+## Compliance Checklist
+
+- [ ] Critical PHI contracts use `ttl-config::critical` helpers
+- [ ] Operational workflow contracts use `ttl-config::operational` helpers
+- [ ] Ephemeral counters use `ttl-config::ephemeral` helpers
+- [ ] Every new persistent key is listed in this document
+- [ ] Retention class matches the `ttl-config` constants in code
+
+## References
+
+- [TTL_POLICY.md](TTL_POLICY.md)
+- [contracts/ttl-config/src/lib.rs](contracts/ttl-config/src/lib.rs)

--- a/contracts/insurer-registry/src/lib.rs
+++ b/contracts/insurer-registry/src/lib.rs
@@ -21,6 +21,20 @@ pub enum Error {
     NoReviewersFound = 5,
     NotAuthorized = 6,
     InvalidAddress = 7,
+    PlanNotFound = 8,
+}
+
+/// Structured coverage plan with service-code allowlist used by downstream
+/// contracts (e.g. prior-authorization) to verify benefit eligibility.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CoveragePlan {
+    pub plan_id: u64,
+    pub plan_name: String,
+    pub service_codes: Vec<String>,
+    pub is_active: bool,
+    pub effective_from: u64,
+    pub effective_until: Option<u64>,
 }
 
 #[contracttype]
@@ -49,6 +63,8 @@ pub struct CredentialAnchor {
 pub enum DataKey {
     Insurer(Address),
     ClaimsReviewers(Address),
+    /// insurer_wallet -> Vec<CoveragePlan>
+    CoveragePlans(Address),
 }
 
 #[contract]
@@ -223,6 +239,34 @@ impl InsurerRegistry {
         } else {
             false
         }
+    }
+
+    /// Replace the full coverage-plan catalog for an insurer.
+    pub fn set_coverage_plans(
+        env: Env,
+        insurer_wallet: Address,
+        plans: Vec<CoveragePlan>,
+    ) -> Result<(), Error> {
+        validate_nonzero_address(&insurer_wallet).map_err(|_| Error::InvalidAddress)?;
+        insurer_wallet.require_auth();
+
+        let insurer_key = DataKey::Insurer(insurer_wallet.clone());
+        if !env.storage().persistent().has(&insurer_key) {
+            return Err(Error::InsurerNotFound);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::CoveragePlans(insurer_wallet), &plans);
+        Ok(())
+    }
+
+    /// Return all coverage plans registered for an insurer.
+    pub fn get_coverage_plans(env: Env, insurer_wallet: Address) -> Vec<CoveragePlan> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CoveragePlans(insurer_wallet))
+            .unwrap_or_else(|| Vec::new(&env))
     }
 
     fn assert_active_insurer(env: &Env, wallet: &Address) -> Result<(), Error> {

--- a/contracts/insurer-registry/src/test.rs
+++ b/contracts/insurer-registry/src/test.rs
@@ -355,3 +355,31 @@ fn test_full_workflow() {
     assert_eq!(reviewers.len(), 1);
     assert_eq!(reviewers.get(0).unwrap(), reviewer2);
 }
+
+#[test]
+fn test_coverage_plans_round_trip() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, InsurerRegistry);
+    let client = InsurerRegistryClient::new(&env, &contract_id);
+
+    let insurer_wallet = Address::generate(&env);
+    env.mock_all_auths();
+    register_insurer_with_anchor(&env, &client, &insurer_wallet);
+
+    let mut service_codes = soroban_sdk::Vec::new(&env);
+    service_codes.push_back(String::from_str(&env, "CPT99213"));
+    let mut plans = soroban_sdk::Vec::new(&env);
+    plans.push_back(CoveragePlan {
+        plan_id: 1,
+        plan_name: String::from_str(&env, "PPO Gold"),
+        service_codes,
+        is_active: true,
+        effective_from: 0,
+        effective_until: None,
+    });
+
+    client.set_coverage_plans(&insurer_wallet, &plans);
+    let loaded = client.get_coverage_plans(&insurer_wallet);
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded.get(0).unwrap().plan_name, String::from_str(&env, "PPO Gold"));
+}

--- a/contracts/medical-claims/Cargo.toml
+++ b/contracts/medical-claims/Cargo.toml
@@ -14,3 +14,4 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+insurer-registry = { path = "../insurer-registry" }

--- a/contracts/medical-claims/src/lib.rs
+++ b/contracts/medical-claims/src/lib.rs
@@ -29,6 +29,12 @@ pub trait AccessControlInterface {
     );
 }
 
+// ── Cross-contract interface for insurer credential validation (#527) ─────────
+#[contractclient(name = "InsurerRegistryClient")]
+pub trait InsurerRegistryInterface {
+    fn is_insurer_active(env: Env, wallet: Address) -> bool;
+}
+
 #[contract]
 pub struct MedicalClaimsSystem;
 
@@ -46,12 +52,16 @@ impl MedicalClaimsSystem {
     ///
     /// `reconciliation_threshold` is the time in seconds after which claims
     /// are considered unreconciled if not matched with payments.
+    ///
+    /// `insurer_registry_id` is the address of the deployed insurer-registry
+    /// contract used to verify insurer credentials before claim submission (#527).
     pub fn initialize(
         env: Env,
         admin: Address,
         access_control_id: Address,
         financial_records_id: Address,
         reconciliation_threshold: u64,
+        insurer_registry_id: Address,
     ) -> Result<(), Error> {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(Error::AlreadyInitialized);
@@ -67,6 +77,9 @@ impl MedicalClaimsSystem {
         env.storage()
             .instance()
             .set(&DataKey::ReconciliationThreshold, &reconciliation_threshold);
+        env.storage()
+            .instance()
+            .set(&DataKey::InsurerRegistryId, &insurer_registry_id);
         Ok(())
     }
 
@@ -115,6 +128,17 @@ impl MedicalClaimsSystem {
     ) -> Result<u64, Error> {
         provider_id.require_auth();
         Self::require_insurer(&env, &insurer_id)?;
+
+        let insurer_registry_id: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsurerRegistryId)
+            .ok_or(Error::NotInitialized)?;
+        let registry = InsurerRegistryClient::new(&env, &insurer_registry_id);
+        if !registry.is_insurer_active(&insurer_id) {
+            return Err(Error::InsurerNotActive);
+        }
+
         validate_policy_metadata(&policy).map_err(|_| Error::InvalidPolicyMetadata)?;
 
         // #300: Verify that the patient has granted consent to this provider

--- a/contracts/medical-claims/src/test.rs
+++ b/contracts/medical-claims/src/test.rs
@@ -2,8 +2,9 @@
 #![allow(deprecated)]
 
 use super::*;
+use insurer_registry::{InsurerRegistry, InsurerRegistryClient};
 use shared::privacy::PolicyMetadata;
-use soroban_sdk::{contract, contractimpl, testutils::Address as _, BytesN, Env, String, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, testutils::{Address as _, Ledger}, BytesN, Env, String, Symbol, Vec};
 
 // ── Mock access-control contract for tests (#300) ────────────────────────────
 //
@@ -49,6 +50,28 @@ fn build_services(env: &Env, amount: i128) -> Vec<ServiceLine> {
     services
 }
 
+fn dummy_hash(env: &Env, byte: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[byte; 32])
+}
+
+fn register_active_insurer(env: &Env, insurer: &Address) -> Address {
+    let ir_id = env.register_contract(None, InsurerRegistry);
+    let ir_client = InsurerRegistryClient::new(env, &ir_id);
+    let issuer = Address::generate(env);
+    ir_client.register_insurer(
+        insurer,
+        &String::from_str(env, "Claims Insurer"),
+        &String::from_str(env, "LIC-CLAIMS"),
+        &String::from_str(env, "metadata"),
+        &dummy_hash(env, 1),
+        &issuer,
+        &dummy_hash(env, 2),
+        &4_100_000_000_u64,
+        &dummy_hash(env, 3),
+    );
+    ir_id
+}
+
 fn setup(
     env: &Env,
 ) -> (
@@ -69,7 +92,8 @@ fn setup(
     let provider = Address::generate(env);
     let patient = Address::generate(env);
     let insurer = Address::generate(env);
-    client.initialize(&admin, &ac_id, &fr_id, &86400); // 24 hour threshold
+    let ir_id = register_active_insurer(env, &insurer);
+    client.initialize(&admin, &ac_id, &fr_id, &86400, &ir_id);
     client.register_insurer(&admin, &insurer);
     (client, admin, provider, patient, insurer)
 }
@@ -318,7 +342,8 @@ fn test_double_initialize_fails() {
     // provided — the AlreadyInitialized guard is checked first.
     let dummy_ac = Address::generate(&env);
     let dummy_fr = Address::generate(&env);
-    let result = client.try_initialize(&admin, &dummy_ac, &dummy_fr, &86400);
+    let dummy_ir = Address::generate(&env);
+    let result = client.try_initialize(&admin, &dummy_ac, &dummy_fr, &86400, &dummy_ir);
     assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
 }
 
@@ -661,4 +686,78 @@ fn test_unauthorized_cannot_mark_disputed() {
     let unauthorized = Address::generate(&env);
     let result = client.try_mark_claim_disputed(&claim_id, &unauthorized);
     assert_eq!(result, Err(Ok(Error::NotAuthorized)));
+}
+
+// -----------------------------------------------------------------------
+// insurer-registry integration (#527)
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_integration_active_insurer_claim_submission_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, provider, patient, insurer) = setup(&env);
+
+    let claim_id = client.submit_claim(
+        &provider,
+        &patient,
+        &insurer,
+        &1,
+        &1000,
+        &make_services(&env),
+        &Vec::new(&env),
+        &BytesN::from_array(&env, &[0; 32]),
+        &policy(&env),
+        &15000,
+    );
+    assert_eq!(claim_id, 1);
+}
+
+#[test]
+fn test_integration_expired_insurer_returns_insurer_not_active() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let ac_id = env.register(MockAccessControl, ());
+    let fr_id = Address::generate(&env);
+    let contract_id = env.register_contract(None, MedicalClaimsSystem);
+    let client = MedicalClaimsSystemClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+    let insurer = Address::generate(&env);
+
+    let ir_id = env.register_contract(None, InsurerRegistry);
+    let ir_client = InsurerRegistryClient::new(&env, &ir_id);
+    let issuer = Address::generate(&env);
+    env.ledger().with_mut(|li| li.timestamp = 100);
+    ir_client.register_insurer(
+        &insurer,
+        &String::from_str(&env, "Expired Insurer"),
+        &String::from_str(&env, "LIC-EXP"),
+        &String::from_str(&env, "metadata"),
+        &dummy_hash(&env, 1),
+        &issuer,
+        &dummy_hash(&env, 2),
+        &150_u64,
+        &dummy_hash(&env, 3),
+    );
+
+    client.initialize(&admin, &ac_id, &fr_id, &86400, &ir_id);
+    client.register_insurer(&admin, &insurer);
+    env.ledger().with_mut(|li| li.timestamp = 200);
+
+    let result = client.try_submit_claim(
+        &provider,
+        &patient,
+        &insurer,
+        &1,
+        &1000,
+        &make_services(&env),
+        &Vec::new(&env),
+        &BytesN::from_array(&env, &[0; 32]),
+        &policy(&env),
+        &15000,
+    );
+    assert_eq!(result, Err(Ok(Error::InsurerNotActive)));
 }

--- a/contracts/medical-claims/src/types.rs
+++ b/contracts/medical-claims/src/types.rs
@@ -31,6 +31,8 @@ pub enum Error {
     PaymentNotFound = 12,
     PaymentAlreadyReconciled = 13,
     InvalidReconciliationAmount = 14,
+    /// #527: Insurer credential is expired or revoked in insurer-registry.
+    InsurerNotActive = 15,
 }
 
 #[contracttype]
@@ -134,4 +136,6 @@ pub enum DataKey {
     FinancialRecordsId,
     ReconciliationThreshold, // configurable threshold in seconds for unreconciled claims
     InsurerUnreconciledClaims(Address), // insurer_id -> Vec<u64> of claim_ids
+    /// #527: Address of the deployed insurer-registry contract.
+    InsurerRegistryId,
 }

--- a/contracts/prior-authorization/Cargo.toml
+++ b/contracts/prior-authorization/Cargo.toml
@@ -14,3 +14,4 @@ shared = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+insurer-registry = { path = "../insurer-registry" }

--- a/contracts/prior-authorization/src/lib.rs
+++ b/contracts/prior-authorization/src/lib.rs
@@ -10,10 +10,27 @@ mod test;
 #[cfg(test)]
 mod test_enhanced;
 
-use soroban_sdk::{contract, contractimpl, xdr::ToXdr, Address, Bytes, BytesN, Env, String, Symbol, Vec};
+use soroban_sdk::{contract, contractclient, contractimpl, xdr::ToXdr, Address, Bytes, BytesN, Env, String, Symbol, Vec};
 use storage::*;
 use types::*;
 use shared::temporal;
+
+/// Cross-contract interface for insurer-registry coverage validation (#526).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CoveragePlan {
+    pub plan_id: u64,
+    pub plan_name: String,
+    pub service_codes: Vec<String>,
+    pub is_active: bool,
+    pub effective_from: u64,
+    pub effective_until: Option<u64>,
+}
+
+#[contractclient(name = "InsurerRegistryClient")]
+pub trait InsurerRegistryInterface {
+    fn get_coverage_plans(env: Env, insurer_wallet: Address) -> Vec<CoveragePlan>;
+}
 
 /// Shorter deadline (hours) assigned to escalated requests.
 const ESCALATION_DEADLINE_HOURS: u64 = 4;
@@ -59,16 +76,84 @@ fn compute_appeal_chain_hash(
     env.crypto().sha256(&data).into()
 }
 
+fn service_codes_covered(
+    env: &Env,
+    insurer_registry_id: &Address,
+    insurer_wallet: &Address,
+    service_codes: &Vec<String>,
+) -> bool {
+    let registry = InsurerRegistryClient::new(env, insurer_registry_id);
+    let plans = registry.get_coverage_plans(insurer_wallet);
+    let now = env.ledger().timestamp();
+
+    for i in 0..service_codes.len() {
+        let code = match service_codes.get(i) {
+            Some(c) => c,
+            None => return false,
+        };
+        let mut covered = false;
+
+        for j in 0..plans.len() {
+            let plan = match plans.get(j) {
+                Some(p) => p,
+                None => continue,
+            };
+            if !plan.is_active || plan.effective_from > now {
+                continue;
+            }
+            if let Some(until) = plan.effective_until {
+                if now > until {
+                    continue;
+                }
+            }
+            for k in 0..plan.service_codes.len() {
+                if let Some(plan_code) = plan.service_codes.get(k) {
+                    if plan_code == code {
+                        covered = true;
+                        break;
+                    }
+                }
+            }
+            if covered {
+                break;
+            }
+        }
+
+        if !covered {
+            return false;
+        }
+    }
+
+    true
+}
+
 #[contract]
 pub struct PriorAuthorizationContract;
 
 #[contractimpl]
 impl PriorAuthorizationContract {
+    /// One-time setup: store the insurer-registry contract address used for
+    /// coverage-plan validation during authorization submission (#526).
+    pub fn initialize(env: Env, insurer_registry_id: Address) -> Result<(), Error> {
+        if env
+            .storage()
+            .instance()
+            .has(&DataKey::InsurerRegistryId)
+        {
+            return Err(Error::AlreadyInitialized);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::InsurerRegistryId, &insurer_registry_id);
+        Ok(())
+    }
+
     /// Submit a new prior authorization request.
     pub fn submit_prior_authorization(
         env: Env,
         provider_id: Address,
         patient_id: Address,
+        insurer_wallet: Address,
         policy_id: u64,
         authorization_type: Symbol,
         requested_service: String,
@@ -78,6 +163,21 @@ impl PriorAuthorizationContract {
         urgency: Symbol,
     ) -> Result<u64, Error> {
         provider_id.require_auth();
+
+        let insurer_registry_id: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsurerRegistryId)
+            .ok_or(Error::NotInitialized)?;
+
+        if !service_codes_covered(
+            &env,
+            &insurer_registry_id,
+            &insurer_wallet,
+            &service_codes,
+        ) {
+            return Err(Error::ServiceNotCovered);
+        }
 
         let auth_request_id = next_auth_id(&env);
 

--- a/contracts/prior-authorization/src/test.rs
+++ b/contracts/prior-authorization/src/test.rs
@@ -1,23 +1,67 @@
 #![cfg(test)]
 
 use super::*;
+use insurer_registry::{CoveragePlan, InsurerRegistry, InsurerRegistryClient};
 use soroban_sdk::{testutils::{Address as _, Ledger}, Address, BytesN, Env, String, Symbol, Vec};
 
 // -----------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------
 
-fn setup() -> (Env, Address, Address) {
+fn dummy_hash(env: &Env, byte: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[byte; 32])
+}
+
+fn setup_insurer_registry(env: &Env, insurer: &Address) -> Address {
+    let ir_id = env.register_contract(None, InsurerRegistry);
+    let ir_client = InsurerRegistryClient::new(env, &ir_id);
+    let issuer = Address::generate(env);
+    ir_client.register_insurer(
+        insurer,
+        &String::from_str(env, "Test Insurer"),
+        &String::from_str(env, "LIC-001"),
+        &String::from_str(env, "metadata"),
+        &dummy_hash(env, 1),
+        &issuer,
+        &dummy_hash(env, 2),
+        &4_100_000_000_u64,
+        &dummy_hash(env, 3),
+    );
+
+    let mut service_codes = Vec::new(env);
+    service_codes.push_back(String::from_str(env, "CPT99213"));
+    let mut plans = Vec::new(env);
+    plans.push_back(CoveragePlan {
+        plan_id: 1,
+        plan_name: String::from_str(env, "PPO Gold"),
+        service_codes,
+        is_active: true,
+        effective_from: 0,
+        effective_until: None,
+    });
+    ir_client.set_coverage_plans(insurer, &plans);
+    ir_id
+}
+
+fn setup() -> (Env, Address, Address, Address) {
     let env = Env::default();
     env.mock_all_auths();
     let provider = Address::generate(&env);
     let patient = Address::generate(&env);
-    (env, provider, patient)
+    let insurer = Address::generate(&env);
+    (env, provider, patient, insurer)
 }
 
-fn register_contract(env: &Env) -> PriorAuthorizationContractClient {
+fn setup_client(env: &Env, insurer: &Address) -> PriorAuthorizationContractClient {
+    let ir_id = setup_insurer_registry(env, insurer);
+    register_contract(env, &ir_id)
+}
+
+fn register_contract(env: &Env, insurer_registry_id: &Address) -> PriorAuthorizationContractClient {
     let contract_id = env.register(PriorAuthorizationContract, ());
-    PriorAuthorizationContractClient::new(env, &contract_id)
+    let client = PriorAuthorizationContractClient::new(env, &contract_id);
+    client.initialize(insurer_registry_id);
+    client
 }
 
 fn submit(
@@ -25,6 +69,7 @@ fn submit(
     client: &PriorAuthorizationContractClient,
     provider: &Address,
     patient: &Address,
+    insurer: &Address,
 ) -> u64 {
     let mut service_codes = Vec::new(env);
     service_codes.push_back(String::from_str(env, "CPT99213"));
@@ -37,6 +82,7 @@ fn submit(
     client.submit_prior_authorization(
         provider,
         patient,
+        insurer,
         &1001u64,
         &Symbol::new(env, "medication"),
         &String::from_str(env, "Insulin Glargine"),
@@ -109,27 +155,27 @@ fn deny(
 
 #[test]
 fn test_submit_success() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     assert_eq!(id, 1);
 }
 
 #[test]
 fn test_submit_increments_ids() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id1 = submit(&env, &client, &provider, &patient);
-    let id2 = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id1 = submit(&env, &client, &provider, &patient, &insurer);
+    let id2 = submit(&env, &client, &provider, &patient, &insurer);
     assert_eq!(id1, 1);
     assert_eq!(id2, 2);
 }
 
 #[test]
 fn test_submit_initial_status_is_submitted() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
 
     let info = client.get_authorization_status(&id, &provider);
     assert!(matches!(info.status, AuthStatus::Submitted));
@@ -143,9 +189,9 @@ fn test_submit_initial_status_is_submitted() {
 
 #[test]
 fn test_attach_document_success() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
 
     let hash = BytesN::from_array(&env, &[2u8; 32]);
     client
@@ -160,9 +206,9 @@ fn test_attach_document_success() {
 
 #[test]
 fn test_attach_document_wrong_provider_fails() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
 
     let other = Address::generate(&env);
     let hash = BytesN::from_array(&env, &[3u8; 32]);
@@ -178,8 +224,8 @@ fn test_attach_document_wrong_provider_fails() {
 
 #[test]
 fn test_attach_document_not_found_fails() {
-    let (env, provider, _) = setup();
-    let client = register_contract(&env);
+    let (env, provider, _, insurer) = setup();
+    let client = setup_client(&env, &insurer);
     let hash = BytesN::from_array(&env, &[4u8; 32]);
 
     let result = client.try_attach_supporting_documentation(
@@ -197,9 +243,9 @@ fn test_attach_document_not_found_fails() {
 
 #[test]
 fn test_review_approve_success() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     approve(&env, &client, id, &reviewer);
 
@@ -213,9 +259,9 @@ fn test_review_approve_success() {
 
 #[test]
 fn test_review_deny_success() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     deny(&env, &client, id, &reviewer);
 
@@ -225,9 +271,9 @@ fn test_review_deny_success() {
 
 #[test]
 fn test_review_more_info_needed() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     let insurer = Address::generate(&env);
     register_test_reviewer(&env, &client, &insurer, &reviewer);
@@ -248,9 +294,9 @@ fn test_review_more_info_needed() {
 
 #[test]
 fn test_review_invalid_decision_fails() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
 
     let result = client.try_review_authorization(
@@ -267,9 +313,9 @@ fn test_review_invalid_decision_fails() {
 
 #[test]
 fn test_review_already_approved_fails() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     approve(&env, &client, id, &reviewer);
 
@@ -291,9 +337,9 @@ fn test_review_already_approved_fails() {
 
 #[test]
 fn test_request_p2p_success() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
 
     let mut times = Vec::new(&env);
     times.push_back(String::from_str(&env, "Mon 9am"));
@@ -308,9 +354,9 @@ fn test_request_p2p_success() {
 
 #[test]
 fn test_request_p2p_twice_fails() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
 
     let mut times = Vec::new(&env);
     times.push_back(String::from_str(&env, "Mon 9am"));
@@ -325,9 +371,9 @@ fn test_request_p2p_twice_fails() {
 
 #[test]
 fn test_schedule_p2p_success() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
 
     let mut times = Vec::new(&env);
     times.push_back(String::from_str(&env, "Tue 2pm"));
@@ -349,9 +395,9 @@ fn test_schedule_p2p_success() {
 
 #[test]
 fn test_p2p_wrong_provider_fails() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
 
     let other = Address::generate(&env);
     let mut times = Vec::new(&env);
@@ -367,9 +413,9 @@ fn test_p2p_wrong_provider_fails() {
 
 #[test]
 fn test_appeal_level_1_success() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     deny(&env, &client, id, &reviewer);
 
@@ -384,11 +430,49 @@ fn test_appeal_level_1_success() {
     assert!(matches!(info.status, AuthStatus::Appealed));
 }
 
+// -----------------------------------------------------------------------
+// insurer-registry integration (#526)
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_integration_covered_service_proceeds() {
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
+    assert_eq!(id, 1);
+}
+
+#[test]
+fn test_integration_uncovered_service_returns_service_not_covered() {
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+
+    let mut service_codes = Vec::new(&env);
+    service_codes.push_back(String::from_str(&env, "CPT99999"));
+    let mut diagnosis_codes = Vec::new(&env);
+    diagnosis_codes.push_back(String::from_str(&env, "E11.9"));
+    let hash = BytesN::from_array(&env, &[1u8; 32]);
+
+    let result = client.try_submit_prior_authorization(
+        &provider,
+        &patient,
+        &insurer,
+        &1001u64,
+        &Symbol::new(&env, "medication"),
+        &String::from_str(&env, "Experimental Therapy"),
+        &service_codes,
+        &diagnosis_codes,
+        &hash,
+        &Symbol::new(&env, "routine"),
+    );
+    assert_eq!(result, Err(Ok(Error::ServiceNotCovered)));
+}
+
 #[test]
 fn test_appeal_level_2_and_3() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     deny(&env, &client, id, &reviewer);
 
@@ -406,9 +490,9 @@ fn test_appeal_level_2_and_3() {
 
 #[test]
 fn test_appeal_exceeds_max_level_fails() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     deny(&env, &client, id, &reviewer);
 
@@ -419,9 +503,9 @@ fn test_appeal_exceeds_max_level_fails() {
 
 #[test]
 fn test_appeal_not_denied_fails() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
 
     let hash = BytesN::from_array(&env, &[9u8; 32]);
     let result = client.try_appeal_denial(&id, &provider, &1u32, &hash, &None);
@@ -430,9 +514,9 @@ fn test_appeal_not_denied_fails() {
 
 #[test]
 fn test_appeal_wrong_provider_fails() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     deny(&env, &client, id, &reviewer);
 
@@ -444,9 +528,9 @@ fn test_appeal_wrong_provider_fails() {
 
 #[test]
 fn test_appeal_with_additional_evidence() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     deny(&env, &client, id, &reviewer);
 
@@ -460,9 +544,9 @@ fn test_appeal_with_additional_evidence() {
 
 #[test]
 fn test_review_history_and_appeal_chain_is_tamper_evident() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     let insurer = Address::generate(&env);
     register_test_reviewer(&env, &client, &insurer, &reviewer);
@@ -504,9 +588,9 @@ fn test_review_history_and_appeal_chain_is_tamper_evident() {
 
 #[test]
 fn test_expedite_success() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
 
     client
         .expedite_authorization(
@@ -520,9 +604,9 @@ fn test_expedite_success() {
 
 #[test]
 fn test_expedite_approved_fails() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     approve(&env, &client, id, &reviewer);
 
@@ -537,9 +621,9 @@ fn test_expedite_approved_fails() {
 
 #[test]
 fn test_expedite_wrong_provider_fails() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
 
     let other = Address::generate(&env);
     let result = client.try_expedite_authorization(
@@ -557,9 +641,9 @@ fn test_expedite_wrong_provider_fails() {
 
 #[test]
 fn test_extend_approved_success() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     approve(&env, &client, id, &reviewer);
 
@@ -575,9 +659,9 @@ fn test_extend_approved_success() {
 
 #[test]
 fn test_extend_not_approved_fails() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
 
     let result = client.try_extend_authorization(
         &id,
@@ -590,9 +674,9 @@ fn test_extend_not_approved_fails() {
 
 #[test]
 fn test_extend_wrong_provider_fails() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     approve(&env, &client, id, &reviewer);
 
@@ -612,9 +696,9 @@ fn test_extend_wrong_provider_fails() {
 
 #[test]
 fn test_track_usage_success() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     approve(&env, &client, id, &reviewer);
 
@@ -628,9 +712,9 @@ fn test_track_usage_success() {
 
 #[test]
 fn test_track_usage_accumulates() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     approve(&env, &client, id, &reviewer);
 
@@ -647,9 +731,9 @@ fn test_track_usage_accumulates() {
 
 #[test]
 fn test_track_usage_exceeds_approved_fails() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     approve(&env, &client, id, &reviewer); // approved_units = 10
 
@@ -659,9 +743,9 @@ fn test_track_usage_exceeds_approved_fails() {
 
 #[test]
 fn test_track_usage_not_approved_fails() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
 
     let result = client.try_track_authorization_usage(&id, &provider, &1u32, &1_500_000u64);
     assert!(result.is_err());
@@ -669,11 +753,11 @@ fn test_track_usage_not_approved_fails() {
 
 #[test]
 fn test_track_usage_expired_fails() {
-    let (env, provider, patient) = setup();
+    let (env, provider, patient, insurer) = setup();
     env.ledger().with_mut(|li| li.timestamp = 1_000_000);
 
-    let client = register_contract(&env);
-    let id = submit(&env, &client, &provider, &patient);
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
     let reviewer = Address::generate(&env);
     let insurer = Address::generate(&env);
     register_test_reviewer(&env, &client, &insurer, &reviewer);
@@ -702,8 +786,8 @@ fn test_track_usage_expired_fails() {
 
 #[test]
 fn test_get_status_not_found_fails() {
-    let (env, provider, _) = setup();
-    let client = register_contract(&env);
+    let (env, provider, _, insurer) = setup();
+    let client = setup_client(&env, &insurer);
     let result = client.try_get_authorization_status(&999, &provider);
     assert!(result.is_err());
 }
@@ -714,11 +798,11 @@ fn test_get_status_not_found_fails() {
 
 #[test]
 fn test_full_workflow_approve_and_use() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
 
     // 1. Submit
-    let id = submit(&env, &client, &provider, &patient);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
 
     // 2. Attach document
     let doc_hash = BytesN::from_array(&env, &[20u8; 32]);
@@ -772,10 +856,10 @@ fn test_full_workflow_approve_and_use() {
 
 #[test]
 fn test_full_workflow_deny_appeal_three_levels() {
-    let (env, provider, patient) = setup();
-    let client = register_contract(&env);
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
 
-    let id = submit(&env, &client, &provider, &patient);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
 
     // Request peer-to-peer
     let mut times = Vec::new(&env);
@@ -818,4 +902,42 @@ fn test_full_workflow_deny_appeal_three_levels() {
 
     let info = client.get_authorization_status(&id, &provider);
     assert!(matches!(info.status, AuthStatus::Appealed));
+}
+
+// -----------------------------------------------------------------------
+// insurer-registry integration (#526)
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_integration_covered_service_proceeds() {
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+    let id = submit(&env, &client, &provider, &patient, &insurer);
+    assert_eq!(id, 1);
+}
+
+#[test]
+fn test_integration_uncovered_service_returns_service_not_covered() {
+    let (env, provider, patient, insurer) = setup();
+    let client = setup_client(&env, &insurer);
+
+    let mut service_codes = Vec::new(&env);
+    service_codes.push_back(String::from_str(&env, "CPT99999"));
+    let mut diagnosis_codes = Vec::new(&env);
+    diagnosis_codes.push_back(String::from_str(&env, "E11.9"));
+    let hash = BytesN::from_array(&env, &[1u8; 32]);
+
+    let result = client.try_submit_prior_authorization(
+        &provider,
+        &patient,
+        &insurer,
+        &1001u64,
+        &Symbol::new(&env, "medication"),
+        &String::from_str(&env, "Experimental Therapy"),
+        &service_codes,
+        &diagnosis_codes,
+        &hash,
+        &Symbol::new(&env, "routine"),
+    );
+    assert_eq!(result, Err(Ok(Error::ServiceNotCovered)));
 }

--- a/contracts/prior-authorization/src/test_enhanced.rs
+++ b/contracts/prior-authorization/src/test_enhanced.rs
@@ -1,10 +1,46 @@
 #![cfg(test)]
 
 use super::*;
+use insurer_registry::{CoveragePlan, InsurerRegistry, InsurerRegistryClient};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     Address, BytesN, Env, String, Symbol, Vec,
 };
+
+fn dummy_hash(env: &Env, byte: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[byte; 32])
+}
+
+fn setup_insurer_registry(env: &Env, insurer: &Address) -> Address {
+    let ir_id = env.register_contract(None, InsurerRegistry);
+    let ir_client = InsurerRegistryClient::new(env, &ir_id);
+    let issuer = Address::generate(env);
+    ir_client.register_insurer(
+        insurer,
+        &String::from_str(env, "Test Insurer"),
+        &String::from_str(env, "LIC-001"),
+        &String::from_str(env, "metadata"),
+        &dummy_hash(env, 1),
+        &issuer,
+        &dummy_hash(env, 2),
+        &4_100_000_000_u64,
+        &dummy_hash(env, 3),
+    );
+
+    let mut service_codes = Vec::new(env);
+    service_codes.push_back(String::from_str(env, "CPT99213"));
+    let mut plans = Vec::new(env);
+    plans.push_back(CoveragePlan {
+        plan_id: 1,
+        plan_name: String::from_str(env, "PPO Gold"),
+        service_codes,
+        is_active: true,
+        effective_from: 0,
+        effective_until: None,
+    });
+    ir_client.set_coverage_plans(insurer, &plans);
+    ir_id
+}
 
 fn setup() -> (Env, Address, Address, Address) {
     let env = Env::default();
@@ -15,9 +51,12 @@ fn setup() -> (Env, Address, Address, Address) {
     (env, insurer, provider, patient)
 }
 
-fn make_contract(env: &Env) -> PriorAuthorizationContractClient {
+fn make_contract(env: &Env, insurer: &Address) -> PriorAuthorizationContractClient {
+    let ir_id = setup_insurer_registry(env, insurer);
     let contract_id = env.register(PriorAuthorizationContract, ());
-    PriorAuthorizationContractClient::new(env, &contract_id)
+    let client = PriorAuthorizationContractClient::new(env, &contract_id);
+    client.initialize(&ir_id);
+    client
 }
 
 fn register_reviewer(
@@ -43,6 +82,7 @@ fn submit_auth(
     client: &PriorAuthorizationContractClient,
     provider: &Address,
     patient: &Address,
+    insurer: &Address,
     urgency: &Symbol,
 ) -> u64 {
     let mut svc = Vec::new(env);
@@ -54,6 +94,7 @@ fn submit_auth(
     client.submit_prior_authorization(
         provider,
         patient,
+        insurer,
         &1001u64,
         &Symbol::new(env, "medication"),
         &String::from_str(env, "Insulin Glargine"),
@@ -69,7 +110,7 @@ fn submit_auth(
 #[test]
 fn test_register_reviewer_success() {
     let (env, insurer, _provider, _patient) = setup();
-    let client = make_contract(&env);
+    let client = make_contract(&env, &insurer);
     let reviewer = Address::generate(&env);
 
     let mut specialties = Vec::new(&env);
@@ -88,7 +129,7 @@ fn test_register_reviewer_success() {
 #[test]
 fn test_register_reviewer_unauthorized_reviewer_fails() {
     let (env, insurer, _provider, _patient) = setup();
-    let client = make_contract(&env);
+    let client = make_contract(&env, &insurer);
     let reviewer = Address::generate(&env);
 
     let mut specialties = Vec::new(&env);
@@ -105,7 +146,14 @@ fn test_register_reviewer_unauthorized_reviewer_fails() {
 
     // Unregistered reviewer should fail
     let unauthorized = Address::generate(&env);
-    let auth_id = submit_auth(&env, &client, &Address::generate(&env), &Address::generate(&env), &Symbol::new(&env, "routine"));
+    let auth_id = submit_auth(
+        &env,
+        &client,
+        &Address::generate(&env),
+        &Address::generate(&env),
+        &insurer,
+        &Symbol::new(&env, "routine"),
+    );
 
     let result = client.try_review_authorization(
         &auth_id,
@@ -124,7 +172,7 @@ fn test_register_reviewer_unauthorized_reviewer_fails() {
 #[test]
 fn test_configure_sla_success() {
     let (env, insurer, _provider, _patient) = setup();
-    let client = make_contract(&env);
+    let client = make_contract(&env, &insurer);
 
     client.configure_sla(
         &insurer,
@@ -141,9 +189,9 @@ fn test_configure_sla_success() {
 #[test]
 fn test_status_on_time_no_breach() {
     let (env, insurer, provider, patient) = setup();
-    let client = make_contract(&env);
+    let client = make_contract(&env, &insurer);
 
-    let auth_id = submit_auth(&env, &client, &provider, &patient, &Symbol::new(&env, "routine"));
+    let auth_id = submit_auth(&env, &client, &provider, &patient, &insurer, &Symbol::new(&env, "routine"));
 
     // Query before deadline — no breach event
     let info = client.get_authorization_status(&auth_id, &provider);
@@ -153,7 +201,7 @@ fn test_status_on_time_no_breach() {
 #[test]
 fn test_status_after_deadline_detects_breach() {
     let (env, insurer, provider, patient) = setup();
-    let client = make_contract(&env);
+    let client = make_contract(&env, &insurer);
 
     // Configure short 1-hour SLA
     client.configure_sla(
@@ -165,7 +213,7 @@ fn test_status_after_deadline_detects_breach() {
         &false,
     );
 
-    let auth_id = submit_auth(&env, &client, &provider, &patient, &Symbol::new(&env, "routine"));
+    let auth_id = submit_auth(&env, &client, &provider, &patient, &insurer, &Symbol::new(&env, "routine"));
 
     // Advance time past the SLA deadline (default 72h for routine = 259200s)
     env.ledger().with_mut(|li| li.timestamp += 300_000);
@@ -180,12 +228,12 @@ fn test_status_after_deadline_detects_breach() {
 #[test]
 fn test_escalate_overdue_authorization() {
     let (env, insurer, provider, patient) = setup();
-    let client = make_contract(&env);
+    let client = make_contract(&env, &insurer);
 
     let reviewer = Address::generate(&env);
     register_reviewer(&env, &client, &insurer, &reviewer);
 
-    let auth_id = submit_auth(&env, &client, &provider, &patient, &Symbol::new(&env, "routine"));
+    let auth_id = submit_auth(&env, &client, &provider, &patient, &insurer, &Symbol::new(&env, "routine"));
 
     // Advance time past the SLA deadline (default 72h = 259200s)
     env.ledger().with_mut(|li| li.timestamp += 300_000);
@@ -205,13 +253,13 @@ fn test_escalate_overdue_authorization() {
 #[test]
 fn test_escalate_no_overdue_returns_zero() {
     let (env, insurer, provider, patient) = setup();
-    let client = make_contract(&env);
+    let client = make_contract(&env, &insurer);
 
     let reviewer = Address::generate(&env);
     register_reviewer(&env, &client, &insurer, &reviewer);
 
     // Submit but don't advance time
-    submit_auth(&env, &client, &provider, &patient, &Symbol::new(&env, "routine"));
+    submit_auth(&env, &client, &provider, &patient, &insurer, &Symbol::new(&env, "routine"));
 
     let count = client.escalate_expired_authorizations(&insurer);
     assert_eq!(count, 0);
@@ -220,12 +268,12 @@ fn test_escalate_no_overdue_returns_zero() {
 #[test]
 fn test_escalate_already_resolved_skipped() {
     let (env, insurer, provider, patient) = setup();
-    let client = make_contract(&env);
+    let client = make_contract(&env, &insurer);
 
     let reviewer = Address::generate(&env);
     register_reviewer(&env, &client, &insurer, &reviewer);
 
-    let auth_id = submit_auth(&env, &client, &provider, &patient, &Symbol::new(&env, "routine"));
+    let auth_id = submit_auth(&env, &client, &provider, &patient, &insurer, &Symbol::new(&env, "routine"));
 
     // Approve the request before the deadline
     client.review_authorization(
@@ -249,7 +297,7 @@ fn test_escalate_already_resolved_skipped() {
 #[test]
 fn test_reviewer_registered_by_insurer() {
     let (env, insurer, _provider, _patient) = setup();
-    let client = make_contract(&env);
+    let client = make_contract(&env, &insurer);
 
     let reviewer1 = Address::generate(&env);
     let reviewer2 = Address::generate(&env);
@@ -260,7 +308,7 @@ fn test_reviewer_registered_by_insurer() {
     // Both reviewers should be able to receive escalated work
     let provider = Address::generate(&env);
     let patient = Address::generate(&env);
-    let auth_id = submit_auth(&env, &client, &provider, &patient, &Symbol::new(&env, "routine"));
+    let auth_id = submit_auth(&env, &client, &provider, &patient, &insurer, &Symbol::new(&env, "routine"));
 
     env.ledger().with_mut(|li| li.timestamp += 300_000);
     client.get_authorization_status(&auth_id, &provider);
@@ -274,12 +322,12 @@ fn test_reviewer_registered_by_insurer() {
 #[test]
 fn test_review_after_sla_deadline_fails() {
     let (env, insurer, provider, patient) = setup();
-    let client = make_contract(&env);
+    let client = make_contract(&env, &insurer);
 
     let reviewer = Address::generate(&env);
     register_reviewer(&env, &client, &insurer, &reviewer);
 
-    let auth_id = submit_auth(&env, &client, &provider, &patient, &Symbol::new(&env, "routine"));
+    let auth_id = submit_auth(&env, &client, &provider, &patient, &insurer, &Symbol::new(&env, "routine"));
 
     // Advance past deadline
     env.ledger().with_mut(|li| li.timestamp += 300_000);

--- a/contracts/prior-authorization/src/types.rs
+++ b/contracts/prior-authorization/src/types.rs
@@ -23,6 +23,9 @@ pub enum Error {
     DeadlineExceeded = 17,
     AutoApprovalFailed = 18,
     ReviewNotFound = 19,
+    ServiceNotCovered = 20,
+    NotInitialized = 21,
+    AlreadyInitialized = 22,
 }
 
 /// Lifecycle status of a prior authorization request.
@@ -251,4 +254,6 @@ pub enum DataKey {
     SLAConfig(Symbol),
     /// SLA tracking: stores Vec<u64> of overdue auth_request_ids.
     OverdueAuths,
+    /// Address of the deployed insurer-registry contract.
+    InsurerRegistryId,
 }


### PR DESCRIPTION
Add DATA_RETENTION.md and CHANGELOG.md so integrators can track TTL classes and API changes, and validate coverage plans and active insurer credentials at submission time.

closes #524 
closes #525 
closes #526 
closes #527 