### PR TITLE
fix: cost-accounting event, role expiry, amendment log, role hierarchy (#499 #490 #485 #488)

### DIFF
--- a/contracts/access-control/src/lib.rs
+++ b/contracts/access-control/src/lib.rs
@@ -272,8 +272,28 @@ impl AccessControl {
         Some(assignment)
     }
 
+    /// Returns `Ok(assignment)` if the role is active, `Err(ConsentExpired)` if the
+    /// role exists but has expired, or `Err(RoleNotFound)` if it was never granted.
+    fn check_role_expiry(
+        env: &Env,
+        address: &Address,
+        role: &Role,
+    ) -> Result<RoleAssignment, ContractError> {
+        let key = DataKey::RoleAssignment(address.clone(), role.clone());
+        let assignment: RoleAssignment = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(ContractError::RoleNotFound)?;
+        let now = env.ledger().timestamp();
+        if assignment.expires_at != 0 && assignment.expires_at <= now {
+            return Err(ContractError::ConsentExpired);
+        }
+        Ok(assignment)
+    }
+
     /// Asserts that `caller` holds `role` (and the role has not expired).
-    /// Returns `InsufficientRole` if the check fails.
+    /// Returns `ConsentExpired` if expired, `InsufficientRole` otherwise.
     fn require_role(
         env: &Env,
         caller: &Address,
@@ -286,10 +306,11 @@ impl AccessControl {
                 return Ok(());
             }
         }
-        if Self::load_active_role(env, caller, role).is_some() {
-            return Ok(());
+        match Self::check_role_expiry(env, caller, role) {
+            Ok(_) => Ok(()),
+            Err(ContractError::ConsentExpired) => Err(ContractError::ConsentExpired),
+            Err(_) => Err(ContractError::InsufficientRole),
         }
-        Err(ContractError::InsufficientRole)
     }
 
     // -------------------------------------------------------------------------
@@ -324,11 +345,14 @@ impl AccessControl {
     // Role management
     // -------------------------------------------------------------------------
 
-    /// Grant `role` to `grantee`. Only an address that itself holds the
-    /// `Admin` role (or is the stored admin address) may call this.
+    /// Grant `role` to `grantee`. The grantor must hold the `Admin` role **or**
+    /// hold a role whose level is strictly higher than the role being granted.
+    ///
+    /// Role hierarchy (higher value = more privileged):
+    ///   Admin(4) > Doctor(3) > Nurse(2) > Patient/Insurer/Auditor/Provider/... (1)
     ///
     /// # Arguments
-    /// * `granter`    - Must hold the `Admin` role.
+    /// * `granter`    - Must hold a role with level > role_level(role).
     /// * `grantee`    - Address receiving the role.
     /// * `role`       - The role to grant.
     /// * `expires_at` - Expiry timestamp; pass `0` for no expiry.
@@ -340,7 +364,14 @@ impl AccessControl {
         expires_at: u64,
     ) -> Result<(), ContractError> {
         granter.require_auth();
-        Self::require_role(&env, &granter, &Role::Admin)?;
+
+        // Determine the granter's highest active role level.
+        let granter_level = Self::highest_role_level(&env, &granter);
+        let required_level = Self::role_level(&role);
+
+        if granter_level <= required_level {
+            return Err(ContractError::InsufficientRole);
+        }
 
         let key = DataKey::RoleAssignment(grantee.clone(), role.clone());
         if env.storage().persistent().has(&key) {
@@ -1213,6 +1244,49 @@ impl AccessControl {
     // Internal helpers
     // -----------------------------------------------------------------------
 
+    /// Numeric role level for hierarchy enforcement (#488).
+    /// Higher value = more privileged.  Admin must be strictly highest.
+    fn role_level(role: &Role) -> u8 {
+        match role {
+            Role::Admin => 4,
+            Role::Doctor => 3,
+            Role::Nurse => 2,
+            _ => 1,
+        }
+    }
+
+    /// Returns the highest active role level held by `address`, or 0 if none.
+    /// The stored admin address is unconditionally treated as level 5.
+    fn highest_role_level(env: &Env, address: &Address) -> u8 {
+        let admin_opt: Option<Address> = env.storage().persistent().get(&DataKey::Admin);
+        if let Some(ref admin) = admin_opt {
+            if address == admin {
+                return 5;
+            }
+        }
+        let roles = [
+            Role::Admin,
+            Role::Doctor,
+            Role::Nurse,
+            Role::Patient,
+            Role::Insurer,
+            Role::Auditor,
+            Role::Provider,
+            Role::PayerReviewer,
+            Role::EmergencyResponder,
+        ];
+        let mut max_level: u8 = 0;
+        for role in &roles {
+            if Self::load_active_role(env, address, role).is_some() {
+                let lvl = Self::role_level(role);
+                if lvl > max_level {
+                    max_level = lvl;
+                }
+            }
+        }
+        max_level
+    }
+
     fn validate_did(did: &Bytes) -> Result<(), ContractError> {
         // Minimum: "did:a:b" = 7 bytes
         if did.len() < 7 {
@@ -1298,7 +1372,7 @@ impl AccessControl {
     /// Grant a role to multiple entities in a single atomic call (#491).
     ///
     /// # Arguments
-    /// * `admin`       - Must hold the `Admin` role.
+    /// * `admin`       - Must hold a role level strictly higher than each role being granted.
     /// * `assignments` - Vec of `RoleBatchEntry`; capped at `BATCH_SIZE_LIMIT`.
     pub fn grant_roles_batch(
         env: Env,
@@ -1306,17 +1380,21 @@ impl AccessControl {
         assignments: Vec<RoleBatchEntry>,
     ) -> Result<(), ContractError> {
         admin.require_auth();
-        Self::require_role(&env, &admin, &Role::Admin)?;
 
         if assignments.len() > BATCH_SIZE_LIMIT {
             return Err(ContractError::BatchTooLarge);
         }
 
+        let granter_level = Self::highest_role_level(&env, &admin);
         let now = env.ledger().timestamp();
 
         // Validate all entries before writing any (atomicity guarantee).
         for i in 0..assignments.len() {
             let entry = assignments.get(i).unwrap();
+            // Hierarchy check
+            if granter_level <= Self::role_level(&entry.role) {
+                return Err(ContractError::InsufficientRole);
+            }
             let key = DataKey::RoleAssignment(entry.entity.clone(), entry.role.clone());
             if env.storage().persistent().has(&key) {
                 if Self::load_active_role(&env, &entry.entity, &entry.role).is_some() {

--- a/contracts/clinical-trial/src/lib.rs
+++ b/contracts/clinical-trial/src/lib.rs
@@ -74,6 +74,13 @@ pub struct TrialPhaseAdvanced {
 }
 
 #[contractevent]
+pub struct ProtocolAmendmentRecorded {
+    pub trial_record_id: u64,
+    pub new_hash: BytesN<32>,
+    pub amended_by: Address,
+}
+
+#[contractevent]
 pub struct ParticipantReEnrolled {
     pub enrollment_id: u64,
     pub prior_enrollment_id: u64,
@@ -116,6 +123,10 @@ pub enum Error {
     SiteEnrollmentFull = 27,
     /// A Vec parameter exceeds its maximum allowed length.
     InputTooLarge = 28,
+    /// Trial is permanently closed; no new enrolments permitted.
+    TrialClosed = 29,
+    /// Prior enrolment is still active; cannot re-enrol.
+    PriorEnrollmentActive = 30,
 }
 
 /// Maximum number of inclusion or exclusion criteria rules per trial.
@@ -1093,6 +1104,64 @@ impl ClinicalTrialContract {
         .publish(&env);
 
         Ok(())
+    }
+
+    /// Update the protocol hash for a trial, appending an amendment record to
+    /// the on-chain audit log (#485 — ICH E6(R2) GCP compliance).
+    ///
+    /// # Arguments
+    /// * `principal_investigator` - Must be the trial's PI.
+    /// * `trial_record_id`        - Target trial.
+    /// * `new_hash`               - SHA-256 hash of the amended protocol document.
+    /// * `reason_hash`            - SHA-256 hash of the written amendment rationale.
+    pub fn update_protocol(
+        env: Env,
+        principal_investigator: Address,
+        trial_record_id: u64,
+        new_hash: BytesN<32>,
+        reason_hash: BytesN<32>,
+    ) -> Result<(), Error> {
+        principal_investigator.require_auth();
+
+        let mut trial = storage::get_trial(&env, trial_record_id)?;
+        if trial.principal_investigator != principal_investigator {
+            return Err(Error::Unauthorized);
+        }
+        if trial.status != TrialStatus::Active {
+            return Err(Error::TrialNotActive);
+        }
+
+        let amendment = ProtocolAmendment {
+            trial_record_id,
+            old_hash: trial.protocol_hash.clone(),
+            new_hash: new_hash.clone(),
+            amended_by: principal_investigator.clone(),
+            reason_hash,
+            timestamp: env.ledger().timestamp(),
+        };
+
+        storage::append_amendment(&env, &amendment);
+
+        trial.protocol_hash = new_hash.clone();
+        storage::save_trial(&env, &trial);
+
+        ProtocolAmendmentRecorded {
+            trial_record_id,
+            new_hash,
+            amended_by: principal_investigator,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Return the full amendment history for a trial (#485).
+    /// Returns an empty vec for trials that have never been amended.
+    pub fn get_amendment_history(
+        env: Env,
+        trial_record_id: u64,
+    ) -> Vec<ProtocolAmendment> {
+        storage::get_amendment_log(&env, trial_record_id)
     }
 
     fn evaluate_rule(

--- a/contracts/clinical-trial/src/storage.rs
+++ b/contracts/clinical-trial/src/storage.rs
@@ -3,7 +3,8 @@ use soroban_sdk::{Address, Env, Vec};
 
 use crate::{
     AdverseEventReport, ClinicalTrial, DataKey, EligibilityCriteria, Error,
-    ParticipantEnrollment, ProtocolDeviation, SafetyHaltProposal, SafetyReport, StudyVisit,
+    ParticipantEnrollment, ProtocolAmendment, ProtocolDeviation, SafetyHaltProposal, SafetyReport,
+    StudyVisit,
 };
 
 /// Get the next trial record ID and increment counter
@@ -264,4 +265,24 @@ pub fn add_trial_site(env: &Env, trial_record_id: u64, site_id: u64) {
         .unwrap_or(Vec::new(env));
     sites.push_back(site_id);
     env.storage().persistent().set(&key, &sites);
+}
+
+/// Append a protocol amendment record to the trial's amendment log (#485).
+pub fn append_amendment(env: &Env, amendment: &ProtocolAmendment) {
+    let key = DataKey::AmendmentLog(amendment.trial_record_id);
+    let mut log: Vec<ProtocolAmendment> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or(Vec::new(env));
+    log.push_back(amendment.clone());
+    env.storage().persistent().set(&key, &log);
+}
+
+/// Return the full amendment history for a trial (#485).
+pub fn get_amendment_log(env: &Env, trial_record_id: u64) -> Vec<ProtocolAmendment> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::AmendmentLog(trial_record_id))
+        .unwrap_or(Vec::new(env))
 }

--- a/contracts/clinical-trial/src/types.rs
+++ b/contracts/clinical-trial/src/types.rs
@@ -236,6 +236,18 @@ pub struct SafetyHaltProposal {
     pub proposed_at: u64,
 }
 
+/// On-chain protocol amendment record for ICH E6(R2) audit trail (#485).
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ProtocolAmendment {
+    pub trial_record_id: u64,
+    pub old_hash: BytesN<32>,
+    pub new_hash: BytesN<32>,
+    pub amended_by: Address,
+    pub reason_hash: BytesN<32>,
+    pub timestamp: u64,
+}
+
 /// Storage keys for the contract
 #[contracttype]
 #[derive(Clone)]
@@ -264,4 +276,6 @@ pub enum DataKey {
     TrialSites(u64),
     /// Current phase protocol hash for a trial (updated on phase advance).
     TrialPhaseProtocol(u64),
+    /// Ordered list of ProtocolAmendment records for a trial (#485).
+    AmendmentLog(u64),
 }

--- a/contracts/healthcare-analytics/src/lib.rs
+++ b/contracts/healthcare-analytics/src/lib.rs
@@ -49,6 +49,19 @@ pub struct ReportJobAccepted {
     pub result_quality: ResultQuality,
 }
 
+/// Cost-accounting metrics event emitted on job completion (#499).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct JobCompleted {
+    pub job_id: u64,
+    pub requester: Address,
+    pub report_type: String,
+    pub actual_cpu: u64,
+    pub actual_memory: u64,
+    pub wall_time_ms: u64,
+    pub result_quality: ResultQuality,
+}
+
 /// --------------------
 /// Data Structures
 /// --------------------
@@ -346,7 +359,7 @@ impl HealthcareAnalytics {
     }
 
     /// Mark a report job as completed with actual resource usage
-    pub fn complete_report(env: Env, job_id: u64, cpu_used: u64, memory_used: u64) -> Result<(), Error> {
+    pub fn complete_report(env: Env, job_id: u64, cpu_used: u64, memory_used: u64, wall_time_ms: u64) -> Result<(), Error> {
         let job = get_job(&env, job_id).map_err(|_| Error::JobNotFound)?;
         complete_job(&env, job_id, cpu_used, memory_used)
             .map_err(|_| Error::JobNotFound)?;
@@ -388,8 +401,24 @@ impl HealthcareAnalytics {
             &(req_mem + memory_used),
         );
 
-        env.events()
-            .publish((symbol_short!("job_done"), job_id), (cpu_used, memory_used));
+        let result_quality: ResultQuality = env
+            .storage()
+            .persistent()
+            .get(&DataKey::JobResultQuality(job_id))
+            .unwrap_or(ResultQuality::Full);
+
+        env.events().publish(
+            (symbol_short!("job_done"), job_id),
+            JobCompleted {
+                job_id,
+                requester: job.requested_by,
+                report_type: job.job_type,
+                actual_cpu: cpu_used,
+                actual_memory: memory_used,
+                wall_time_ms,
+                result_quality,
+            },
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Resolves four issues across `healthcare-analytics`, `access-control`, and `clinical-trial` contracts.

---

### closes #499 — healthcare-analytics: emit cost-accounting metrics event on job completion

**Problem:** `complete_report` published a bare `(cpu_used, memory_used)` tuple that gave finance teams no way to correlate costs back to a specific requester or report type.

**Change:**
- Added `JobCompleted` contracttype struct with fields `job_id`, `requester`, `report_type`, `actual_cpu`, `actual_memory`, `wall_time_ms`, `result_quality`.
- `complete_report` signature extended with `wall_time_ms: u64`.
- `result_quality` is resolved from the persistent `JobResultQuality` store (defaults to `Full` for non-degraded jobs).
- The structured `JobCompleted` value is published as the event body under the existing `job_done` topic.

**Acceptance:**
- Event is present in `env.events()` after `complete_report` is called.
- All fields (`job_id`, `requester`, `report_type`, `actual_cpu`, `actual_memory`, `wall_time_ms`, `result_quality`) match the values passed to `complete_report`.

---

### closes #490 — access-control: time-bounded access grants with automatic on-chain expiry

**Problem:** `require_role` returned a generic `InsufficientRole` whether a role was absent or expired; callers could not distinguish the two cases and expired roles were silently treated as never-granted.

**Change:**
- Added `check_role_expiry(env, address, role) -> Result<RoleAssignment, ContractError>` which returns `ConsentExpired` when a role record exists but `expires_at <= now`, and `RoleNotFound` when no record exists.
- `require_role` delegates to `check_role_expiry` and propagates `ConsentExpired` directly; non-holders still receive `InsufficientRole`.
- `load_active_role` (used by `has_role`, `get_role_assignment`, etc.) is unchanged — expired roles still produce a falsy result in boolean contexts.

**Acceptance:**
- Expired role assignment is rejected in all protected functions (returns `ConsentExpired`).
- Non-expired assignment continues to work normally.

---

### closes #485 — clinical-trial: on-chain audit log for protocol amendments (ICH E6(R2) GCP)

**Problem:** `advance_trial_phase` overwrote `protocol_hash` in-place with no history, violating ICH E6(R2) GCP amendment-tracking requirements.

**Change:**
- Added `ProtocolAmendment { trial_record_id, old_hash, new_hash, amended_by, reason_hash, timestamp }` contracttype to `types.rs`.
- Added `AmendmentLog(u64)` variant to the `DataKey` enum.
- Added `append_amendment` and `get_amendment_log` helpers in `storage.rs`.
- Added `update_protocol(pi, trial_record_id, new_hash, reason_hash)` public function: appends an amendment record and updates `trial.protocol_hash`; requires PI auth and active trial status.
- Added `get_amendment_history(trial_record_id) -> Vec<ProtocolAmendment>` view; returns empty vec for unamended trials.
- Emits `ProtocolAmendmentRecorded { trial_record_id, new_hash, amended_by }` on each update.
- Also adds the missing `TrialClosed = 29` and `PriorEnrollmentActive = 30` error variants that were referenced in `re_enroll_participant` but absent from the enum (pre-existing compilation blocker).

**Acceptance:**
- Each `update_protocol` call creates an amendment record with `old_hash`, `new_hash`, `amended_by`, `reason_hash`, `timestamp`.
- `get_amendment_history` returns all amendments in order after multiple updates.
- Unamended trials return an empty history.

---

### closes #488 — access-control: role hierarchy enforcement (Admin > Doctor > Nurse)

**Problem:** `grant_role` only checked that the granter held the `Admin` role, allowing any Admin — and by extension, with a misconfigured deployment, a Nurse — to grant any role including Doctor.

**Change:**
- Added `role_level(role: &Role) -> u8` mapping: `Admin = 4`, `Doctor = 3`, `Nurse = 2`, all others = `1`.
- Added `highest_role_level(env, address) -> u8` which iterates over all role variants and returns the highest active level; returns `5` unconditionally for the stored admin address.
- `grant_role`: replaced `require_role(Admin)` with a direct hierarchy check — granter's level must be strictly greater than `role_level(role)`. Returns `InsufficientRole` on violation.
- `grant_roles_batch`: same per-entry hierarchy check in the validate phase before any writes.

**Acceptance:**
- Nurse (level 2) cannot grant Doctor role (level 3) — returns `InsufficientRole`.
- Doctor (level 3) can grant Nurse role (level 2).
- Admin (level 4) can grant any non-Admin role; stored admin address (level 5) can grant Admin role.

---

## Files changed

| File | Issues |
|---|---|
| `contracts/healthcare-analytics/src/lib.rs` | #499 |
| `contracts/access-control/src/lib.rs` | #490, #488 |
| `contracts/clinical-trial/src/lib.rs` | #485 |
| `contracts/clinical-trial/src/types.rs` | #485 |
| `contracts/clinical-trial/src/storage.rs` | #485 |

Closes #499
Closes #490
Closes #485
Closes #488