### PR TITLE
 CICD_SETUP.md documents secret names and CLI commands that don't match the actual GitHub Actions workflows

### DIFF
--- a/CICD_SETUP.md
+++ b/CICD_SETUP.md
@@ -5,43 +5,99 @@ This guide walks you through setting up the complete CI/CD pipeline for the Heal
 ## Prerequisites
 
 - Repository admin access
-- Stellar testnet account with XLM for deployments
+- Stellar testnet and/or mainnet account with XLM for deployments
 - Basic understanding of GitHub Actions
 
-## Step 1: Configure Repository Secrets
+---
 
-### Required Secrets
+## Secrets Reference
+
+> **Which secret does which workflow use?** Use this table as the authoritative reference. If the table and any other section of this document disagree, the table wins — and please open a PR to fix the discrepancy.
+
+| Secret Name | Workflow(s) | Purpose |
+|---|---|---|
+| `STELLAR_SECRET_KEY` | `deploy-testnet.yml` | Raw secret key (`S...`) imported as the `deployer` identity for testnet deployments |
+| `TESTNET_DEPLOYER_IDENTITY` | `extend-ttls.yml` | Stellar identity credential used by the `stellar` CLI to extend contract TTLs on testnet |
+| `MAINNET_DEPLOYER_IDENTITY` | `extend-ttls.yml` | Stellar identity credential used by the `stellar` CLI to extend contract TTLs on mainnet |
+
+`ci.yml` requires **no secrets** — it only runs `cargo fmt`, `cargo clippy`, `cargo test`, and a WASM build.
+
+---
+
+## Step 1: Configure Repository Secrets
 
 1. Navigate to your repository on GitHub
 2. Go to **Settings** → **Secrets and variables** → **Actions**
 3. Click **New repository secret**
-4. Add the following secret:
+4. Add each secret described below
 
-#### STELLAR_SECRET_KEY
+### `STELLAR_SECRET_KEY`
 
 - **Name:** `STELLAR_SECRET_KEY`
 - **Value:** Your Stellar testnet secret key (starts with `S...`)
-- **Purpose:** Used for deploying contracts to testnet
+- **Used by:** `deploy-testnet.yml`
+- **Purpose:** Imported as the `deployer` identity that signs testnet contract deployments
 
-**How to get a testnet account:**
+**How to create a testnet deployer account:**
 
 ```bash
-# Install soroban-cli
-cargo install soroban-cli
+# Install the Stellar CLI
+cargo install --locked stellar-cli --features opt
 
-# Generate a new identity
-soroban keys generate deployer --network testnet
+# Generate a new identity (writes keys to ~/.config/stellar/identity/)
+stellar keys generate deployer --network testnet
 
-# Get the secret key
-soroban keys show deployer
+# Show the secret key to copy into the GitHub secret
+stellar keys show deployer
 
-# Fund the account (get testnet XLM)
-soroban keys address deployer
-# Visit https://laboratory.stellar.org/#account-creator
-# Paste the address and click "Create Account"
+# Get the public address (to fund the account)
+stellar keys address deployer
 ```
 
-⚠️ **Security Warning:** Never commit secret keys to the repository or share them publicly.
+Then fund the account at the [Stellar Laboratory Friendbot](https://laboratory.stellar.org/#account-creator) by pasting the public address.
+
+> ⚠️ **Security:** Never commit secret keys to the repository or share them publicly. Rotate them if they are ever exposed.
+
+---
+
+### `TESTNET_DEPLOYER_IDENTITY`
+
+- **Name:** `TESTNET_DEPLOYER_IDENTITY`
+- **Used by:** `extend-ttls.yml`
+- **Purpose:** Passed directly to `extend-ttls.sh` as the `--identity` argument and exported as `STELLAR_IDENTITY` so the `stellar` CLI can sign TTL-extension transactions on testnet
+
+**How to obtain the value:**
+
+```bash
+# After generating your testnet identity (see above), export it
+stellar keys show deployer
+# Copy the output — this is the value for TESTNET_DEPLOYER_IDENTITY
+```
+
+---
+
+### `MAINNET_DEPLOYER_IDENTITY`
+
+- **Name:** `MAINNET_DEPLOYER_IDENTITY`
+- **Used by:** `extend-ttls.yml` (scheduled runs and manual mainnet triggers)
+- **Purpose:** Passed to `extend-ttls.sh` and exported as `STELLAR_IDENTITY` so the `stellar` CLI can sign TTL-extension transactions on mainnet
+
+**How to obtain the value:**
+
+```bash
+# Generate a separate mainnet identity — never reuse testnet keys on mainnet
+stellar keys generate mainnet-deployer
+
+# Show the secret key for the GitHub secret value
+stellar keys show mainnet-deployer
+
+# Get the address to fund with real XLM
+stellar keys address mainnet-deployer
+```
+
+> ⚠️ **Mainnet keys carry real financial risk.** Use a dedicated account with the minimum XLM needed for TTL extensions. Rotate this secret immediately if it is ever exposed.
+
+---
 
 ## Step 2: Enable GitHub Actions
 
@@ -52,6 +108,8 @@ soroban keys address deployer
    - ✅ **Read and write permissions**
    - ✅ **Allow GitHub Actions to create and approve pull requests**
 4. Click **Save**
+
+---
 
 ## Step 3: Configure Branch Protection Rules
 
@@ -72,12 +130,12 @@ main
 - ✅ Enable
 - **Required approvals:** 1
 - ✅ Dismiss stale pull request approvals when new commits are pushed
-- ✅ Require review from Code Owners (if you have CODEOWNERS file)
+- ✅ Require review from Code Owners (if you have a CODEOWNERS file)
 
 #### Require status checks to pass before merging
 - ✅ Enable
 - ✅ Require branches to be up to date before merging
-- **Required status checks:**
+- **Required status checks** (these are the job names defined in `ci.yml`):
   - `CI Success`
   - `Format Check`
   - `Clippy Lint`
@@ -98,81 +156,90 @@ main
 
 4. Click **Create** or **Save changes**
 
+---
+
 ## Step 4: Verify Workflows
 
-### Test CI Workflow
+### Test CI Workflow (`ci.yml`)
+
+The CI workflow runs on every push and pull request to `main`. It has four jobs — `Format Check`, `Clippy Lint`, `Test Suite`, and `Build WASM` — plus a gating `CI Success` job. No secrets are required.
 
 1. Create a test branch:
 ```bash
 git checkout -b test-ci
 ```
 
-2. Make a small change (e.g., add a comment to a file)
+2. Make a small change (e.g., add a comment to a source file)
 
 3. Commit and push:
 ```bash
 git add .
-git commit -m "Test CI workflow"
+git commit -m "test: trigger CI workflow"
 git push origin test-ci
 ```
 
-4. Create a pull request on GitHub
+4. Open a pull request on GitHub and confirm all five checks turn green.
 
-5. Verify that all CI checks run and pass:
-   - Format Check ✅
-   - Clippy Lint ✅
-   - Test Suite ✅
-   - Build WASM ✅
-   - CI Success ✅
+---
 
-### Test Deployment Workflow
+### Test Deployment Workflow (`deploy-testnet.yml`)
 
-1. Merge a PR to `main` (or push directly if allowed)
+This workflow triggers automatically on push to `main` and can also be triggered manually. It requires the `STELLAR_SECRET_KEY` secret.
 
-2. Go to **Actions** tab → **Deploy to Testnet**
+The workflow:
+1. Detects which contracts changed (or uses your manual input)
+2. Builds each contract to WASM
+3. Runs `stellar contract optimize` on the WASM
+4. Runs `stellar contract deploy` using the `deployer` identity imported from `STELLAR_SECRET_KEY`
 
-3. Verify the workflow runs and deploys contracts
+To trigger manually:
+1. Go to **Actions** tab → **Deploy to Testnet**
+2. Click **Run workflow**
+3. Optionally specify a comma-separated list of contract names (leave blank to deploy all changed contracts)
+4. Verify the deployment summary in the workflow run output
 
-4. Check the deployment summary in the workflow run
+---
+
+### Test TTL Extension Workflow (`extend-ttls.yml`)
+
+This workflow runs on a schedule (every Monday) and can be triggered manually. It uses the `stellar` CLI (not `soroban`) and requires `MAINNET_DEPLOYER_IDENTITY` and/or `TESTNET_DEPLOYER_IDENTITY`.
+
+To test with a dry run:
+1. Go to **Actions** tab → **Extend Contract TTLs**
+2. Click **Run workflow**
+3. Set **Network** to `testnet`
+4. Set **Dry run** to `true`
+5. Verify the workflow completes without errors
+
+---
 
 ### Test Security Audit
 
 1. Go to **Actions** tab → **Security Audit**
-
 2. Click **Run workflow** → **Run workflow**
-
 3. Verify the audit completes successfully
-
 4. Check for any security issues in the summary
+
+---
 
 ## Step 5: Configure Notifications (Optional)
 
 ### Email Notifications
 
-GitHub automatically sends email notifications for:
-- Failed workflow runs
-- Security issues
-- Pull request reviews
-
-Configure in **Settings** → **Notifications**
+GitHub automatically sends email notifications for failed workflow runs, security issues, and pull request reviews. Configure in **Settings** → **Notifications**.
 
 ### Slack Integration (Optional)
 
-To receive Slack notifications:
+1. Create a Slack Incoming Webhook for your workspace and copy the URL.
 
-1. Create a Slack webhook:
-   - Go to your Slack workspace
-   - Create an Incoming Webhook
-   - Copy the webhook URL
+2. Add it as a repository secret:
+   - **Name:** `SLACK_WEBHOOK_URL`
+   - **Value:** Your webhook URL
 
-2. Add as repository secret:
-   - Name: `SLACK_WEBHOOK_URL`
-   - Value: Your webhook URL
-
-3. Add Slack notification step to workflows (example):
+3. Add a notification step to any workflow:
 
 ```yaml
-- name: Notify Slack
+- name: Notify Slack on failure
   if: failure()
   uses: slackapi/slack-github-action@v1
   with:
@@ -192,11 +259,11 @@ To receive Slack notifications:
       }
 ```
 
+---
+
 ## Step 6: Set Up Dependabot (Optional but Recommended)
 
-Automate dependency updates:
-
-1. Create `.github/dependabot.yml`:
+Create `.github/dependabot.yml`:
 
 ```yaml
 version: 2
@@ -214,50 +281,33 @@ updates:
       include: "scope"
 ```
 
-2. Commit and push:
+Then commit and push:
 ```bash
 git add .github/dependabot.yml
-git commit -m "Add Dependabot configuration"
+git commit -m "chore: add Dependabot configuration"
 git push
 ```
+
+---
 
 ## Step 7: Monitor and Maintain
 
 ### Weekly Tasks
 
-1. **Review Security Audit Results**
-   - Check **Actions** → **Security Audit**
-   - Review any created security issues
-   - Update vulnerable dependencies
-
-2. **Review Dependabot PRs**
-   - Check for dependency update PRs
-   - Review changelogs
-   - Merge after CI passes
+1. **Review Security Audit Results** — check **Actions** → **Security Audit**, review any created issues, and update vulnerable dependencies.
+2. **Review Dependabot PRs** — check changelogs and merge after CI passes.
 
 ### Monthly Tasks
 
-1. **Review Deployment History**
-   - Check deployment artifacts
-   - Verify contract IDs are documented
-   - Clean up old artifacts if needed
-
-2. **Update Workflows**
-   - Check for GitHub Actions updates
-   - Update Rust/soroban-cli versions if needed
-   - Review and optimize caching strategies
+1. **Review Deployment History** — check deployment artifacts, verify contract IDs are documented, and clean up old artifacts if needed.
+2. **Update Workflows** — check for GitHub Actions version updates, update Rust and `stellar-cli` versions as needed, and review caching strategies.
 
 ### Quarterly Tasks
 
-1. **Security Review**
-   - Run comprehensive security audit
-   - Review all dependencies
-   - Update security policies
+1. **Security Review** — run a comprehensive security audit, review all dependencies, and update security policies.
+2. **Performance Review** — analyze CI run times, optimize slow jobs, and review caching effectiveness.
 
-2. **Performance Review**
-   - Analyze CI run times
-   - Optimize slow jobs
-   - Review caching effectiveness
+---
 
 ## Troubleshooting
 
@@ -265,54 +315,76 @@ git push
 
 **Problem:** CI fails with "required checks not found"
 
-**Solution:** 
-1. Let the CI run complete at least once
+**Solution:**
+1. Let the CI run complete at least once so the job names are registered
 2. Then add the checks to branch protection
-3. The checks must exist before they can be required
+3. Status checks must exist before GitHub allows them to be required
 
-### Deployment Fails with "Secret not found"
+---
 
-**Problem:** `STELLAR_SECRET_KEY` not configured
+### Deployment Fails with "Secret not found" or "identity not found"
+
+**Problem:** `deploy-testnet.yml` exits with an error about the deployer identity or missing secret
 
 **Solution:**
-1. Verify secret is added in repository settings
-2. Check secret name matches exactly (case-sensitive)
-3. Ensure secret has correct format (starts with `S`)
+1. Confirm `STELLAR_SECRET_KEY` is added under **Settings** → **Secrets and variables** → **Actions**
+2. Check the secret name is exactly `STELLAR_SECRET_KEY` (case-sensitive)
+3. Confirm the value starts with `S` (Stellar secret key format)
+4. The workflow imports this key with `stellar keys add deployer --secret-key "$STELLAR_SECRET_KEY"` — if the key is malformed, that step will fail
+
+---
+
+### TTL Extension Fails with "identity not found" or Permission Error
+
+**Problem:** `extend-ttls.yml` exits with an error about the deployer identity
+
+**Solution:**
+1. Confirm both `MAINNET_DEPLOYER_IDENTITY` and `TESTNET_DEPLOYER_IDENTITY` are configured in repository secrets
+2. Verify neither value is empty — an empty identity will silently fail or produce a cryptic CLI error
+3. Check that the identity's account has enough XLM to cover the transaction fees on the target network
+
+---
 
 ### Security Audit Creates Too Many Issues
 
-**Problem:** Multiple security issues created for same vulnerabilities
+**Problem:** Multiple security issues created for the same vulnerabilities
 
 **Solution:**
 1. The workflow checks for existing issues before creating new ones
-2. If duplicates occur, manually close extras
-3. Update the workflow to improve deduplication logic
+2. If duplicates occur, manually close the extras
+3. Open a PR to improve the deduplication logic in the workflow
+
+---
 
 ### WASM Build Fails
 
 **Problem:** Contracts don't compile to WASM
 
 **Solution:**
-1. Test locally: `cargo build --target wasm32-unknown-unknown`
+1. Test locally: `cargo build --release --target wasm32-unknown-unknown`
 2. Check for platform-specific dependencies
 3. Ensure all contracts use `#![no_std]`
-4. Review soroban-sdk compatibility
+4. Review `soroban-sdk` compatibility
+
+---
 
 ### Deployment Takes Too Long
 
 **Problem:** Deployment workflow times out
 
 **Solution:**
-1. Deploy only changed contracts (automatic)
-2. Use manual trigger to deploy specific contracts
+1. The workflow only deploys changed contracts automatically — verify the change detection is working
+2. Use the manual trigger to deploy specific contracts by name
 3. Optimize WASM binaries before deployment
-4. Consider parallel deployment (advanced)
+4. Consider parallel deployment for large contract sets
+
+---
 
 ## Advanced Configuration
 
 ### Custom Deployment Environments
 
-Create separate workflows for different environments:
+Create a separate workflow for mainnet releases:
 
 ```yaml
 # .github/workflows/deploy-mainnet.yml
@@ -323,10 +395,11 @@ on:
     types: [published]
 
 env:
-  SOROBAN_NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015"
-  SOROBAN_RPC_URL: "https://soroban-mainnet.stellar.org"
+  STELLAR_NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015"
+  STELLAR_RPC_URL: "https://soroban-mainnet.stellar.org"
 
 # ... rest of deployment workflow
+# Use secrets.MAINNET_DEPLOYER_IDENTITY, not STELLAR_SECRET_KEY
 ```
 
 ### Matrix Testing
@@ -347,7 +420,7 @@ test:
 
 ### Conditional Workflows
 
-Run workflows only for specific paths:
+Run workflows only when contract files change:
 
 ```yaml
 on:
@@ -358,65 +431,54 @@ on:
       - 'Cargo.lock'
 ```
 
+---
+
 ## Best Practices
 
-1. **Test Locally First**
-   - Run all CI checks locally before pushing
-   - Use the commands in `.github/workflows/README.md`
+1. **Test locally first** — run all CI checks locally before pushing. See `.github/workflows/README.md` for the exact commands.
+2. **Keep secrets secure** — never commit secrets, rotate them regularly, and use separate accounts for testnet and mainnet.
+3. **Use the Secrets Reference table** — when adding a new workflow that needs credentials, update the table at the top of this document at the same time.
+4. **Monitor CI performance** — review workflow run times, optimize caching, and parallelize where possible.
+5. **Stay updated** — keep GitHub Actions versions, Rust, and `stellar-cli` current and review security advisories weekly.
+6. **Document changes** — update this file and the workflow README whenever secrets or CLI commands change.
 
-2. **Keep Secrets Secure**
-   - Never commit secrets to the repository
-   - Rotate secrets regularly
-   - Use separate accounts for testnet/mainnet
-
-3. **Monitor CI Performance**
-   - Review workflow run times
-   - Optimize caching
-   - Parallelize where possible
-
-4. **Stay Updated**
-   - Update GitHub Actions regularly
-   - Keep Rust and soroban-cli current
-   - Review security advisories weekly
-
-5. **Document Changes**
-   - Update README when workflows change
-   - Document deployment procedures
-   - Keep runbooks current
+---
 
 ## Getting Help
 
 - **GitHub Actions Issues:** [GitHub Community Forum](https://github.community/)
-- **Soroban Issues:** [Soroban Discord](https://discord.gg/stellar)
+- **Stellar CLI Issues:** [Stellar Discord](https://discord.gg/stellar)
 - **Security Issues:** Create a private security advisory in the repository
 
-## Checklist
+---
 
-Use this checklist to verify your setup:
+## Setup Checklist
 
-- [ ] `STELLAR_SECRET_KEY` secret configured
-- [ ] GitHub Actions enabled with write permissions
+Use this checklist to verify your setup is complete:
+
+- [ ] `STELLAR_SECRET_KEY` secret configured (used by `deploy-testnet.yml`)
+- [ ] `TESTNET_DEPLOYER_IDENTITY` secret configured (used by `extend-ttls.yml`)
+- [ ] `MAINNET_DEPLOYER_IDENTITY` secret configured (used by `extend-ttls.yml`)
+- [ ] GitHub Actions enabled with read and write permissions
 - [ ] Branch protection rules configured for `main`
-- [ ] Required status checks added to branch protection
+- [ ] Required status checks added to branch protection (`CI Success`, `Format Check`, `Clippy Lint`, `Test Suite`, `Build WASM`)
 - [ ] CI workflow tested with a pull request
-- [ ] Deployment workflow tested (manual trigger)
+- [ ] Deployment workflow tested (manual trigger with dry run)
+- [ ] TTL extension workflow tested (manual trigger, testnet, dry run)
 - [ ] Security audit workflow tested
 - [ ] Notifications configured (email/Slack)
 - [ ] Dependabot configured (optional)
 - [ ] Team members have appropriate access levels
-- [ ] Documentation reviewed and understood
 - [ ] Monitoring and maintenance schedule established
+
+---
 
 ## Next Steps
 
 After completing this setup:
 
-1. **Create a test PR** to verify all checks work
-2. **Deploy a test contract** to verify deployment works
-3. **Review security audit** results
-4. **Train team members** on the CI/CD process
-5. **Document any custom procedures** specific to your team
-
----
-
-**Congratulations!** Your CI/CD pipeline is now set up and ready to ensure code quality and automate deployments for the Healthy-Stellar contracts.
+1. **Create a test PR** to verify all CI checks pass
+2. **Trigger a manual testnet deployment** to verify `STELLAR_SECRET_KEY` is working
+3. **Run a dry-run TTL extension** to verify `TESTNET_DEPLOYER_IDENTITY` is working
+4. **Review the security audit** results
+5. **Train team members** on the CI/CD process and point them to the Secrets Reference table first


### PR DESCRIPTION
Closes #647  docs: CICD_SETUP.md documents secret names and CLI commands that don't match the actual GitHub Actions workflows
- Replace single STELLAR_SECRET_KEY-only setup with all three real secrets: STELLAR_SECRET_KEY, TESTNET_DEPLOYER_IDENTITY, MAINNET_DEPLOYER_IDENTITY
- Add secrets reference table mapping each secret to its workflow
- Replace all soroban CLI examples with stellar CLI equivalents
- Note that ci.yml requires no secrets
- Update troubleshooting and checklist to cover all three secrets

## Summary

<!-- What does this PR change and why? -->

## Changelog

- [ ] I have updated `CHANGELOG.md` for any user-facing contract API change (new functions, breaking changes, deprecations, or security fixes).

## Test plan

- [ ] Unit / integration tests added or updated
- [ ] `cargo test` passes locally (if applicable)
