### PR TITLE
fix(allergy-tracking): register_cross_sensitivity validates stored admin

### DIFF
--- a/contracts/allergy-tracking/src/lib.rs
+++ b/contracts/allergy-tracking/src/lib.rs
@@ -734,6 +734,9 @@ impl AllergyTrackingContract {
         drug2: String,
     ) -> Result<(), Error> {
         admin.require_auth();
+        if !Self::is_admin(&env, &admin) {
+            return Err(Error::Unauthorized);
+        }
 
         let key1 = DataKey::DrugCrossSensitivity(drug1.clone());
         let mut related1: Vec<String> = env


### PR DESCRIPTION
## Summary

- Add `is_admin` check in `register_cross_sensitivity` so only the stored admin address can register drug cross-sensitivity pairs
- `require_auth()` alone was insufficient — any self-declared address could pass auth for itself

## Validation

- No build/test run required per contribution guidelines (no formatter, linter, typecheck, build, or test)

Closes #595