### PR TITLE
fix(allergy): add requester auth to check_drug_allergy_interaction

### DIFF
--- a/contracts/allergy-management/src/lib.rs
+++ b/contracts/allergy-management/src/lib.rs
@@ -400,8 +400,16 @@ impl AllergyManagement {
     pub fn check_drug_allergy_interaction(
         env: Env,
         patient_id: Address,
+        requester: Address,
         drug_name: String,
     ) -> Result<Vec<AllergyInteraction>, Error> {
+        requester.require_auth();
+
+        // Check access permissions (same as get_active_allergies)
+        if !storage::check_access_permission(&env, &patient_id, &requester) {
+            return Err(Error::AccessDenied);
+        }
+
         let mut interactions = Vec::new(&env);
 
         // Get all active allergies for patient

--- a/contracts/allergy-tracking/src/lib.rs
+++ b/contracts/allergy-tracking/src/lib.rs
@@ -545,8 +545,10 @@ impl AllergyTrackingContract {
     pub fn check_drug_allergy_interaction(
         env: Env,
         patient_id: Address,
+        requester: Address,
         drug_name: String,
     ) -> Result<Vec<InteractionWarning>, Error> {
+        requester.require_auth();
         let patient_key = DataKey::PatientAllergies(patient_id.clone());
         let patient_allergies: Vec<u64> = env
             .storage()


### PR DESCRIPTION
## Summary

- Add `requester: Address` parameter to `check_drug_allergy_interaction` in both `allergy-tracking` and `allergy-management`
- Enforce `requester.require_auth()` on both contracts
- Enforce `check_access_permission` in `allergy-management` matching the same gate used by `get_active_allergies`

## Validation

- No build/test run required per contribution guidelines

Closes #596