### PR TITLE
fix(allergy-management): deregister_patient removes all access grants

### DIFF
--- a/contracts/allergy-management/src/lib.rs
+++ b/contracts/allergy-management/src/lib.rs
@@ -552,11 +552,9 @@ impl AllergyManagement {
             .persistent()
             .remove(&DataKey::PatientAllergies(patient_id.clone()));
 
-        // Remove all access grants for this patient (iterate known providers via allergy records)
-        // Access grants are keyed AccessControl(patient, provider); we remove the whole patient
-        // namespace by clearing grants found during the allergy scan above.
-        // Since we don't have a separate provider index, we rely on the fact that
-        // AccessControl entries are only meaningful while PatientAllergies exists.
+        // Remove all AccessControl(patient, *) grants using the provider index
+        storage::remove_all_access_grants(&env, &patient_id);
+
         // Emit cleanup event.
         env.events().publish(
             (symbol_short!("pat_dreg"), patient_id),

--- a/contracts/allergy-management/src/storage.rs
+++ b/contracts/allergy-management/src/storage.rs
@@ -93,12 +93,62 @@ pub fn grant_access(env: &Env, patient_id: &Address, provider_id: &Address) {
     let key = DataKey::AccessControl(patient_id.clone(), provider_id.clone());
     env.storage().persistent().set(&key, &true);
     extend_critical_ttl(env, &key);
+
+    // Maintain per-patient provider index
+    let index_key = DataKey::GrantedProviders(patient_id.clone());
+    let mut providers: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&index_key)
+        .unwrap_or(Vec::new(env));
+    let mut already = false;
+    for p in providers.iter() {
+        if p == *provider_id {
+            already = true;
+            break;
+        }
+    }
+    if !already {
+        providers.push_back(provider_id.clone());
+        env.storage().persistent().set(&index_key, &providers);
+        extend_critical_ttl(env, &index_key);
+    }
 }
 
 /// Revoke access from a provider
 pub fn revoke_access(env: &Env, patient_id: &Address, provider_id: &Address) {
     let key = DataKey::AccessControl(patient_id.clone(), provider_id.clone());
     env.storage().persistent().remove(&key);
+
+    // Remove from per-patient provider index
+    let index_key = DataKey::GrantedProviders(patient_id.clone());
+    let providers: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&index_key)
+        .unwrap_or(Vec::new(env));
+    let mut updated: Vec<Address> = Vec::new(env);
+    for p in providers.iter() {
+        if p != *provider_id {
+            updated.push_back(p);
+        }
+    }
+    env.storage().persistent().set(&index_key, &updated);
+}
+
+/// Remove all AccessControl grants for a patient (used during deregistration)
+pub fn remove_all_access_grants(env: &Env, patient_id: &Address) {
+    let index_key = DataKey::GrantedProviders(patient_id.clone());
+    let providers: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&index_key)
+        .unwrap_or(Vec::new(env));
+    for provider_id in providers.iter() {
+        let key = DataKey::AccessControl(patient_id.clone(), provider_id.clone());
+        env.storage().persistent().remove(&key);
+    }
+    env.storage().persistent().remove(&index_key);
 }
 
 /// Check if a requester has access to patient allergies

--- a/contracts/allergy-management/src/types.rs
+++ b/contracts/allergy-management/src/types.rs
@@ -80,6 +80,7 @@ pub enum DataKey {
     Allergy(u64),
     PatientAllergies(Address),
     AccessControl(Address, Address),  // (patient, provider)
+    GrantedProviders(Address),        // (patient) -> Vec<Address>
     CrossSensitivity(String, String), // (allergen1, allergen2)
     PatientRegistry,
     ProviderRegistry,


### PR DESCRIPTION
## Summary

- Add `DataKey::GrantedProviders(Address)` to track per-patient provider index
- `grant_access` now appends the provider to the `GrantedProviders` index
- `revoke_access` now removes the provider from the index
- Add `remove_all_access_grants` helper that iterates the index and deletes every `AccessControl(patient, provider)` entry plus the index itself
- `deregister_patient` calls `remove_all_access_grants` instead of leaving grants dangling

## Validation

- No build/test run required per contribution guidelines

Closes #594