### PR TITLE
fix(rehabilitation-services): replace O(N) goal scan with per-plan co…

### DIFF
--- a/contracts/rehabilitation-services/src/lib.rs
+++ b/contracts/rehabilitation-services/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![allow(clippy::too_many_arguments)]
+#![allow(deprecated)]
 
 //! # Rehabilitation Services Contract
 //!
@@ -242,6 +243,8 @@ pub enum DataKey {
     PlanVersion(u64),
     /// plan_id -> Vec<PlanVersionEntry>
     PlanVersionHistory(u64),
+    /// plan_id -> u64 (number of goals set for this plan, used as plan_version)
+    PlanGoalCount(u64),
 }
 
 #[contracttype]
@@ -801,10 +804,7 @@ impl RehabilitationServicesContract {
     }
 
     /// Retrieve the full version history for a treatment plan.
-    pub fn get_treatment_plan_history(
-        env: Env,
-        plan_id: u64,
-    ) -> Vec<PlanVersionEntry> {
+    pub fn get_treatment_plan_history(env: Env, plan_id: u64) -> Vec<PlanVersionEntry> {
         // Bump TTL on read
         env.storage().instance().extend_ttl(0, 5000);
 
@@ -922,26 +922,13 @@ impl RehabilitationServicesContract {
             .unwrap_or(0u64)
             + 1;
 
-        // Version is the number of goals already set for this plan (monotonic).
-        let plan_version: u64 = {
-            let mut count = 0u64;
-            let max = goal_id;
-            // Count goals belonging to this plan (linear scan over goal ids up to current).
-            // Using the stored counter as the upper bound is correct because goal_id is
-            // globally monotonic and we haven't persisted this new goal yet.
-            for gid in 1..max {
-                if let Some(g) = env
-                    .storage()
-                    .instance()
-                    .get::<_, MeasurableGoal>(&DataKey::MeasurableGoal(gid))
-                {
-                    if g.plan_id == plan_id {
-                        count += 1;
-                    }
-                }
-            }
-            count
-        };
+        // plan_version is the number of goals already set for this plan.
+        // Read a per-plan counter directly — O(1), no global scan.
+        let plan_version: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::PlanGoalCount(plan_id))
+            .unwrap_or(0u64);
 
         let goal = MeasurableGoal {
             goal_id,
@@ -959,6 +946,9 @@ impl RehabilitationServicesContract {
         env.storage()
             .instance()
             .set(&DataKey::GoalCounter, &goal_id);
+        env.storage()
+            .instance()
+            .set(&DataKey::PlanGoalCount(plan_id), &(plan_version + 1));
 
         env.events().publish(
             (Symbol::new(&env, "goal_set"), plan_id),
@@ -1071,7 +1061,7 @@ impl RehabilitationServicesContract {
         page: u32,
         page_size: u32,
     ) -> TherapyPage {
-        let page_size = page_size.min(MAX_PAGE_SIZE).max(1);
+        let page_size = page_size.clamp(1, MAX_PAGE_SIZE);
         let all: Vec<TherapySession> = env
             .storage()
             .instance()
@@ -1085,7 +1075,10 @@ impl RehabilitationServicesContract {
             items.push_back(all.get(i).unwrap());
             i += 1;
         }
-        TherapyPage { items, has_more: (start + page_size) < total }
+        TherapyPage {
+            items,
+            has_more: (start + page_size) < total,
+        }
     }
 
     /// Paginated progress notes for a treatment plan.
@@ -1097,7 +1090,7 @@ impl RehabilitationServicesContract {
         page: u32,
         page_size: u32,
     ) -> NotePage {
-        let page_size = page_size.min(MAX_PAGE_SIZE).max(1);
+        let page_size = page_size.clamp(1, MAX_PAGE_SIZE);
         let all: Vec<ProgressNote> = env
             .storage()
             .instance()
@@ -1111,7 +1104,10 @@ impl RehabilitationServicesContract {
             items.push_back(all.get(i).unwrap());
             i += 1;
         }
-        NotePage { items, has_more: (start + page_size) < total }
+        NotePage {
+            items,
+            has_more: (start + page_size) < total,
+        }
     }
 }
 

--- a/contracts/rehabilitation-services/src/test.rs
+++ b/contracts/rehabilitation-services/src/test.rs
@@ -833,12 +833,8 @@ fn test_record_progress_achieves_goal() {
     let client = RehabilitationServicesContractClient::new(&env, &contract_id);
 
     let (_, plan_id) = create_plan(&env, &client, &patient, &therapist);
-    let goal_id = client.set_rehabilitation_goal(
-        &plan_id,
-        &Symbol::new(&env, "pain_scale"),
-        &3u32,
-        &2000u64,
-    );
+    let goal_id =
+        client.set_rehabilitation_goal(&plan_id, &Symbol::new(&env, "pain_scale"), &3u32, &2000u64);
 
     // Pain scale — lower is better but we track as "has reached target"
     client.record_progress(&plan_id, &goal_id, &5u32, &1400u64);
@@ -861,12 +857,8 @@ fn test_goal_progress_time_series_queryable() {
     let client = RehabilitationServicesContractClient::new(&env, &contract_id);
 
     let (_, plan_id) = create_plan(&env, &client, &patient, &therapist);
-    let goal_id = client.set_rehabilitation_goal(
-        &plan_id,
-        &Symbol::new(&env, "fim"),
-        &100u32,
-        &3000u64,
-    );
+    let goal_id =
+        client.set_rehabilitation_goal(&plan_id, &Symbol::new(&env, "fim"), &100u32, &3000u64);
 
     for i in 0..5u32 {
         client.record_progress(&plan_id, &goal_id, &(50 + i * 10), &(1000 + i as u64 * 100));
@@ -1028,4 +1020,41 @@ fn test_get_progress_notes_paged() {
     let page2 = client.get_progress_notes_paged(&plan_id, &1u32, &3u32);
     assert_eq!(page2.items.len(), 1);
     assert!(!page2.has_more);
+}
+
+#[test]
+fn test_plan_version_is_per_plan_not_global() {
+    // Goals created on plan_b must not inflate plan_version on plan_a.
+    let env = Env::default();
+    env.mock_all_auths();
+    let patient = Address::generate(&env);
+    let therapist = Address::generate(&env);
+    let contract_id = env.register(RehabilitationServicesContract, ());
+    let client = RehabilitationServicesContractClient::new(&env, &contract_id);
+
+    let (_, plan_a) = create_plan(&env, &client, &patient, &therapist);
+    let (_, plan_b) = create_plan(&env, &client, &patient, &therapist);
+
+    // Add several goals to plan_b first.
+    for _ in 0..5 {
+        client.set_rehabilitation_goal(&plan_b, &Symbol::new(&env, "strength"), &100u32, &9000u64);
+    }
+
+    // First goal on plan_a should have plan_version == 0 regardless of plan_b's goals.
+    let g1 = client.set_rehabilitation_goal(
+        &plan_a,
+        &Symbol::new(&env, "range_of_motion"),
+        &120u32,
+        &9000u64,
+    );
+    assert_eq!(client.get_measurable_goal(&g1).plan_version, 0);
+
+    // Second goal on plan_a should have plan_version == 1.
+    let g2 = client.set_rehabilitation_goal(
+        &plan_a,
+        &Symbol::new(&env, "range_of_motion"),
+        &130u32,
+        &9001u64,
+    );
+    assert_eq!(client.get_measurable_goal(&g2).plan_version, 1);
 }


### PR DESCRIPTION
…unter

set_rehabilitation_goal previously computed plan_version by iterating over every goal ever created (1..global_goal_counter), reading each from storage and filtering by plan_id. This is an O(N) storage scan on every write and will hit the ledger CPU/read budget as goals accumulate.

Fix: introduce DataKey::PlanGoalCount(plan_id), a per-plan counter that is read (O(1)) to derive plan_version and incremented after each goal is stored. The global GoalCounter is preserved for goal_id generation.

Also fix two pre-existing clippy::manual_clamp warnings and add #![allow(deprecated)] for the existing events().publish() calls, matching the pattern used by other contracts in the workspace.

Migration note: existing deployed goals retain their stored plan_version values unchanged. The new PlanGoalCount key starts from 0 for any plan that has no entry, so new goals on plans with pre-existing goals will restart plan_version from 0. Deployments with existing goal data should backfill PlanGoalCount(plan_id) = count_of_goals_for_that_plan before upgrading, or accept a version reset.

Closes #624

## Summary

<!-- What does this PR change and why? -->

## Changelog

- [ ] I have updated `CHANGELOG.md` for any user-facing contract API change (new functions, breaking changes, deprecations, or security fixes).

## Test plan

- [ ] Unit / integration tests added or updated
- [ ] `cargo test` passes locally (if applicable)
