### PR TITLE
fix(ci): remove invalid --features opt flag from soroban-cli install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Install soroban-cli
         run: |
-          cargo install --locked soroban-cli --features opt || echo "soroban-cli already installed"
+          cargo install --locked soroban-cli
 
       - name: Build WASM binaries
         run: |

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Install soroban-cli
         run: |
-          cargo install --locked soroban-cli --features opt
+          cargo install --locked soroban-cli
 
       - name: Configure Soroban identity
         env:


### PR DESCRIPTION
## Summary

- Remove `--features opt` from `cargo install soroban-cli` in `deploy-testnet.yml` — this feature does not exist in soroban-cli v27.0.0
- Remove `|| echo "soroban-cli already installed"` fallback in `ci.yml` so install failures are visible
- Both files now use `cargo install --locked soroban-cli` (no feature flags)

## Validation

- No build, lint, or typecheck required for workflow-only changes

Closes #634