### PR TITLE
fix(security): update deny.toml unmaintained field to valid cargo-deny value

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,7 +8,7 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # The lint level for security vulnerabilities
 vulnerability = "deny"
 # The lint level for unmaintained crates
-unmaintained = "warn"
+unmaintained = "all"
 # The lint level for crates that have been yanked from their source registry
 yanked = "deny"
 # The lint level for crates with security notices


### PR DESCRIPTION
## Summary

- Change `unmaintained = "warn"` to `unmaintained = "all"` in `deny.toml`
- The old value is incompatible with the current cargo-deny version which expects one of `all`/`workspace`/`transitive`/`none`
- `"all"` preserves the original intent of flagging all unmaintained crates

## Validation

- No build, lint, or typecheck required for config-only change

Closes #633