### PR TITLE
fix(deployment): install stellar-cli instead of stellar-core in extend-ttls workflow

### DIFF
--- a/.github/workflows/extend-ttls.yml
+++ b/.github/workflows/extend-ttls.yml
@@ -33,10 +33,10 @@ jobs:
 
       - name: Install Stellar CLI
         run: |
-          curl -L https://github.com/stellar/go/releases/download/stellar-core-21.5.0/stellar-core-21.5.0-ubuntu-22.04.tar.gz | tar -xz
-          mv stellar-core /usr/local/bin/
-          # Or install using package manager:
-          # sudo apt-get update && sudo apt-get install -y stellar-cli
+          cargo install --locked stellar-cli
+
+      - name: Verify Stellar CLI install
+        run: stellar --version
 
       - name: Extend TTLs - Mainnet
         if: github.event_name == 'schedule' || inputs.network == 'mainnet'


### PR DESCRIPTION
## Summary

- Replace broken `curl` install of `stellar-core` (wrong binary, broken URL) with `cargo install --locked stellar-cli`
- Add `stellar --version` sanity-check step so a broken install fails fast with a clear message
- The workflow invokes `CLI_BIN: stellar` throughout — `stellar-cli` is the correct package that provides that binary

## Validation

- No build, lint, or typecheck required for workflow-only changes

Closes #632