### PR TITLE
fix: close role-escalation & deactivated-entity gaps, sync consent in…

### DIFF
--- a/.github/workflows/extend-ttls.yml
+++ b/.github/workflows/extend-ttls.yml
@@ -84,6 +84,8 @@ jobs:
               title: '⚠️ TTL Extension Failed - Manual Intervention Required',
               body: `The automatic TTL extension job failed on ${new Date().toISOString()}.
 
+              Follow the manual extension runbook: https://github.com/${{ github.repository }}/blob/main/TTL_POLICY.md#manual-ttl-extension
+
               Please review the workflow run and manually extend TTLs if necessary:
               - Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               - Network: ${{ inputs.network || 'mainnet' }}

--- a/TTL_POLICY.md
+++ b/TTL_POLICY.md
@@ -229,6 +229,105 @@ Set up alerts for:
 - Contracts with no TTL bump activity
 - Unexpected storage deletions
 
+## Manual TTL Extension
+
+> **Known-broken state:** The scheduled `extend-ttls.yml` job has failed on every
+> recent run (see #578, #579, #580, and the separately filed automation bug).
+> Until that automation issue is fixed, treat the "Manual Intervention Required"
+> issue it files each week as expected, and follow this runbook every time it
+> fires. Remove this note once the underlying automation bug is resolved and the
+> cron can be trusted again.
+
+When the automated `Extend Contract TTLs` workflow fails, or you need to extend
+TTLs outside the schedule, run `scripts/extend-ttls.sh` directly.
+
+### 1. Prerequisites
+
+- The [Stellar CLI](https://developers.stellar.org/docs/tools/cli/stellar-cli) (`stellar`) installed and on `PATH`.
+- A `deployments/<network>.json` manifest containing the contract IDs to extend (e.g. `deployments/mainnet.json`).
+- A Stellar CLI identity/secret with enough XLM to pay the extension fees for every contract in the manifest.
+
+### 2. Identity / secret to use
+
+- **Mainnet:** use the identity backing the `MAINNET_DEPLOYER_IDENTITY` GitHub Actions secret — the same
+  identity the scheduled job authenticates with. Get the secret value from whoever holds repo/org secret
+  access (repo admin or the deployment owner), then import it locally before running the script:
+
+  ```bash
+  stellar keys add mainnet-deployer --secret-key   # paste the MAINNET_DEPLOYER_IDENTITY secret value
+  ```
+
+  Never commit this secret or paste it into a shell history file that gets synced anywhere. Prefer an
+  interactive prompt (as above) over passing `--secret-key` inline.
+
+- **Testnet:** use the identity backing `TESTNET_DEPLOYER_IDENTITY`, imported the same way under a
+  different local key name (e.g. `testnet-deployer`).
+
+### 3. Run the script
+
+```bash
+# Dry run first — logs what would be extended without submitting any transactions.
+./scripts/extend-ttls.sh \
+  --network mainnet \
+  --identity mainnet-deployer \
+  --ledgers-to-extend 535680 \
+  --dry-run
+
+# Then the real run.
+./scripts/extend-ttls.sh \
+  --network mainnet \
+  --identity mainnet-deployer \
+  --ledgers-to-extend 535680
+```
+
+Key flags (see `./scripts/extend-ttls.sh --help` for the full list):
+
+- `--network <name>` — `mainnet` or `testnet`.
+- `--identity <name>` — the local CLI identity name from step 2 (not the raw secret).
+- `--ledgers-to-extend <count>` — defaults to `535680` (~1 year at 5s/ledger); match the value the
+  cron job normally uses unless you have a specific reason to diverge.
+- `--dry-run` — logs the contracts that would be extended without calling `stellar contract extend`.
+
+The script reads contract IDs out of `deployments/<network>.json` and calls `stellar contract extend`
+for each one, printing an `Extended: N / Failed: N / Total: N` summary at the end and exiting non-zero
+if any contract failed.
+
+### 4. Verify success
+
+- **Script output:** confirm the summary line reports `Failed: 0` and that every contract ID logged an
+  `Extending TTL for: <id>` line without a following `WARNING: Failed to extend TTL for: <id>`.
+- **`stellar contract extend` output:** the command itself reports the resulting expiration ledger for
+  each entry it touches — capture the script's stdout (it's not redirected) and confirm the reported
+  ledger is `~LEDGERS_TO_EXTEND` ledgers ahead of the ledger the transaction landed in.
+- **Current TTL / expiry lookup (per contract, without extending anything):** query the contract
+  instance's `liveUntilLedgerSeq` via [Stellar Laboratory](https://laboratory.stellar.org)'s "Ledger
+  Entries" / contract-data explorer for the target network, using the contract's `C...` address — or
+  call the network's Soroban RPC `getLedgerEntries` method directly with the contract instance's
+  ledger key, and compare the returned `liveUntilLedgerSeq` against the current sequence from
+  `getLatestLedger`:
+
+  ```bash
+  RPC_URL="https://mainnet.sorobanrpc.com"   # use the network's RPC endpoint
+
+  curl -s -X POST "$RPC_URL" -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"getLatestLedger"}' | jq '.result.sequence'
+  ```
+
+  The contract is healthy if `liveUntilLedgerSeq` is comfortably above the current ledger sequence
+  (well beyond `CRITICAL_THRESHOLD`, ~86,400 ledgers / ~1 day, from `scripts/extend-ttls.sh`). See the
+  [Stellar CLI TTL cookbook](https://developers.stellar.org/docs/tools/cli/cookbook/extend-contract-instance)
+  for how to encode a contract instance's ledger key for `getLedgerEntries`.
+
+### 5. If extension still fails
+
+- Re-run with `--dry-run` to confirm the manifest and contract IDs are being parsed correctly.
+- Check the identity's XLM balance — insufficient balance is the most common cause of `stellar contract
+  extend` failures.
+- Confirm `deployments/<network>.json` is up to date and every listed contract ID is still deployed.
+- If the failure persists, escalate in the deployment/automation-bug issue rather than retrying
+  indefinitely — repeated manual extension without addressing the root cause just delays discovering why
+  the cron job itself is broken.
+
 ## Compliance Checklist
 
 - [ ] All critical healthcare data uses Critical retention class

--- a/contracts/access-control/src/lib.rs
+++ b/contracts/access-control/src/lib.rs
@@ -11,6 +11,15 @@
 //! Patient, Insurer, Auditor, Provider, PayerReviewer, EmergencyResponder). Expiring role assignments,
 //! entity registration validation, and composite uniqueness indexes prevent unauthorized access.
 //!
+//! **Role Hierarchy:** `grant_role` only succeeds if the granter's highest active role level is
+//! strictly greater than the target role's level (see `role_level`). Levels, high to low:
+//! the literal contract admin address (5, unconditional) > Admin / EmergencyResponder (4) >
+//! Doctor / PayerReviewer (3) > Nurse / Auditor (2) > Provider / Insurer / Patient (1).
+//! EmergencyResponder and PayerReviewer sit at the top alongside Admin/Doctor because they unlock
+//! high-trust powers — an unsuppressible 1-hour emergency data-access override, and the ability to
+//! revoke any grantor's access permissions, respectively — that must never be mintable by a
+//! Nurse-level (or lower) account.
+//!
 //! **Audit Controls:** Monotonic operation IDs (op_id) track every access grant, revocation, consent,
 //! and emergency access event. Events published: grant, revoke, consent, revoke_consent, did_aud,
 //! emergency_access, deactivate, role_grant, role_revoke. Audit systems can replay events for
@@ -68,6 +77,8 @@ pub enum ContractError {
     CommitExpired = 25,
     /// The batch of role assignments exceeds the maximum allowed size.
     BatchTooLarge = 26,
+    /// #625: grantor or grantee entity has been deactivated via `deactivate_entity`.
+    EntityInactive = 27,
 }
 
 /// Maximum number of access permissions a single grantee may accumulate.
@@ -373,8 +384,14 @@ impl AccessControl {
     /// Grant `role` to `grantee`. The grantor must hold the `Admin` role **or**
     /// hold a role whose level is strictly higher than the role being granted.
     ///
-    /// Role hierarchy (higher value = more privileged):
-    ///   Admin(4) > Doctor(3) > Nurse(2) > Patient/Insurer/Auditor/Provider/... (1)
+    /// Role hierarchy (higher value = more privileged), see `role_level`:
+    ///   Admin(4) = EmergencyResponder(4) > Doctor(3) = PayerReviewer(3) >
+    ///   Nurse(2) = Auditor(2) > Provider/Insurer/Patient(1)
+    ///
+    /// Note: because the check is strict (`>`), only the literal contract admin
+    /// address (treated as level 5) can grant a level-4 role such as
+    /// `EmergencyResponder` — holding `Admin` or `EmergencyResponder` itself is
+    /// not sufficient to grant another level-4 role.
     ///
     /// # Arguments
     /// * `granter`    - Must hold a role with level > role_level(role).
@@ -575,22 +592,26 @@ impl AccessControl {
             Self::verify_and_consume_commit(&env, &grantor, &grantee, &resource_id, n)?;
         }
 
-        // Verify grantor is a registered entity
-        if !env
+        // Verify grantor is a registered, active entity (#625: a deactivated
+        // entity must not be able to keep granting access).
+        let grantor_entity: EntityData = env
             .storage()
             .persistent()
-            .has(&DataKey::Entity(grantor.clone()))
-        {
-            return Err(ContractError::GrantorNotRegistered);
+            .get(&DataKey::Entity(grantor.clone()))
+            .ok_or(ContractError::GrantorNotRegistered)?;
+        if !grantor_entity.active {
+            return Err(ContractError::EntityInactive);
         }
 
-        // Verify grantee is a registered entity
-        if !env
+        // Verify grantee is a registered, active entity (#625: a deactivated
+        // entity must not be able to keep receiving access).
+        let grantee_entity: EntityData = env
             .storage()
             .persistent()
-            .has(&DataKey::Entity(grantee.clone()))
-        {
-            return Err(ContractError::GranteeNotRegistered);
+            .get(&DataKey::Entity(grantee.clone()))
+            .ok_or(ContractError::GranteeNotRegistered)?;
+        if !grantee_entity.active {
+            return Err(ContractError::EntityInactive);
         }
 
         // #220: composite uniqueness check — (grantor, grantee, resource_id)
@@ -1269,14 +1290,27 @@ impl AccessControl {
     // Internal helpers
     // -----------------------------------------------------------------------
 
-    /// Numeric role level for hierarchy enforcement (#488).
-    /// Higher value = more privileged.  Admin must be strictly highest.
+    /// Numeric role level for hierarchy enforcement (#488, #626).
+    /// Higher value = more privileged. Every role has an explicit level — no
+    /// catch-all — so a newly added `Role` variant must be assigned one here
+    /// deliberately rather than silently falling into the lowest tier.
+    ///
+    /// `EmergencyResponder` and `PayerReviewer` are pinned to the
+    /// Admin/Doctor tier (4/3) because they unlock high-trust powers (an
+    /// unsuppressible emergency data-access override, and the ability to
+    /// revoke any grantor's access permissions) that must not be grantable
+    /// by a Nurse-level account.
     fn role_level(role: &Role) -> u8 {
         match role {
             Role::Admin => 4,
+            Role::EmergencyResponder => 4,
             Role::Doctor => 3,
+            Role::PayerReviewer => 3,
             Role::Nurse => 2,
-            _ => 1,
+            Role::Auditor => 2,
+            Role::Provider => 1,
+            Role::Insurer => 1,
+            Role::Patient => 1,
         }
     }
 

--- a/contracts/health-records/src/lib.rs
+++ b/contracts/health-records/src/lib.rs
@@ -211,9 +211,25 @@ impl HealthRecords {
         validate_nonzero_address(&patient).map_err(|_| Error::InvalidAddress)?;
         validate_nonzero_address(&provider).map_err(|_| Error::InvalidAddress)?;
         patient.require_auth();
-        env.storage()
+        env.storage().persistent().set(
+            &DataKey::Consent(patient.clone(), provider.clone()),
+            &scope,
+        );
+
+        // #627: keep PatientProviders in sync so deregister_patient's consent
+        // cleanup loop actually has providers to iterate over. Dedup on
+        // repeat grants to the same provider.
+        let idx_key = DataKey::PatientProviders(patient.clone());
+        let mut providers: Vec<Address> = env
+            .storage()
             .persistent()
-            .set(&DataKey::Consent(patient, provider), &scope);
+            .get(&idx_key)
+            .unwrap_or(Vec::new(&env));
+        if !providers.iter().any(|p| p == provider) {
+            providers.push_back(provider);
+            env.storage().persistent().set(&idx_key, &providers);
+        }
+
         Ok(())
     }
 
@@ -224,7 +240,27 @@ impl HealthRecords {
         patient.require_auth();
         env.storage()
             .persistent()
-            .remove(&DataKey::Consent(patient, provider));
+            .remove(&DataKey::Consent(patient.clone(), provider.clone()));
+
+        // #627: prune the PatientProviders index entry so it doesn't keep
+        // accumulating providers the patient no longer has any consent
+        // record for.
+        let idx_key = DataKey::PatientProviders(patient.clone());
+        let providers: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&idx_key)
+            .unwrap_or(Vec::new(&env));
+        if providers.iter().any(|p| p == provider) {
+            let mut remaining: Vec<Address> = Vec::new(&env);
+            for p in providers.iter() {
+                if p != provider {
+                    remaining.push_back(p);
+                }
+            }
+            env.storage().persistent().set(&idx_key, &remaining);
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
…dex, add TTL runbook

security: access-control grant_access does not check entity.active, letting deactivated entities keep granting/receiving access Fixes #625

security: access-control role_level() puts EmergencyResponder at the same low tier as Patient/Insurer, letting a Nurse grant it Fixes #626

bug: health-records grant_consent never populates PatientProviders index, making deregister_patient's consent cleanup dead code Fixes #627

docs: TTL_POLICY.md has no manual-extension runbook despite the automated TTL job failing on every recent scheduled run Fixes #648

## Summary

<!-- What does this PR change and why? -->

## Changelog

- [ ] I have updated `CHANGELOG.md` for any user-facing contract API change (new functions, breaking changes, deprecations, or security fixes).

## Test plan

- [ ] Unit / integration tests added or updated
- [ ] `cargo test` passes locally (if applicable)
