### PR TITLE
fix(medical-device-tracking): require implanting provider for removal

### DIFF
--- a/contracts/emergency-medical-info/src/lib.rs
+++ b/contracts/emergency-medical-info/src/lib.rs
@@ -463,10 +463,50 @@ impl EmergencyMedicalInfo {
                 .persistent()
                 .get(&old_profile_key)
                 .ok_or(Error::EmergencyProfileNotFound)?;
+
+            let old_dnr_key = DataKey::DNROrder(patient_id.clone());
+            let old_alerts_key = DataKey::CriticalAlerts(patient_id.clone());
+            let old_access_log_key = DataKey::EmergencyAccessLog(patient_id.clone());
+
+            let dnr: Option<DNROrder> = env.storage().persistent().get(&old_dnr_key);
+            let alerts: Option<Vec<CriticalAlert>> =
+                env.storage().persistent().get(&old_alerts_key);
+            let access_logs: Option<Vec<EmergencyAccessLog>> =
+                env.storage().persistent().get(&old_access_log_key);
+
+            // Migrate all related data to the new owner key before removing
+            // any old keys, so a failure partway through never orphans data.
             env.storage()
                 .persistent()
                 .set(&DataKey::EmergencyProfile(new_owner.clone()), &profile);
+            if let Some(dnr) = &dnr {
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::DNROrder(new_owner.clone()), dnr);
+            }
+            if let Some(alerts) = &alerts {
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::CriticalAlerts(new_owner.clone()), alerts);
+            }
+            if let Some(access_logs) = &access_logs {
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::EmergencyAccessLog(new_owner.clone()), access_logs);
+            }
+
+            // Only remove old keys after all migrations above have succeeded.
             env.storage().persistent().remove(&old_profile_key);
+            if dnr.is_some() {
+                env.storage().persistent().remove(&old_dnr_key);
+            }
+            if alerts.is_some() {
+                env.storage().persistent().remove(&old_alerts_key);
+            }
+            if access_logs.is_some() {
+                env.storage().persistent().remove(&old_access_log_key);
+            }
+
             env.storage().temporary().remove(&proposal_key);
             env.events()
                 .publish((Symbol::new(&env, "recovered"), patient_id), new_owner);

--- a/contracts/emergency-medical-info/src/test.rs
+++ b/contracts/emergency-medical-info/src/test.rs
@@ -325,6 +325,58 @@ fn test_guardian_threshold_rekeys_emergency_profile() {
 }
 
 #[test]
+fn test_recovery_migrates_dnr_order_and_critical_alerts() {
+    let env = Env::default();
+    let contract_id = env.register(EmergencyMedicalInfo, ());
+    let client = EmergencyMedicalInfoClient::new(&env, &contract_id);
+
+    let patient = Address::generate(&env);
+    let contact = Address::generate(&env);
+    let guardian_1 = Address::generate(&env);
+    let guardian_2 = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let provider = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.set_emergency_profile(
+        &patient,
+        &Symbol::new(&env, "AB_NEG"),
+        &Vec::new(&env),
+        &Vec::new(&env),
+        &Vec::new(&env),
+        &create_test_emergency_contacts(&env),
+        &None,
+    );
+
+    client.record_dnr_order(&patient, &provider, &hash(&env, 33), &1700000000u64);
+    client.add_critical_alert(
+        &patient,
+        &provider,
+        &Symbol::new(&env, "CARDIAC"),
+        &hash(&env, 44),
+        &Symbol::new(&env, "HIGH"),
+    );
+
+    let mut guardians = Vec::new(&env);
+    guardians.push_back(guardian_1.clone());
+    guardians.push_back(guardian_2.clone());
+    client.set_recovery_config(&patient, &contact, &guardians, &2);
+
+    client.propose_recovery(&patient, &guardian_1, &new_owner);
+    client.propose_recovery(&patient, &guardian_2, &new_owner);
+
+    assert!(!client.has_emergency_profile(&patient));
+    assert!(client.has_emergency_profile(&new_owner));
+
+    let dnr = client.get_dnr_order(&new_owner, &new_owner).unwrap();
+    assert_eq!(dnr.dnr_document_hash, hash(&env, 33));
+
+    let alerts = client.get_critical_alerts(&new_owner, &new_owner);
+    assert_eq!(alerts.len(), 1);
+    assert_eq!(alerts.get(0).unwrap().alert_text_hash, hash(&env, 44));
+}
+
+#[test]
 fn test_dnr_with_advance_directives() {
     let env = Env::default();
     let contract_id = env.register(EmergencyMedicalInfo, ());

--- a/contracts/medical-device-tracking/src/lib.rs
+++ b/contracts/medical-device-tracking/src/lib.rs
@@ -452,6 +452,10 @@ impl MedicalDeviceRegistry {
             return Err(Error::DeviceNotActive);
         }
 
+        if provider_id != record.implanting_provider {
+            return Err(Error::NotAuthorized);
+        }
+
         record.is_active = false;
         record.removal_date = Some(removal_date);
         record.removal_reason = Some(removal_reason);

--- a/contracts/medical-device-tracking/src/test.rs
+++ b/contracts/medical-device-tracking/src/test.rs
@@ -465,6 +465,89 @@ fn test_remove_implant_already_inactive() {
 }
 
 #[test]
+fn test_remove_implant_rejects_unauthorized_provider() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = setup_client(&env);
+
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+    let other_provider = Address::generate(&env);
+    let manufacturer = Address::generate(&env);
+
+    let device_id = register_device_helper(&env, &client, &manufacturer);
+    let implant_id = client.implant_device(
+        &patient_id,
+        &device_id,
+        &provider_id,
+        &1700000000u64,
+        &String::from_str(&env, "Shoulder"),
+        &dummy_hash(&env),
+    );
+
+    // A provider who did not perform the implant attempts removal.
+    let res = client.try_remove_implant(
+        &implant_id,
+        &other_provider,
+        &1750000000u64,
+        &String::from_str(&env, "Unauthorized removal attempt"),
+        &None,
+    );
+    assert_eq!(res.unwrap_err().unwrap(), Error::NotAuthorized);
+}
+
+#[test]
+fn test_falsely_removed_implant_cannot_suppress_recall_notification() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = setup_client(&env);
+
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+    let other_provider = Address::generate(&env);
+    let manufacturer = Address::generate(&env);
+
+    let device_id = register_device_helper(&env, &client, &manufacturer);
+    let implant_id = client.implant_device(
+        &patient_id,
+        &device_id,
+        &provider_id,
+        &1700000000u64,
+        &String::from_str(&env, "Chest"),
+        &dummy_hash(&env),
+    );
+
+    // Unauthorized removal attempt must fail and not affect the implant.
+    let res = client.try_remove_implant(
+        &implant_id,
+        &other_provider,
+        &1740000000u64,
+        &String::from_str(&env, "Malicious removal"),
+        &None,
+    );
+    assert!(res.is_err());
+
+    let mut device_ids: Vec<u64> = Vec::new(&env);
+    device_ids.push_back(device_id);
+
+    let recall_id = client.issue_device_recall(
+        &manufacturer,
+        &device_ids,
+        &String::from_str(&env, "Battery failure risk"),
+        &Symbol::new(&env, "HIGH"),
+        &1750000000u64,
+        &String::from_str(&env, "Immediate replacement required"),
+    );
+
+    // The patient must still be surfaced for recall notification.
+    let affected = client.notify_affected_patients(&recall_id, &1750100000u64);
+    assert_eq!(affected.len(), 1);
+    assert!(affected.contains(patient_id));
+}
+
+#[test]
 fn test_track_device_performance_no_complications() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/multisig-governance/src/lib.rs
+++ b/contracts/multisig-governance/src/lib.rs
@@ -54,6 +54,8 @@ pub enum Error {
     AlreadySigner      = 12,
     /// Removing this signer would make the threshold unreachable.
     ThresholdBreached  = 13,
+    /// Removing this signer would make the quorum minimum unreachable.
+    QuorumBreached     = 14,
 }
 
 #[contracttype]
@@ -138,6 +140,9 @@ impl MultisigGovernance {
             return Err(Error::AlreadyInitialized);
         }
         if threshold == 0 || threshold as usize > signers.len() as usize {
+            return Err(Error::InvalidThreshold);
+        }
+        if quorum_min > signers.len() {
             return Err(Error::InvalidThreshold);
         }
         env.storage().persistent().set(&DataKey::Signers, &signers);
@@ -484,6 +489,15 @@ impl MultisigGovernance {
                 // After removal there must still be enough signers to meet threshold.
                 if signers.len() <= threshold {
                     return Err(Error::ThresholdBreached);
+                }
+                // After removal there must still be enough signers to meet quorum.
+                let quorum_min: u32 = env
+                    .storage()
+                    .persistent()
+                    .get(&DataKey::QuorumMin)
+                    .unwrap_or(0);
+                if signers.len() - 1 < quorum_min {
+                    return Err(Error::QuorumBreached);
                 }
                 // Target must be a current signer.
                 if !is_signer(&env, &signers, &target) {

--- a/contracts/multisig-governance/src/test.rs
+++ b/contracts/multisig-governance/src/test.rs
@@ -448,6 +448,20 @@ fn test_remove_signer_threshold_breach_returns_error() {
 }
 
 #[test]
+fn test_remove_signer_quorum_breach_returns_error() {
+    // 5 signers, threshold=3, quorum_min=5 → removing any signer would leave
+    // only 4 signers, making quorum_min=5 permanently unreachable.
+    let (_env, signers, client) = setup_with_quorum(5, 3, 5);
+    let s0 = signers.get(0).unwrap();
+    let s1 = signers.get(1).unwrap();
+    let err = client
+        .try_propose_signer_change(&s0, &SignerChangeKind::Remove, &s1)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::QuorumBreached);
+}
+
+#[test]
 fn test_remove_non_signer_returns_error() {
     let (env, signers, client) = setup(3, 2);
     let s0 = signers.get(0).unwrap();

--- a/contracts/nft-badges/src/lib.rs
+++ b/contracts/nft-badges/src/lib.rs
@@ -41,6 +41,7 @@ pub enum Error {
     /// Soulbound tokens may never be transferred.
     Soulbound         = 5,
     AlreadyMinted     = 6,
+    AlreadyRevoked    = 7,
 }
 
 #[contracttype]
@@ -60,6 +61,8 @@ pub struct BadgeMetadata {
     pub achievement: String,   // human-readable title
     pub issued_at:   u64,
     pub metadata_uri: String,  // IPFS / off-chain URI
+    pub revoked:      bool,
+    pub revoked_reason: Option<String>,
 }
 
 #[contract]
@@ -94,6 +97,20 @@ impl NftBadgesContract {
             return Err(Error::Unauthorized);
         }
 
+        let mut badges: Vec<u64> = env.storage().persistent()
+            .get(&DataKey::OwnerBadges(recipient.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        for existing_id in badges.iter() {
+            if let Some(existing) = env.storage().persistent()
+                .get::<_, BadgeMetadata>(&DataKey::Badge(existing_id))
+            {
+                if existing.badge_type == badge_type {
+                    return Err(Error::AlreadyMinted);
+                }
+            }
+        }
+
         let id: u64 = env.storage().instance()
             .get(&DataKey::NextId)
             .unwrap_or(1);
@@ -105,13 +122,12 @@ impl NftBadgesContract {
             achievement,
             issued_at:    env.ledger().timestamp(),
             metadata_uri,
+            revoked:      false,
+            revoked_reason: None,
         };
 
         env.storage().persistent().set(&DataKey::Badge(id), &badge);
 
-        let mut badges: Vec<u64> = env.storage().persistent()
-            .get(&DataKey::OwnerBadges(recipient.clone()))
-            .unwrap_or_else(|| Vec::new(&env));
         badges.push_back(id);
         env.storage().persistent().set(&DataKey::OwnerBadges(recipient.clone()), &badges);
 
@@ -127,6 +143,36 @@ impl NftBadgesContract {
     /// Always panics — badges are soulbound and non-transferable.
     pub fn transfer(_env: Env, _from: Address, _to: Address, _id: u64) -> Result<(), Error> {
         Err(Error::Soulbound)
+    }
+
+    /// Revoke a previously minted badge. Restricted to the stored admin.
+    /// The badge is flagged as revoked (with a reason) rather than deleted.
+    pub fn revoke(env: Env, admin: Address, badge_id: u64, reason: String) -> Result<(), Error> {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let mut badge: BadgeMetadata = env.storage().persistent()
+            .get(&DataKey::Badge(badge_id))
+            .ok_or(Error::BadgeNotFound)?;
+
+        if badge.revoked {
+            return Err(Error::AlreadyRevoked);
+        }
+
+        badge.revoked = true;
+        badge.revoked_reason = Some(reason);
+        env.storage().persistent().set(&DataKey::Badge(badge_id), &badge);
+
+        env.events().publish(
+            (symbol_short!("REVOKE"), badge.recipient),
+            badge_id,
+        );
+        Ok(())
     }
 
     pub fn get_badge(env: Env, id: u64) -> Result<BadgeMetadata, Error> {

--- a/contracts/nft-badges/src/test.rs
+++ b/contracts/nft-badges/src/test.rs
@@ -69,3 +69,40 @@ fn non_admin_cannot_mint() {
     let student  = Address::generate(&env);
     client.mint(&attacker, &student, &s(&env, "t"), &s(&env, "A"), &s(&env, "u"));
 }
+
+#[test]
+fn revoke_flags_badge_with_reason() {
+    let (env, client, admin) = setup();
+    let student = Address::generate(&env);
+    let id = client.mint(&admin, &student, &s(&env, "completion"), &s(&env, "A"), &s(&env, "u"));
+
+    client.revoke(&admin, &id, &s(&env, "fraudulent credential"));
+
+    let badge = client.get_badge(&id);
+    assert!(badge.revoked);
+    assert_eq!(badge.revoked_reason, Some(s(&env, "fraudulent credential")));
+}
+
+#[test]
+fn double_revoke_is_rejected() {
+    let (env, client, admin) = setup();
+    let student = Address::generate(&env);
+    let id = client.mint(&admin, &student, &s(&env, "completion"), &s(&env, "A"), &s(&env, "u"));
+
+    client.revoke(&admin, &id, &s(&env, "reason 1"));
+    let err = client.try_revoke(&admin, &id, &s(&env, "reason 2")).unwrap_err().unwrap();
+    assert_eq!(err, Error::AlreadyRevoked);
+}
+
+#[test]
+fn duplicate_mint_same_recipient_and_badge_type_is_rejected() {
+    let (env, client, admin) = setup();
+    let student = Address::generate(&env);
+    client.mint(&admin, &student, &s(&env, "completion"), &s(&env, "A"), &s(&env, "u1"));
+
+    let err = client
+        .try_mint(&admin, &student, &s(&env, "completion"), &s(&env, "B"), &s(&env, "u2"))
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::AlreadyMinted);
+}


### PR DESCRIPTION
bug: nft-badges — no revocation function exists despite the module docstring claiming revocation support Fixes #613

security: medical-device-tracking remove_implant has no check that provider_id is authorized for that implant Fixes #612

bug: emergency-medical-info propose_recovery migrates only EmergencyProfile, orphaning DNR orders, critical alerts, and access logs Fixes #602

security: multisig-governance — removing a signer doesn't validate against quorum_min, can permanently deadlock the contract Fixes #623

## Summary

<!-- What does this PR change and why? -->

## Changelog

- [ ] I have updated `CHANGELOG.md` for any user-facing contract API change (new functions, breaking changes, deprecations, or security fixes).

## Test plan

- [ ] Unit / integration tests added or updated
- [ ] `cargo test` passes locally (if applicable)
