### PR TITLE
fix(healthcare-analytics): correct stored_admin -> stored in propose_…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,35 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
+  check-healthcare-analytics:
+    name: Check healthcare-analytics
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-git-
+
+      - name: cargo check healthcare-analytics
+        run: cargo check -p healthcare-analytics
+
   format:
     name: Format Check
     runs-on: ubuntu-latest
@@ -168,12 +197,13 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [format, clippy, test, build-wasm]
+    needs: [check-healthcare-analytics, format, clippy, test, build-wasm]
     if: always()
     steps:
       - name: Check all jobs
         run: |
-          if [[ "${{ needs.format.result }}" != "success" ]] || \
+          if [[ "${{ needs.check-healthcare-analytics.result }}" != "success" ]] || \
+             [[ "${{ needs.format.result }}" != "success" ]] || \
              [[ "${{ needs.clippy.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \
              [[ "${{ needs.build-wasm.result }}" != "success" ]]; then

--- a/contracts/healthcare-analytics/src/lib.rs
+++ b/contracts/healthcare-analytics/src/lib.rs
@@ -548,7 +548,7 @@ impl HealthcareAnalytics {
             .instance()
             .get(&DataKey::Admin)
             .ok_or(Error::Unauthorized)?;
-        if admin != stored_admin {
+        if admin != stored {
             return Err(Error::Unauthorized);
         }
         if env.storage().instance().has(&DataKey::PendingAdmin) {

--- a/contracts/healthcare-analytics/src/test.rs
+++ b/contracts/healthcare-analytics/src/test.rs
@@ -909,3 +909,54 @@ fn test_cancel_report_executing() {
     let err_executing = client.try_cancel_report(&requester, &job_id);
     assert_eq!(err_executing, Err(Ok(Error::JobAlreadyExecuting)));
 }
+
+// ========================
+// Admin rotation tests
+// ========================
+
+#[test]
+fn test_propose_admin_rotation_rejects_non_admin() {
+    let (env, client, _admin) = setup_with_admin();
+
+    // A random address that was never set as admin.
+    let impostor = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    let result = client.try_propose_admin_rotation(&impostor, &new_admin);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_propose_admin_rotation_succeeds_for_admin() {
+    let (env, client, admin) = setup_with_admin();
+    let new_admin = Address::generate(&env);
+
+    // Current admin should be able to propose a rotation without error.
+    client.propose_admin_rotation(&admin, &new_admin);
+}
+
+#[test]
+fn test_propose_admin_rotation_rejects_duplicate_pending() {
+    let (env, client, admin) = setup_with_admin();
+    let new_admin_a = Address::generate(&env);
+    let new_admin_b = Address::generate(&env);
+
+    client.propose_admin_rotation(&admin, &new_admin_a);
+
+    // A second proposal before the first is accepted or expires must fail.
+    let result = client.try_propose_admin_rotation(&admin, &new_admin_b);
+    assert_eq!(result, Err(Ok(Error::RotationPending)));
+}
+
+#[test]
+fn test_accept_admin_rotation_rejects_wrong_pending_admin() {
+    let (env, client, admin) = setup_with_admin();
+    let new_admin = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    client.propose_admin_rotation(&admin, &new_admin);
+
+    // An address that is not the pending admin cannot accept.
+    let result = client.try_accept_admin_rotation(&other);
+    assert_eq!(result, Err(Ok(Error::NotPendingAdmin)));
+}


### PR DESCRIPTION
…admin_rotation

- Fix compile error: comparison used undeclared ; variable was bound as  a few lines above (missed rename)
- Add unit tests for propose_admin_rotation: rejects non-admin caller, rejects duplicate pending rotation, rejects wrong pending admin on accept
- Add cargo check -p healthcare-analytics job to CI and wire it into the ci-success gate so the crate must compile on every PR

## Summary

<!-- What does this PR change and why? -->

## Changelog

- [ ] I have updated `CHANGELOG.md` for any user-facing contract API change (new functions, breaking changes, deprecations, or security fixes).

## Test plan

- [ ] Unit / integration tests added or updated
- [ ] `cargo test` passes locally (if applicable)
- [ ] closes #584
