### PR TITLE
fix: bind treatment/care-plan mutators to owning provider and add mis…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,43 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all --check
 
+  check:
+    name: Cargo Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-git-
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-target-
+
+      - name: Run cargo check
+        run: cargo check --workspace --keep-going
+
   clippy:
     name: Clippy Lint
     runs-on: ubuntu-latest
@@ -168,12 +205,13 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [format, clippy, test, build-wasm]
+    needs: [format, check, clippy, test, build-wasm]
     if: always()
     steps:
       - name: Check all jobs
         run: |
           if [[ "${{ needs.format.result }}" != "success" ]] || \
+             [[ "${{ needs.check.result }}" != "success" ]] || \
              [[ "${{ needs.clippy.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \
              [[ "${{ needs.build-wasm.result }}" != "success" ]]; then

--- a/contracts/care-plan/src/lib.rs
+++ b/contracts/care-plan/src/lib.rs
@@ -33,6 +33,20 @@ use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Symbol, 
 use storage::*;
 use types::*;
 
+/// Returns true if `caller` is the plan's provider or an assigned care-team member.
+fn is_bound_to_plan(env: &Env, plan: &CarePlan, caller: &Address) -> bool {
+    if *caller == plan.provider_id {
+        return true;
+    }
+    let team = load_care_team(env, plan.care_plan_id);
+    for member in team.iter() {
+        if member.team_member == *caller {
+            return true;
+        }
+    }
+    false
+}
+
 #[contract]
 pub struct CarePlanContract;
 
@@ -92,8 +106,9 @@ impl CarePlanContract {
     ) -> Result<u64, Error> {
         provider_id.require_auth();
 
-        if load_care_plan(&env, care_plan_id).is_none() {
-            return Err(Error::CarePlanNotFound);
+        let plan = load_care_plan(&env, care_plan_id).ok_or(Error::CarePlanNotFound)?;
+        if !is_bound_to_plan(&env, &plan, &provider_id) {
+            return Err(Error::Unauthorized);
         }
 
         let goal_id = next_goal_id(&env);
@@ -134,8 +149,9 @@ impl CarePlanContract {
     ) -> Result<u64, Error> {
         provider_id.require_auth();
 
-        if load_care_plan(&env, care_plan_id).is_none() {
-            return Err(Error::CarePlanNotFound);
+        let plan = load_care_plan(&env, care_plan_id).ok_or(Error::CarePlanNotFound)?;
+        if !is_bound_to_plan(&env, &plan, &provider_id) {
+            return Err(Error::Unauthorized);
         }
 
         let intervention_id = next_intervention_id(&env);
@@ -174,6 +190,10 @@ impl CarePlanContract {
         patient_id.require_auth();
 
         let mut goal = load_goal(&env, goal_id).ok_or(Error::GoalNotFound)?;
+        let plan = load_care_plan(&env, goal.care_plan_id).ok_or(Error::CarePlanNotFound)?;
+        if patient_id != plan.patient_id {
+            return Err(Error::Unauthorized);
+        }
 
         if matches!(goal.status, GoalStatus::Achieved) {
             return Err(Error::GoalAlreadyAchieved);
@@ -245,8 +265,9 @@ impl CarePlanContract {
     ) -> Result<u64, Error> {
         reporter.require_auth();
 
-        if load_care_plan(&env, care_plan_id).is_none() {
-            return Err(Error::CarePlanNotFound);
+        let plan = load_care_plan(&env, care_plan_id).ok_or(Error::CarePlanNotFound)?;
+        if !is_bound_to_plan(&env, &plan, &reporter) {
+            return Err(Error::Unauthorized);
         }
 
         let barrier_id = next_barrier_id(&env);
@@ -316,8 +337,9 @@ impl CarePlanContract {
     ) -> Result<u64, Error> {
         provider_id.require_auth();
 
-        if load_care_plan(&env, care_plan_id).is_none() {
-            return Err(Error::CarePlanNotFound);
+        let plan = load_care_plan(&env, care_plan_id).ok_or(Error::CarePlanNotFound)?;
+        if !is_bound_to_plan(&env, &plan, &provider_id) {
+            return Err(Error::Unauthorized);
         }
 
         let review_id = next_review_id(&env);
@@ -359,6 +381,10 @@ impl CarePlanContract {
         provider_id.require_auth();
 
         let mut review = load_review(&env, review_id).ok_or(Error::ReviewNotFound)?;
+        let mut plan = load_care_plan(&env, review.care_plan_id).ok_or(Error::CarePlanNotFound)?;
+        if !is_bound_to_plan(&env, &plan, &provider_id) {
+            return Err(Error::Unauthorized);
+        }
 
         if review.conducted {
             return Err(Error::ReviewAlreadyConducted);
@@ -374,17 +400,14 @@ impl CarePlanContract {
         review.conducted_at = Some(conducted_at);
 
         // Update the parent care plan's last/next review dates
-        if let Some(mut plan) = load_care_plan(&env, review.care_plan_id) {
-            plan.last_review_date = Some(conducted_at);
-            plan.next_review_date = conducted_at + (plan.review_frequency_days as u64 * 86_400);
+        plan.last_review_date = Some(conducted_at);
+        plan.next_review_date = conducted_at + (plan.review_frequency_days as u64 * 86_400);
 
-            if !continue_plan {
-                plan.status = CarePlanStatus::Completed;
-            }
-
-            save_care_plan(&env, &plan);
+        if !continue_plan {
+            plan.status = CarePlanStatus::Completed;
         }
 
+        save_care_plan(&env, &plan);
         save_review(&env, &review);
 
         env.events().publish(
@@ -406,8 +429,9 @@ impl CarePlanContract {
     ) -> Result<(), Error> {
         coordinating_provider.require_auth();
 
-        if load_care_plan(&env, care_plan_id).is_none() {
-            return Err(Error::CarePlanNotFound);
+        let plan = load_care_plan(&env, care_plan_id).ok_or(Error::CarePlanNotFound)?;
+        if !is_bound_to_plan(&env, &plan, &coordinating_provider) {
+            return Err(Error::Unauthorized);
         }
 
         let mut team = load_care_team(&env, care_plan_id);

--- a/contracts/dental-records/src/lib.rs
+++ b/contracts/dental-records/src/lib.rs
@@ -237,6 +237,17 @@ impl DentalRecordsContract {
             .persistent()
             .get(&DataKey::Appt(appointment_id))
             .ok_or(Error::NotFound)?;
+
+        // #600 – ensure the caller is actually the dentist assigned to this treatment plan
+        let plan: TreatmentPlan = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Plan(appt.treatment_plan_id))
+            .ok_or(Error::NotFound)?;
+        if dentist_id != plan.dentist_id {
+            return Err(Error::Unauthorized);
+        }
+
         appt.is_completed = true;
         env.storage()
             .persistent()

--- a/contracts/nutrition-care-management/src/types.rs
+++ b/contracts/nutrition-care-management/src/types.rs
@@ -22,6 +22,7 @@ pub enum Error {
     ProviderNotAuthorized = 12,
     CarePlanContractNotConfigured = 13,
     OutcomeNotLinked = 14,
+    DietContraindicatedWithMedication = 15,
 }
 
 // -----------------------------------------------------------------------
@@ -289,6 +290,12 @@ pub enum DataKey {
     OutcomeCarePlanLink(u64),
     /// global care-plan contract address (#566)
     CarePlanContractAddress,
+    /// global prescription-management contract address (#562)
+    PrescriptionContractAddress,
+    /// diet_type → Vec<String> (contraindicated medications) (#562)
+    ContraindicationList(Symbol),
+    /// admin address authorized to manage contraindication lists (#562)
+    ContraindicationAdmin,
 }
 
 /// Paginated outcome history result (#566).

--- a/contracts/telemedicine/src/types.rs
+++ b/contracts/telemedicine/src/types.rs
@@ -23,6 +23,10 @@ pub enum Error {
     ProviderNotLicensedInPatientState = 14,
     /// Controlled substance requires in-person visit per jurisdiction policy
     ControlledSubstanceRequiresInPerson = 15,
+    /// Provider has exceeded the allowed session-creation rate limit
+    RateLimitExceeded = 16,
+    /// Provider is not registered in the provider registry
+    ProviderNotRegistered = 17,
 }
 
 /// On-chain record of a provider's license in a given jurisdiction (state/region).
@@ -138,4 +142,10 @@ pub enum DataKey {
     JurisdictionPolicy(String),
     /// jurisdiction -> bool (true = requires in-person for controlled substances)
     ControlledSubstancePolicy(String),
+    /// Global rate-limit configuration for session creation
+    RateLimitConfig,
+    /// provider_id -> current rate-limit window state
+    ProviderSessionWindow(Address),
+    /// Address of the external provider registry contract
+    ProviderRegistryAddress,
 }


### PR DESCRIPTION
…sing enum variants

bug: telemedicine fails to compile — rate-limit/provider-check feature references DataKey/Error variants missing from types.rs Fixes #590

bug: nutrition-care-management fails to compile
Fixes #592

security: care-plan mutators don't verify the caller is bound to the plan Fixes #593

security: dental-records document_procedure_performed doesn't verify the dentist is assigned to the treatment plan Fixes #600

## Summary

<!-- What does this PR change and why? -->

## Changelog

- [ ] I have updated `CHANGELOG.md` for any user-facing contract API change (new functions, breaking changes, deprecations, or security fixes).

## Test plan

- [ ] Unit / integration tests added or updated
- [ ] `cargo test` passes locally (if applicable)
