### PR TITLE
fix: prescription-management crate compile error - remove orphaned code from create_template #583

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,9 +702,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "fastrand"

--- a/contracts/prescription-management/src/lib.rs
+++ b/contracts/prescription-management/src/lib.rs
@@ -174,7 +174,9 @@ pub enum Error {
     MissingRecallReason = 28,
     /// Patient already has MAX_ACTIVE_PRESCRIPTIONS active prescriptions
     TooManyActivePrescriptions = 29,
-    StaleNonce = 30,
+    /// Provider has exceeded their per-window prescription issuance limit
+    RateLimitExceeded = 30,
+    StaleNonce = 31,
 }
 
 #[contracttype]
@@ -286,6 +288,14 @@ pub enum DataKey {
     PatientPrescriptions(Address),
     /// Per-caller nonce for replay attack protection: (caller) -> u64
     CallerNonce(Address),
+    /// Prescription template storage: (template_id) -> StoredTemplate
+    Template(u64),
+    /// Auto-incrementing counter for template IDs.
+    TemplateCounter,
+    /// Per-provider sliding-window prescription issuance limit override.
+    ProviderPrescriptionLimit(Address),
+    /// Per-provider sliding-window state (rate limiting).
+    ProviderPrescriptionWindow(Address),
 }
 
 #[contracttype]
@@ -568,82 +578,7 @@ impl PrescriptionContract {
             }
         }
 
-        // Allergy cross-check against allergy-management contract.
-        if req.bypass_allergy_check {
-            // Bypass requires admin role.
-            let admin: Option<Address> = env.storage().persistent().get(&DataKey::Admin);
-            match admin {
-                Some(ref a) if *a == provider_id => {}
-                _ => return Err(Error::AllergyBypassRequiresAdmin),
-            }
-        } else if let Some(allergy_addr) = env
-            .storage()
-            .persistent()
-            .get::<_, Address>(&DataKey::AllergyRegistry)
-        {
-            let allergy_client = AllergyManagementClient::new(&env, &allergy_addr);
-            let interactions =
-                allergy_client.check_drug_allergy_interaction(&patient_id, &req.medication_name);
-            if !interactions.is_empty() {
-                // Emit alert for every detected interaction.
-                for interaction in interactions.iter() {
-                    env.events().publish(
-                        (Symbol::new(&env, "allergy_interaction_alert"),),
-                        (
-                            patient_id.clone(),
-                            req.medication_name.clone(),
-                            interaction.allergen.clone(),
-                            interaction.severity.clone(),
-                        ),
-                    );
-                }
-                let strict: bool = env
-                    .storage()
-                    .persistent()
-                    .get(&DataKey::AllergyStrictMode)
-                    .unwrap_or(false);
-                if strict {
-                    return Err(Error::AllergyInteractionDetected);
-                }
-            }
-        }
-
-        // DEA registration check: controlled substances require a valid DEA number.
-        if req.is_controlled && req.schedule.is_some() {
-            match &req.dea_number {
-                None => return Err(Error::ControlledSubstanceViolation),
-                Some(dea) => {
-                    // A valid DEA number is always exactly 9 ASCII characters.
-                    // Reject anything that isn't 9 bytes long before byte extraction.
-                    // soroban_sdk::String::len() returns u32.
-                    if dea.len() != 9u32 {
-                        return Err(Error::ControlledSubstanceViolation);
-                    }
-                    let mut buf = [0u8; 9];
-                    dea.copy_into_slice(&mut buf);
-                    if !validate_dea_number(&buf) {
-                        return Err(Error::ControlledSubstanceViolation);
-                    }
-                }
-            }
-        }
-
-        // #215 – valid_until must be in the future and within a 1-year window
-        temporal::must_be_future(&env, req.valid_until)
-            .map_err(|_| Error::InvalidValidityWindow)?;
-        temporal::within_validity_window(
-            env.ledger().timestamp(),
-            req.valid_until,
-            shared::temporal::MAX_VALIDITY_WINDOW_SECS,
-        )
-        .map_err(|_| Error::InvalidValidityWindow)?;
-
-        // #478 – cap concurrent active prescriptions per patient.
-        if count_and_prune_active_prescriptions(&env, &patient_id) >= MAX_ACTIVE_PRESCRIPTIONS {
-            return Err(Error::TooManyActivePrescriptions);
-        }
-
-        let id = env
+        let template_id = env
             .storage()
             .instance()
             .get::<_, u64>(&DataKey::TemplateCounter)
@@ -673,8 +608,50 @@ impl PrescriptionContract {
             .set(&DataKey::Template(template_id), &stored);
         env.storage()
             .instance()
-            .set(&Symbol::new(&env, "ID_COUNTER"), &(id + 1));
-        add_patient_prescription(&env, &prescription.patient_id, id);
+            .set(&DataKey::TemplateCounter, &(template_id + 1));
+
+        Ok(template_id)
+    }
+
+    /// Issue a prescription from a reusable template created by the same provider.
+    /// Loads the template, constructs an IssueRequest from its fields, and delegates
+    /// to `do_issue_prescription`.
+    pub fn issue_from_template(
+        env: Env,
+        provider: Address,
+        patient: Address,
+        template_id: u64,
+        valid_until: u64,
+    ) -> Result<u64, Error> {
+        provider.require_auth();
+
+        let template: StoredTemplate = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Template(template_id))
+            .ok_or(Error::NotFound)?;
+
+        if template.provider != provider {
+            return Err(Error::Unauthorized);
+        }
+
+        let req = IssueRequest {
+            medication_name: template.medication_name,
+            ndc_code: template.ndc_code,
+            dosage: template.dosage,
+            quantity: template.quantity,
+            days_supply: template.days_supply,
+            refills_allowed: template.refills_allowed,
+            instructions_hash: template.instructions_hash,
+            is_controlled: template.is_controlled,
+            schedule: template.schedule,
+            valid_until,
+            substitution_allowed: template.substitution_allowed,
+            pharmacy_id: template.pharmacy_id,
+            bypass_allergy_check: template.bypass_allergy_check,
+            dea_number: template.dea_number,
+            bypass_reason_hash: template.bypass_reason_hash,
+        };
 
         do_issue_prescription(&env, provider, patient, req)
     }
@@ -1669,13 +1646,23 @@ fn do_issue_prescription(
         if let Some(_schedule) = req.schedule {
             match &req.dea_number {
                 Some(dea) => {
-                    if !validate_dea_number(dea.to_bytes().as_slice()) {
+                    if dea.len() != 9u32 {
+                        return Err(Error::ControlledSubstanceViolation);
+                    }
+                    let mut buf = [0u8; 9];
+                    dea.copy_into_slice(&mut buf);
+                    if !validate_dea_number(&buf) {
                         return Err(Error::ControlledSubstanceViolation);
                     }
                 }
                 None => return Err(Error::ControlledSubstanceViolation),
             }
         }
+    }
+
+    // ── #478: cap concurrent active prescriptions per patient ─────────────────
+    if count_and_prune_active_prescriptions(env, &patient_id) >= MAX_ACTIVE_PRESCRIPTIONS {
+        return Err(Error::TooManyActivePrescriptions);
     }
 
     // ── #480: rate-limit enforcement ──────────────────────────────────────────
@@ -1779,6 +1766,7 @@ fn do_issue_prescription(
     };
 
     env.storage().persistent().set(&rx_id, &prescription);
+    add_patient_prescription(env, &patient_id, rx_id);
 
     env.events().publish(
         (Symbol::new(env, "prescription_issued"),),

--- a/contracts/prescription-management/src/test.rs
+++ b/contracts/prescription-management/src/test.rs
@@ -132,6 +132,7 @@ fn max_cap_request(env: &Env, pharmacy: &Address, valid_until: u64) -> IssueRequ
         pharmacy_id: Some(pharmacy.clone()),
         bypass_allergy_check: false,
         dea_number: None,
+        bypass_reason_hash: None,
     }
 }
 

--- a/contracts/prescription-management/src/test_enhanced.rs
+++ b/contracts/prescription-management/src/test_enhanced.rs
@@ -790,8 +790,10 @@ fn test_rate_limit_exceeded_after_default_cap() {
     let provider = Address::generate(&env);
     let patient = Address::generate(&env);
 
-    // Set a tiny limit so we can exceed it quickly
-    client.configure_allergy_check(&admin, &admin, &false);
+    // Set admin directly without configuring allergy registry (avoids cross-contract call)
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    });
     client.set_provider_limit(&admin, &provider, &2);
 
     let make_req = |n: u8| -> IssueRequest {
@@ -832,7 +834,9 @@ fn test_rate_limit_resets_after_window() {
     let provider = Address::generate(&env);
     let patient = Address::generate(&env);
 
-    client.configure_allergy_check(&admin, &admin, &false);
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    });
     client.set_provider_limit(&admin, &provider, &1);
 
     let make_req = |ts: u64| -> IssueRequest {
@@ -880,7 +884,9 @@ fn test_admin_set_provider_limit_works() {
     let provider = Address::generate(&env);
     let patient = Address::generate(&env);
 
-    client.configure_allergy_check(&admin, &admin, &false);
+    env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    });
     // Default limit is 100; set to 3
     client.set_provider_limit(&admin, &provider, &3);
 
@@ -1056,4 +1062,79 @@ fn test_non_owning_provider_cannot_use_template() {
 
     let result = client.try_issue_from_template(&other, &patient, &template_id, &valid_until);
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+/// Regression test for #583: ensures create_template does not contain orphaned
+/// prescription-issuance logic and that create_template and issue_prescription
+/// can be called independently without cross-contamination.
+#[test]
+fn test_create_template_and_issue_prescription_independently() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(PrescriptionContract, ());
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+    let pharmacy = Address::generate(&env);
+
+    // Create a template independently — should succeed and return a template ID.
+    let template = PrescriptionTemplate {
+        medication_name: String::from_str(&env, "Lisinopril"),
+        ndc_code: String::from_str(&env, "00000-7777"),
+        dosage: String::from_str(&env, "10mg"),
+        quantity: 30,
+        days_supply: 30,
+        refills_allowed: 3,
+        instructions_hash: BytesN::from_array(&env, &[3u8; 32]),
+        is_controlled: false,
+        schedule: None,
+        substitution_allowed: true,
+        pharmacy_id: None,
+        bypass_allergy_check: false,
+        dea_number: None,
+        bypass_reason_hash: None,
+    };
+
+    let template_id = client.create_template(&provider, &template);
+    // Template IDs start at 0
+    assert_eq!(template_id, 0);
+
+    // Issue a prescription independently (not from template) — should succeed.
+    let req = IssueRequest {
+        medication_name: String::from_str(&env, "Amoxicillin"),
+        ndc_code: String::from_str(&env, "0501-1234-01"),
+        dosage: String::from_str(&env, "500mg"),
+        quantity: 30,
+        days_supply: 10,
+        refills_allowed: 2,
+        instructions_hash: BytesN::from_array(&env, &[0u8; 32]),
+        is_controlled: false,
+        schedule: None,
+        valid_until: env.ledger().timestamp() + 86_400 * 30,
+        substitution_allowed: true,
+        pharmacy_id: Some(pharmacy.clone()),
+        bypass_allergy_check: false,
+        dea_number: None,
+        bypass_reason_hash: None,
+    };
+
+    let rx_id = client.issue_prescription(&provider, &patient, &req);
+    // Prescription IDs start at 0 (RxCounter)
+    assert_eq!(rx_id, 0);
+
+    // Verify the prescription was stored independently
+    let stored: Prescription = env.as_contract(&contract_id, || {
+        env.storage().persistent().get(&rx_id).unwrap()
+    });
+    assert_eq!(stored.medication_name, String::from_str(&env, "Amoxicillin"));
+    assert_eq!(stored.provider_id, provider);
+    assert_eq!(stored.patient_id, patient);
+
+    // Verify the template still exists independently
+    let stored_template: StoredTemplate = env.as_contract(&contract_id, || {
+        env.storage().persistent().get(&DataKey::Template(template_id)).unwrap()
+    });
+    assert_eq!(stored_template.medication_name, String::from_str(&env, "Lisinopril"));
+    assert_eq!(stored_template.provider, provider);
 }

--- a/contracts/prescription-management/test_snapshots/test/test_fail_expired_prescription.1.json
+++ b/contracts/prescription-management/test_snapshots/test/test_fail_expired_prescription.1.json
@@ -33,6 +33,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "bypass_reason_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "days_supply"
                       },
                       "val": {
@@ -332,6 +338,117 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "PatientPrescriptions"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "PatientPrescriptions"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "u64": "0"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ProviderPrescriptionWindow"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ProviderPrescriptionWindow"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "count"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "window_start"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -353,7 +470,7 @@
                     "storage": [
                       {
                         "key": {
-                          "symbol": "ID_COUNTER"
+                          "symbol": "RxCounter"
                         },
                         "val": {
                           "u64": "1"

--- a/contracts/prescription-management/test_snapshots/test/test_prescription_lifecycle.1.json
+++ b/contracts/prescription-management/test_snapshots/test/test_prescription_lifecycle.1.json
@@ -33,6 +33,12 @@
                     },
                     {
                       "key": {
+                        "symbol": "bypass_reason_hash"
+                      },
+                      "val": "void"
+                    },
+                    {
+                      "key": {
                         "symbol": "days_supply"
                       },
                       "val": {
@@ -496,6 +502,117 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "PatientPrescriptions"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "PatientPrescriptions"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "vec": [
+                    {
+                      "u64": "0"
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ProviderPrescriptionWindow"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ProviderPrescriptionWindow"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "count"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "window_start"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }
@@ -517,7 +634,7 @@
                     "storage": [
                       {
                         "key": {
-                          "symbol": "ID_COUNTER"
+                          "symbol": "RxCounter"
                         },
                         "val": {
                           "u64": "1"


### PR DESCRIPTION
## Overview

Fix compile error in prescription-management crate by removing orphaned allergy-bypass, DEA-validation, and validity-window logic from create_template that was incorrectly merged from create_prescription.

## Related Issue

Closes #583

## Changes

- [FIX] Remove ~90 lines of orphaned prescription-issuance logic from create_template
- [RESTORE] create_template real body (template CRUD only)
- [ADD] issue_from_template function for template-based prescription issuance
- [ADD] Missing DataKey variants (Template, TemplateCounter, ProviderPrescriptionLimit, ProviderPrescriptionWindow)
- [ADD] Missing Error variant (RateLimitExceeded)
- [FIX] Add active-prescriptions cap and patient-prescription tracking to do_issue_prescription
- [FIX] Pre-existing rate-limit test failures (invalid allergy registry config)
- [ADD] Regression test calling create_template and issue_prescription independently

## Verification

```
cargo test -p prescription-management
✅ 43 passed, 0 failed
```