### PR TITLE
fix: close provider-registry & medical-claims security gaps (#669, #670, #671, #672)

### DIFF
--- a/contracts/medical-claims/src/lib.rs
+++ b/contracts/medical-claims/src/lib.rs
@@ -164,6 +164,7 @@ impl MedicalClaimsSystem {
         }
 
         validate_policy_metadata(&policy).map_err(|_| Error::InvalidPolicyMetadata)?;
+        Self::validate_claim_amounts(&service_codes, total_amount)?;
 
         // #300: Verify that the patient has granted consent to this provider
         // before creating a claim record (HIPAA compliance).
@@ -290,16 +291,18 @@ impl MedicalClaimsSystem {
             patient_responsibility,
         )?;
 
+        // Re-adjudicating an appealed claim must preserve any payments already
+        // recorded against the prior adjudication rather than wiping them out.
+        let is_reappeal = claim.status == ClaimStatus::Appealed;
+
         claim.status = ClaimStatus::Adjudicated;
         claim.approved_amount = Some(approved_amount);
         claim.patient_responsibility = Some(patient_responsibility);
-        claim.insurer_paid_amount = 0;
-        claim.patient_paid_amount = 0;
-        claim.reconciliation_status = if approved_amount == 0 && patient_responsibility == 0 {
-            ReconciliationStatus::FullyReconciled
-        } else {
-            ReconciliationStatus::Pending
-        };
+        if !is_reappeal {
+            claim.insurer_paid_amount = 0;
+            claim.patient_paid_amount = 0;
+        }
+        Self::refresh_reconciliation_status(&mut claim)?;
 
         env.storage()
             .persistent()
@@ -310,14 +313,16 @@ impl MedicalClaimsSystem {
         env.storage()
             .persistent()
             .set(&DataKey::DenialInfos(claim_id), &denied_lines);
-        env.storage().persistent().set(
-            &DataKey::ClaimPayment(claim_id),
-            &Vec::<InsurerPaymentRecord>::new(&env),
-        );
-        env.storage().persistent().set(
-            &DataKey::PatientPayment(claim_id),
-            &Vec::<PatientPaymentRecord>::new(&env),
-        );
+        if !is_reappeal {
+            env.storage().persistent().set(
+                &DataKey::ClaimPayment(claim_id),
+                &Vec::<InsurerPaymentRecord>::new(&env),
+            );
+            env.storage().persistent().set(
+                &DataKey::PatientPayment(claim_id),
+                &Vec::<PatientPaymentRecord>::new(&env),
+            );
+        }
 
         Ok(())
     }

--- a/contracts/medical-claims/src/test.rs
+++ b/contracts/medical-claims/src/test.rs
@@ -177,7 +177,7 @@ fn test_unregistered_insurer_cannot_adjudicate() {
         &Vec::new(&env),
         &BytesN::from_array(&env, &[0; 32]),
         &policy(&env),
-        &5000,
+        &15000,
     );
 
     let result =
@@ -203,7 +203,7 @@ fn test_wrong_insurer_cannot_adjudicate() {
         &Vec::new(&env),
         &BytesN::from_array(&env, &[0; 32]),
         &policy(&env),
-        &5000,
+        &15000,
     );
 
     let result = client.try_adjudicate_claim(
@@ -234,7 +234,7 @@ fn test_unregistered_insurer_cannot_process_payment() {
         &Vec::new(&env),
         &BytesN::from_array(&env, &[0; 32]),
         &policy(&env),
-        &5000,
+        &15000,
     );
 
     client.adjudicate_claim(
@@ -268,7 +268,7 @@ fn test_submit_claim_with_unregistered_insurer_fails() {
         &Vec::new(&env),
         &BytesN::from_array(&env, &[0; 32]),
         &policy(&env),
-        &5000,
+        &15000,
     );
     assert_eq!(result, Err(Ok(Error::InsurerNotRegistered)));
 }
@@ -289,7 +289,7 @@ fn test_appeal_workflow() {
         &Vec::new(&env),
         &BytesN::from_array(&env, &[1; 32]),
         &policy(&env),
-        &25000,
+        &15000,
     );
 
     let mut denials = Vec::new(&env);

--- a/contracts/provider-registry/src/lib.rs
+++ b/contracts/provider-registry/src/lib.rs
@@ -54,6 +54,7 @@ pub enum Error {
     RotationExpired    = 10,
     NotPendingAdmin    = 11,
     StaleNonce         = 12,
+    AlreadyExists      = 13,
 }
 
 /// Input entry for `batch_register_providers`.
@@ -110,7 +111,7 @@ pub enum DataKey {
     Initialized,
     Admin,
     Provider(Address),
-    Record(String),
+    Record(Address, String),
     ProviderRecords(Address),
     ProviderRecordCount(Address),
     RateLimitConfig,
@@ -157,6 +158,10 @@ impl ProviderRegistry {
         validate_nonzero_address(&provider).map_err(|_| Error::InvalidAddress)?;
         validate_nonzero_address(&issuer).map_err(|_| Error::InvalidAddress)?;
         Self::assert_admin(&env, &admin)?;
+        let key = DataKey::Provider(provider.clone());
+        if env.storage().persistent().has(&key) {
+            return Err(Error::AlreadyExists);
+        }
         let profile = ProviderProfile {
             name,
             specialty,
@@ -171,9 +176,7 @@ impl ProviderRegistry {
             },
             active: true,
         };
-        env.storage()
-            .persistent()
-            .set(&DataKey::Provider(provider.clone()), &profile);
+        env.storage().persistent().set(&key, &profile);
         env.events()
             .publish((symbol_short!("reg_prov"), provider), symbol_short!("ok"));
         Ok(())
@@ -251,6 +254,30 @@ impl ProviderRegistry {
         Ok(())
     }
 
+    /// Reactivate a previously revoked provider without altering their credential
+    /// anchor. Distinct from `register_provider`, which now rejects re-registration
+    /// of an existing address, and emits its own event for audit-trail clarity.
+    pub fn reactivate_provider(env: Env, admin: Address, provider: Address) -> Result<(), Error> {
+        Self::assert_initialized(&env)?;
+        validate_nonzero_address(&admin).map_err(|_| Error::InvalidAddress)?;
+        validate_nonzero_address(&provider).map_err(|_| Error::InvalidAddress)?;
+        Self::assert_admin(&env, &admin)?;
+        let key = DataKey::Provider(provider.clone());
+        let mut profile: ProviderProfile = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(Error::RecordNotFound)?;
+
+        profile.active = true;
+        profile.credential.revoked_at = None;
+        env.storage().persistent().set(&key, &profile);
+
+        env.events()
+            .publish((symbol_short!("react_pr"), provider), symbol_short!("ok"));
+        Ok(())
+    }
+
     pub fn is_provider(env: Env, provider: Address) -> bool {
         Self::is_provider_active(&env, &provider)
     }
@@ -288,16 +315,33 @@ impl ProviderRegistry {
         }
         env.storage()
             .persistent()
-            .set(&DataKey::Record(record_id.clone()), &data);
+            .set(&DataKey::Record(provider.clone(), record_id.clone()), &data);
         env.events()
             .publish((symbol_short!("add_rec"), provider, record_id), symbol_short!("ok"));
         Ok(())
     }
 
-    pub fn get_record(env: Env, record_id: String) -> Result<String, Error> {
+    /// Fetch a provider's record. `requester` must authenticate and be either the
+    /// owning provider or the admin — records are scoped per-provider and are not
+    /// globally readable given the module's HIPAA framing.
+    pub fn get_record(
+        env: Env,
+        requester: Address,
+        provider: Address,
+        record_id: String,
+    ) -> Result<String, Error> {
+        requester.require_auth();
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        if requester != provider && requester != admin {
+            return Err(Error::Unauthorized);
+        }
         env.storage()
             .persistent()
-            .get(&DataKey::Record(record_id))
+            .get(&DataKey::Record(provider, record_id))
             .ok_or(Error::RecordNotFound)
     }
 

--- a/contracts/provider-registry/src/test.rs
+++ b/contracts/provider-registry/src/test.rs
@@ -1,10 +1,8 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{
-use shared::test_utils::{dummy_hash};
-    testutils::Address as _, Address, BytesN, Env, String,
-};
+use shared::test_utils::dummy_hash;
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String};
 
 
 fn register_provider_with_anchor(
@@ -159,7 +157,7 @@ fn test_add_record_by_whitelisted_provider() {
         &String::from_str(&env, "Patient data"),
     );
     assert_eq!(
-        client.get_record(&String::from_str(&env, "REC001")),
+        client.get_record(&provider, &provider, &String::from_str(&env, "REC001")),
         String::from_str(&env, "Patient data")
     );
 }
@@ -200,9 +198,9 @@ fn test_add_record_after_revocation_returns_error() {
 
 #[test]
 fn test_get_missing_record_returns_error() {
-    let (env, _, client) = setup();
+    let (env, admin, client) = setup();
     let err = client
-        .try_get_record(&String::from_str(&env, "MISSING"))
+        .try_get_record(&admin, &admin, &String::from_str(&env, "MISSING"))
         .unwrap_err()
         .unwrap();
     assert_eq!(err, Error::RecordNotFound);


### PR DESCRIPTION
## Summary

Fixes four related security issues across `provider-registry` and `medical-claims`:

- **closes #672 ** — `register_provider` silently overwrote (and un-revoked) an existing provider profile. It now rejects re-registration of an existing address, matching `batch_register_providers`'s guard (`Error::AlreadyExists`). Added a dedicated `reactivate_provider` admin path (with its own `react_pr` event) for intentional reactivation, so it's distinguishable from a first-time registration in the audit trail.
- **closes #671  ** — `add_record`/`get_record` used a single global `record_id` keyspace with no ownership check and no auth on reads. Records are now scoped per-provider (`DataKey::Record(provider, record_id)`), and `get_record` requires an authenticated `requester` who must be either the owning provider or the admin.
- **closes #670 ** — `adjudicate_claim` unconditionally zeroed `insurer_paid_amount`/`patient_paid_amount` and wiped the `ClaimPayment`/`PatientPayment` vectors on every call, including when re-adjudicating a claim after `appeal_denial`. It now only resets those on first adjudication (`Submitted` → `Adjudicated`); re-adjudication of an `Appealed` claim preserves prior payment amounts/history and reconciles via the existing `refresh_reconciliation_status` helper (which itself rejects an inconsistent re-adjudication where already-paid amounts would exceed the newly approved amount).
- **closes #669 ** — `validate_claim_amounts()` was dead code; `submit_claim` stored the caller-supplied `total_amount` with no relation to `service_codes`. `submit_claim` now calls `validate_claim_amounts()` and rejects claims whose `total_amount` doesn't equal the sum of line-item `charge_amount`s.

## Notes

- Existing test fixtures that called `get_record`/`register_provider`/`submit_claim` with signatures/amounts affected by these fixes were updated to keep them compiling and passing (no new test coverage was added per scope).
- No Rust toolchain was available in this environment to run `cargo test`; changes were verified by careful manual review of all call sites, including cross-crate dependents (`allergy-management`, `patient-registry`) of `provider-registry`.

## Test plan

- [ ] `cargo test -p provider-registry`
- [ ] `cargo test -p medical-claims`