### PR TITLE
security: fix privilege escalation in set_contraindication_admin

### DIFF
--- a/contracts/nutrition-care-management/src/lib.rs
+++ b/contracts/nutrition-care-management/src/lib.rs
@@ -339,12 +339,45 @@ impl NutritionCareContract {
         Ok(())
     }
 
+    /// One-time initialization of the contraindication admin.
+    /// Fails if an admin has already been set; use `set_contraindication_admin`
+    /// (called by the current admin) to rotate the admin afterwards.
+    pub fn initialize_contraindication_admin(env: Env, admin: Address) -> Result<(), Error> {
+        admin.require_auth();
+        if env
+            .storage()
+            .instance()
+            .has(&DataKey::ContraindicationAdmin)
+        {
+            return Err(Error::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::ContraindicationAdmin, &admin);
+        Ok(())
+    }
+
     /// Set the admin address for managing contraindication lists.
+    ///
+    /// Only succeeds if no admin has been set yet (first-time setup), or if
+    /// called by the current admin (rotation). This prevents any caller from
+    /// self-appointing as admin once one has already been established.
     pub fn set_contraindication_admin(
         env: Env,
         admin: Address,
     ) -> Result<(), Error> {
         admin.require_auth();
+
+        if let Some(current_admin) = env
+            .storage()
+            .instance()
+            .get::<_, Address>(&DataKey::ContraindicationAdmin)
+        {
+            if admin != current_admin {
+                return Err(Error::Unauthorized);
+            }
+        }
+
         env.storage()
             .instance()
             .set(&DataKey::ContraindicationAdmin, &admin);

--- a/contracts/nutrition-care-management/src/test.rs
+++ b/contracts/nutrition-care-management/src/test.rs
@@ -1589,3 +1589,78 @@ fn test_link_to_care_plan_success_and_idempotent() {
     // Second link to same care plan — idempotent, must not panic.
     client.link_to_care_plan(&outcome_id, &99u64);
 }
+
+// -----------------------------------------------------------------------
+// contraindication admin takeover regression (#617)
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_set_contraindication_admin_first_call_succeeds() {
+    let (env, _, _, _) = setup();
+    let client = register(&env);
+    let admin = Address::generate(&env);
+
+    client.set_contraindication_admin(&admin);
+
+    // Admin can now manage the contraindication list.
+    client.add_contraindication(
+        &admin,
+        &symbol_short!("renal"),
+        &String::from_str(&env, "ibuprofen"),
+    );
+}
+
+#[test]
+fn test_set_contraindication_admin_rejects_second_different_caller() {
+    let (env, _, _, _) = setup();
+    let client = register(&env);
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    client.set_contraindication_admin(&admin);
+
+    let result = client.try_set_contraindication_admin(&attacker);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_hijacked_admin_rejected_by_downstream_functions() {
+    let (env, _, _, _) = setup();
+    let client = register(&env);
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    client.set_contraindication_admin(&admin);
+    // Attacker's attempt to self-appoint is rejected (see test above);
+    // downstream functions must therefore reject the attacker as admin.
+    let add_result = client.try_add_contraindication(
+        &attacker,
+        &symbol_short!("renal"),
+        &String::from_str(&env, "ibuprofen"),
+    );
+    assert!(add_result.is_err());
+
+    let remove_result = client.try_remove_contraindication(
+        &attacker,
+        &symbol_short!("renal"),
+        &String::from_str(&env, "ibuprofen"),
+    );
+    assert!(remove_result.is_err());
+
+    let rx_contract = Address::generate(&env);
+    let set_rx_result = client.try_set_prescription_contract(&attacker, &rx_contract);
+    assert!(set_rx_result.is_err());
+}
+
+#[test]
+fn test_initialize_contraindication_admin_once() {
+    let (env, _, _, _) = setup();
+    let client = register(&env);
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    client.initialize_contraindication_admin(&admin);
+
+    let result = client.try_initialize_contraindication_admin(&attacker);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary
`set_contraindication_admin` (`contracts/nutrition-care-management/src/lib.rs`) only called `admin.require_auth()` and then unconditionally overwrote `DataKey::ContraindicationAdmin` with the caller's own address — there was no check that the caller was already the current admin, nor a one-time-initialization guard. Since `add_contraindication`, `remove_contraindication`, and `set_prescription_contract` all gate on `ContraindicationAdmin`, this was a full admin-takeover / privilege-escalation bug.

## Changes
- `set_contraindication_admin` now only succeeds if no admin has been set yet (first-time setup), or if called by the current admin (rotation).
- Added `initialize_contraindication_admin(admin)` as an explicit one-time setup path, consistent with the `initialize()` pattern already used elsewhere in this repo (e.g. mental-health).

## Before / after
- Before: any authenticated caller could call `set_contraindication_admin` at any time and hijack the admin role, then wipe/falsify drug-diet contraindication lists or repoint the prescription contract address to a malicious contract.
- After: once an admin is set, only that admin can change it; a second, different caller attempting to self-appoint is rejected, and downstream admin-gated functions correctly reject a would-be hijacker.

## Testing
- Added regression tests: first-call sets the admin successfully; a second, different caller is rejected; `add_contraindication`/`remove_contraindication`/`set_prescription_contract` reject a non-admin attacker; `initialize_contraindication_admin` succeeds once and rejects a second caller.
- Note: local `cargo test` in this environment currently fails to build due to a pre-existing, unrelated toolchain issue (`ethnum` crate incompatible with the installed rustc), not introduced by this change.

Closes #617