### PR TITLE
fix: patch four critical access-control and fund-safety gaps

### DIFF
--- a/contracts/allergy-tracking/src/lib.rs
+++ b/contracts/allergy-tracking/src/lib.rs
@@ -130,6 +130,8 @@ pub enum DataKey {
     PatientAllergies(Address),
     SeverityHistory(u64),
     DrugCrossSensitivity(String),
+    AccessControl(Address, Address),
+    GrantedProviders(Address),
 }
 
 /// A single entry in a batch allergy recording request.
@@ -541,6 +543,47 @@ impl AllergyTrackingContract {
         Ok(())
     }
 
+    /// Grant a provider access to a patient's allergy records. Only the patient can grant.
+    pub fn grant_access(env: Env, patient_id: Address, provider_id: Address) {
+        patient_id.require_auth();
+
+        let key = DataKey::AccessControl(patient_id.clone(), provider_id.clone());
+        env.storage().persistent().set(&key, &true);
+
+        let index_key = DataKey::GrantedProviders(patient_id.clone());
+        let mut providers: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&index_key)
+            .unwrap_or(Vec::new(&env));
+        if !Self::vec_contains_address(&providers, &provider_id) {
+            providers.push_back(provider_id);
+            env.storage().persistent().set(&index_key, &providers);
+        }
+    }
+
+    /// Revoke a previously granted provider's access. Only the patient can revoke.
+    pub fn revoke_access(env: Env, patient_id: Address, provider_id: Address) {
+        patient_id.require_auth();
+
+        let key = DataKey::AccessControl(patient_id.clone(), provider_id.clone());
+        env.storage().persistent().remove(&key);
+
+        let index_key = DataKey::GrantedProviders(patient_id.clone());
+        let providers: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&index_key)
+            .unwrap_or(Vec::new(&env));
+        let mut updated: Vec<Address> = Vec::new(&env);
+        for p in providers.iter() {
+            if p != provider_id {
+                updated.push_back(p);
+            }
+        }
+        env.storage().persistent().set(&index_key, &updated);
+    }
+
     /// Check for drug allergy interactions
     pub fn check_drug_allergy_interaction(
         env: Env,
@@ -549,6 +592,9 @@ impl AllergyTrackingContract {
         drug_name: String,
     ) -> Result<Vec<InteractionWarning>, Error> {
         requester.require_auth();
+        if !Self::check_access(&env, &patient_id, &requester) {
+            return Err(Error::Unauthorized);
+        }
         let patient_key = DataKey::PatientAllergies(patient_id.clone());
         let patient_allergies: Vec<u64> = env
             .storage()
@@ -609,6 +655,9 @@ impl AllergyTrackingContract {
         requester: Address,
     ) -> Result<Vec<AllergyRecord>, Error> {
         requester.require_auth();
+        if !Self::check_access(&env, &patient_id, &requester) {
+            return Err(Error::Unauthorized);
+        }
 
         let patient_key = DataKey::PatientAllergies(patient_id);
         let patient_allergies: Vec<u64> = env
@@ -662,7 +711,9 @@ impl AllergyTrackingContract {
     }
 
     /// Get a specific record by ID. Soft-deleted records are treated as not found.
-    pub fn get_record(env: Env, record_id: u64) -> Result<AllergyRecord, Error> {
+    pub fn get_record(env: Env, record_id: u64, requester: Address) -> Result<AllergyRecord, Error> {
+        requester.require_auth();
+
         let allergy: AllergyRecord = env
             .storage()
             .persistent()
@@ -671,6 +722,10 @@ impl AllergyTrackingContract {
 
         if allergy.is_deleted {
             return Err(Error::AllergyNotFound);
+        }
+
+        if !Self::check_access(&env, &allergy.patient_id, &requester) {
+            return Err(Error::Unauthorized);
         }
 
         Ok(allergy)
@@ -688,6 +743,9 @@ impl AllergyTrackingContract {
         requester.require_auth();
 
         if include_deleted && !Self::is_admin(&env, &requester) {
+            return Err(Error::Unauthorized);
+        }
+        if !Self::check_access(&env, &patient_id, &requester) {
             return Err(Error::Unauthorized);
         }
 
@@ -716,8 +774,8 @@ impl AllergyTrackingContract {
     }
 
     /// Get a specific allergy record
-    pub fn get_allergy(env: Env, allergy_id: u64) -> Result<AllergyRecord, Error> {
-        Self::get_record(env, allergy_id)
+    pub fn get_allergy(env: Env, allergy_id: u64, requester: Address) -> Result<AllergyRecord, Error> {
+        Self::get_record(env, allergy_id, requester)
     }
 
     /// Get severity update history for an allergy
@@ -879,6 +937,29 @@ impl AllergyTrackingContract {
     }
 
     fn vec_contains(vec: &Vec<String>, item: &String) -> bool {
+        for v in vec.iter() {
+            if v == *item {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Check whether `requester` is allowed to read `patient_id`'s records:
+    /// the patient themselves, the contract admin, or a provider the patient
+    /// has explicitly granted access to via `grant_access`.
+    fn check_access(env: &Env, patient_id: &Address, requester: &Address) -> bool {
+        if patient_id == requester {
+            return true;
+        }
+        if Self::is_admin(env, requester) {
+            return true;
+        }
+        let key = DataKey::AccessControl(patient_id.clone(), requester.clone());
+        env.storage().persistent().has(&key)
+    }
+
+    fn vec_contains_address(vec: &Vec<Address>, item: &Address) -> bool {
         for v in vec.iter() {
             if v == *item {
                 return true;

--- a/contracts/clinical-trial/src/lib.rs
+++ b/contracts/clinical-trial/src/lib.rs
@@ -344,7 +344,7 @@ impl ClinicalTrialContract {
         validation::validate_date_not_future(&env, enrollment_date)?;
 
         // Verify informed consent hash matches current consent version
-        if !Self::is_valid_consent(&env, &informed_consent_hash) {
+        if !Self::is_valid_consent(&env, trial_record_id, &informed_consent_hash) {
             return Err(Error::InvalidConsent);
         }
 
@@ -404,14 +404,37 @@ impl ClinicalTrialContract {
         Ok(enrollment_id)
     }
 
-    /// Check if the informed consent hash matches the current consent version
-    fn is_valid_consent(env: &Env, informed_consent_hash: &BytesN<32>) -> bool {
-        // In a real implementation, this would invoke the patient registry contract
-        // For now, return true as placeholder
-        // let patient_registry: Address = env.storage().instance().get(&DataKey::PatientRegistry).unwrap();
-        // let current_version: BytesN<32> = env.invoke_contract(&patient_registry, &symbol_short!("get_consent_version"), ()).unwrap();
-        // informed_consent_hash == &current_version
-        true
+    /// Set the current informed-consent document hash for a trial. Only the
+    /// trial's principal investigator may update it.
+    pub fn set_consent_version(
+        env: Env,
+        principal_investigator: Address,
+        trial_record_id: u64,
+        consent_hash: BytesN<32>,
+    ) -> Result<(), Error> {
+        principal_investigator.require_auth();
+
+        let trial = storage::get_trial(&env, trial_record_id)?;
+        if trial.principal_investigator != principal_investigator {
+            return Err(Error::Unauthorized);
+        }
+
+        storage::set_consent_version(&env, trial_record_id, &consent_hash);
+        Ok(())
+    }
+
+    /// Check if the informed consent hash matches the trial's current consent version.
+    /// Fails closed: if no consent version has been configured for the trial, no hash
+    /// can be considered valid.
+    fn is_valid_consent(
+        env: &Env,
+        trial_record_id: u64,
+        informed_consent_hash: &BytesN<32>,
+    ) -> bool {
+        match storage::get_consent_version(env, trial_record_id) {
+            Some(current_version) => &current_version == informed_consent_hash,
+            None => false,
+        }
     }
 
     /// Record a study visit
@@ -918,7 +941,7 @@ impl ClinicalTrialContract {
         validation::validate_date_not_future(&env, enrollment_date)?;
 
         // Validate consent
-        if !Self::is_valid_consent(&env, &informed_consent_hash) {
+        if !Self::is_valid_consent(&env, trial_record_id, &informed_consent_hash) {
             return Err(Error::InvalidConsent);
         }
 
@@ -1017,7 +1040,7 @@ impl ClinicalTrialContract {
 
         validation::validate_date_not_future(&env, enrollment_date)?;
 
-        if !Self::is_valid_consent(&env, &new_consent_hash) {
+        if !Self::is_valid_consent(&env, trial_record_id, &new_consent_hash) {
             return Err(Error::InvalidConsent);
         }
 

--- a/contracts/clinical-trial/src/storage.rs
+++ b/contracts/clinical-trial/src/storage.rs
@@ -1,5 +1,5 @@
 use shared_contracts::safe_increment;
-use soroban_sdk::{Address, Env, Vec};
+use soroban_sdk::{Address, BytesN, Env, Vec};
 
 use crate::{
     AdverseEventReport, ClinicalTrial, DataKey, EligibilityCriteria, Error,
@@ -285,4 +285,18 @@ pub fn get_amendment_log(env: &Env, trial_record_id: u64) -> Vec<ProtocolAmendme
         .persistent()
         .get(&DataKey::AmendmentLog(trial_record_id))
         .unwrap_or(Vec::new(env))
+}
+
+/// Set the current informed-consent document hash for a trial.
+pub fn set_consent_version(env: &Env, trial_record_id: u64, consent_hash: &BytesN<32>) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::ConsentVersion(trial_record_id), consent_hash);
+}
+
+/// Get the current informed-consent document hash for a trial, if one has been set.
+pub fn get_consent_version(env: &Env, trial_record_id: u64) -> Option<BytesN<32>> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ConsentVersion(trial_record_id))
 }

--- a/contracts/clinical-trial/src/types.rs
+++ b/contracts/clinical-trial/src/types.rs
@@ -278,4 +278,6 @@ pub enum DataKey {
     TrialPhaseProtocol(u64),
     /// Ordered list of ProtocolAmendment records for a trial (#485).
     AmendmentLog(u64),
+    /// Current informed-consent document hash for a trial, set by the PI.
+    ConsentVersion(u64),
 }

--- a/contracts/healthcare-credentialing/src/lib.rs
+++ b/contracts/healthcare-credentialing/src/lib.rs
@@ -48,6 +48,7 @@ pub enum Error {
     NotSuspended = 10,
     CredentialExpired = 11,
     RecredentialingInProgress = 12,
+    AlreadyInitialized = 13,
 }
 
 #[contracttype]
@@ -221,6 +222,9 @@ pub enum DataKey {
     ProviderFacilitySuspensions(Address, Address),
     ProviderFacilityReinstatements(Address, Address),
     ActiveRecredentialingCases(Address, Address),
+    Admin,
+    AuthorizedVerifier(Address),
+    CommitteeMember(Address),
 }
 
 #[contract]
@@ -228,6 +232,57 @@ pub struct HealthcareCredentialingSystem;
 
 #[contractimpl]
 impl HealthcareCredentialingSystem {
+    /// Initialize the contract with an admin, who alone may register authorized
+    /// verifiers and credentialing-committee members.
+    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+        admin.require_auth();
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    /// Register an address as an authorized credential verifier. Admin only.
+    pub fn add_authorized_verifier(env: Env, admin: Address, verifier: Address) -> Result<(), Error> {
+        admin.require_auth();
+        require_admin(&env, &admin)?;
+        env.storage()
+            .persistent()
+            .set(&DataKey::AuthorizedVerifier(verifier), &true);
+        Ok(())
+    }
+
+    /// Revoke an address's authorized-verifier status. Admin only.
+    pub fn remove_authorized_verifier(env: Env, admin: Address, verifier: Address) -> Result<(), Error> {
+        admin.require_auth();
+        require_admin(&env, &admin)?;
+        env.storage()
+            .persistent()
+            .remove(&DataKey::AuthorizedVerifier(verifier));
+        Ok(())
+    }
+
+    /// Register an address as a credentialing-committee member. Admin only.
+    pub fn add_committee_member(env: Env, admin: Address, member: Address) -> Result<(), Error> {
+        admin.require_auth();
+        require_admin(&env, &admin)?;
+        env.storage()
+            .persistent()
+            .set(&DataKey::CommitteeMember(member), &true);
+        Ok(())
+    }
+
+    /// Revoke an address's credentialing-committee membership. Admin only.
+    pub fn remove_committee_member(env: Env, admin: Address, member: Address) -> Result<(), Error> {
+        admin.require_auth();
+        require_admin(&env, &admin)?;
+        env.storage()
+            .persistent()
+            .remove(&DataKey::CommitteeMember(member));
+        Ok(())
+    }
+
     pub fn initiate_credentialing(
         env: Env,
         provider_id: Address,
@@ -276,13 +331,18 @@ impl HealthcareCredentialingSystem {
     pub fn submit_credential_document(
         env: Env,
         case_id: u64,
+        caller: Address,
         document_type: Symbol, // medical_license, dea, board_cert, cv, references
         document_hash: BytesN<32>,
         issuing_authority: String,
         issue_date: u64,
         expiration_date: Option<u64>,
     ) -> Result<(), Error> {
+        caller.require_auth();
         let mut case = get_case(&env, case_id)?;
+        if caller != case.provider_id {
+            return Err(Error::NotAuthorized);
+        }
         if !is_supported_credential_type(&env, &document_type) {
             return Err(Error::InvalidCredentialType);
         }
@@ -322,6 +382,9 @@ impl HealthcareCredentialingSystem {
         verification_notes: String,
     ) -> Result<(), Error> {
         verifier.require_auth();
+        if !is_authorized_verifier(&env, &verifier) {
+            return Err(Error::NotAuthorized);
+        }
         let mut case = get_case(&env, case_id)?;
 
         let docs: Vec<CredentialDocument> = env
@@ -378,6 +441,9 @@ impl HealthcareCredentialingSystem {
         check_date: u64,
     ) -> Result<(), Error> {
         checker.require_auth();
+        if !is_authorized_verifier(&env, &checker) {
+            return Err(Error::NotAuthorized);
+        }
         let mut case = get_case(&env, case_id)?;
 
         let mut checks: Vec<SanctionCheckRecord> = env
@@ -413,6 +479,9 @@ impl HealthcareCredentialingSystem {
         recommended: bool,
     ) -> Result<(), Error> {
         reference_provider.require_auth();
+        if !is_authorized_verifier(&env, &reference_provider) {
+            return Err(Error::NotAuthorized);
+        }
         let mut case = get_case(&env, case_id)?;
         validate_competency_ratings(&competency_ratings)?;
 
@@ -450,6 +519,9 @@ impl HealthcareCredentialingSystem {
         expiration_date: u64,
     ) -> Result<(), Error> {
         credentialing_committee.require_auth();
+        if !is_committee_member(&env, &credentialing_committee) {
+            return Err(Error::NotAuthorized);
+        }
         let mut case = get_case(&env, case_id)?;
         if case.status != CredentialingStatus::CommitteeReview {
             return Err(Error::InvalidStatusTransition);
@@ -996,6 +1068,9 @@ impl HealthcareCredentialingSystem {
         new_expiration_date: u64,
     ) -> Result<(), Error> {
         credentialing_committee.require_auth();
+        if !is_committee_member(&env, &credentialing_committee) {
+            return Err(Error::NotAuthorized);
+        }
         let mut case = get_case(&env, case_id)?;
 
         if case.case_type != Symbol::new(&env, "reappointment") {
@@ -1048,6 +1123,32 @@ fn get_case(env: &Env, case_id: u64) -> Result<CredentialingCase, Error> {
         .persistent()
         .get(&DataKey::Case(case_id))
         .ok_or(Error::CaseNotFound)
+}
+
+fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(Error::NotAuthorized)?;
+    if admin != *caller {
+        return Err(Error::NotAuthorized);
+    }
+    Ok(())
+}
+
+fn is_authorized_verifier(env: &Env, addr: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::AuthorizedVerifier(addr.clone()))
+        .unwrap_or(false)
+}
+
+fn is_committee_member(env: &Env, addr: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CommitteeMember(addr.clone()))
+        .unwrap_or(false)
 }
 
 fn is_supported_credential_type(env: &Env, credential_type: &Symbol) -> bool {

--- a/contracts/liquidity-pool/src/lib.rs
+++ b/contracts/liquidity-pool/src/lib.rs
@@ -24,7 +24,7 @@
 //! mathematically. Reserve balances cryptographically signed via Soroban state.
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Symbol,
+    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, Env, Symbol,
 };
 
 const POOL_FEE_BPS: i128 = 30; // 0.30%
@@ -58,6 +58,8 @@ pub enum DataKey {
     Shares(Address),
     PendingAdmin,
     RotationExpiry,
+    TokenA,
+    TokenB,
 }
 
 #[contracttype]
@@ -73,11 +75,18 @@ pub struct LiquidityPoolContract;
 
 #[contractimpl]
 impl LiquidityPoolContract {
-    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        token_a: Address,
+        token_b: Address,
+    ) -> Result<(), Error> {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(Error::AlreadyInitialized);
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::TokenA, &token_a);
+        env.storage().instance().set(&DataKey::TokenB, &token_b);
         env.storage().instance().set(&DataKey::ReserveA, &0i128);
         env.storage().instance().set(&DataKey::ReserveB, &0i128);
         env.storage().instance().set(&DataKey::TotalShares, &0i128);
@@ -125,6 +134,20 @@ impl LiquidityPoolContract {
         if shares <= 0 {
             return Err(Error::InsufficientLiquidity);
         }
+
+        let token_a: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenA)
+            .ok_or(Error::NotInitialized)?;
+        let token_b: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenB)
+            .ok_or(Error::NotInitialized)?;
+        let pool = env.current_contract_address();
+        token::Client::new(&env, &token_a).transfer(&provider, &pool, &amount_a);
+        token::Client::new(&env, &token_b).transfer(&provider, &pool, &amount_b);
 
         env.storage()
             .instance()
@@ -202,6 +225,20 @@ impl LiquidityPoolContract {
             .persistent()
             .set(&DataKey::Shares(provider.clone()), &(held - shares));
 
+        let token_a: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenA)
+            .ok_or(Error::NotInitialized)?;
+        let token_b: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenB)
+            .ok_or(Error::NotInitialized)?;
+        let pool = env.current_contract_address();
+        token::Client::new(&env, &token_a).transfer(&pool, &provider, &out_a);
+        token::Client::new(&env, &token_b).transfer(&pool, &provider, &out_b);
+
         env.events()
             .publish((symbol_short!("REM_LIQ"), provider), (out_a, out_b, shares));
         Ok((out_a, out_b))
@@ -241,6 +278,20 @@ impl LiquidityPoolContract {
         if amount_out < min_out {
             return Err(Error::SlippageExceeded);
         }
+
+        let token_a: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenA)
+            .ok_or(Error::NotInitialized)?;
+        let token_b: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenB)
+            .ok_or(Error::NotInitialized)?;
+        let pool = env.current_contract_address();
+        token::Client::new(&env, &token_a).transfer(&trader, &pool, &amount_in);
+        token::Client::new(&env, &token_b).transfer(&pool, &trader, &amount_out);
 
         env.storage()
             .instance()


### PR DESCRIPTION
## Summary
Fixes four security issues found across four contracts:

- **#668** — `allergy-tracking` had no patient-scoped access control on any read function. Added `grant_access`/`revoke_access` (mirroring `allergy-management`'s pattern) and enforced it in `get_record`, `get_allergy`, `get_active_allergies`, `get_all_records`, and `check_drug_allergy_interaction`.
- **#667** — `clinical-trial`'s `is_valid_consent` was a hardcoded stub always returning `true`. Replaced with a real per-trial consent-version check (`set_consent_version`, PI-only) that fails closed when no version has been configured, and wired it into `enroll_participant`, `enrol_participant_at_site`, and `re_enroll_participant`.
- **#666** — `healthcare-credentialing` had no admin/authorized-role registry, allowing self-credentialing. Added `initialize` + admin-managed `AuthorizedVerifier`/`CommitteeMember` registries. `verify_credential`, `check_sanctions`, `conduct_peer_reference`, `grant_privileges`, and `complete_recredentialing` now check registry membership instead of only that the caller signed for themselves. `submit_credential_document` now takes and verifies a caller address that must match the case's provider.
- **#665** — `liquidity-pool`'s `add_liquidity`/`remove_liquidity`/`swap` never moved real tokens; reserves were fictitious bookkeeping counters. Added token addresses to `initialize` and wired real `token::Client` transfers into all three functions so reserves reflect actual custodied funds.

## Test plan
Per instructions, test-suite updates were out of scope for this change — the acceptance-criteria test items were intentionally skipped. Existing inline/`test.rs` suites for these contracts will need call-site updates (new required parameters, registry/consent setup) before they compile again; that's left for a follow-up.

Closes #668
Closes #667
Closes #666
Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)