### PR TITLE
fix: resolve four Stellar Wave critical bugs (patient-registry, mental-health, liquidity-pool, provider-registry)

### DIFF
--- a/contracts/liquidity-pool/src/lib.rs
+++ b/contracts/liquidity-pool/src/lib.rs
@@ -186,8 +186,12 @@ impl LiquidityPoolContract {
             .get(&DataKey::TotalShares)
             .unwrap_or(0);
 
-        let out_a = shares * reserve_a / total;
-        let out_b = shares * reserve_b / total;
+        let out_a = shares
+            .checked_mul(reserve_a)
+            .ok_or(Error::ArithmeticOverflow)? / total;
+        let out_b = shares
+            .checked_mul(reserve_b)
+            .ok_or(Error::ArithmeticOverflow)? / total;
 
         env.storage()
             .instance()

--- a/contracts/liquidity-pool/src/test.rs
+++ b/contracts/liquidity-pool/src/test.rs
@@ -58,6 +58,35 @@ fn swap_slippage_protection_rejects_bad_trade() {
 }
 
 #[test]
+fn remove_liquidity_overflow_returns_proper_error() {
+    let (env, _, _) = setup();
+    let provider = Address::generate(&env);
+    // Register a fresh contract so we can manipulate storage directly.
+    let contract_id = env.register(LiquidityPoolContract, ());
+    let client = LiquidityPoolContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    // Deposit moderate values so the provider holds shares.
+    let shares = client.add_liquidity(&provider, &2_000_000, &2_000_000);
+
+    // Bypass normal flow: directly pump reserves to huge values via storage manipulation.
+    // With shares = 2_000_000 and reserve_a = i128::MAX, the multiplication overflows.
+    env.as_contract(&contract_id, || {
+        env.storage().instance().set(&DataKey::ReserveA, &i128::MAX);
+        env.storage().instance().set(&DataKey::ReserveB, &i128::MAX);
+        env.storage().instance().set(&DataKey::TotalShares, &shares);
+    });
+
+    // remove_liquidity will compute shares * reserve_a → overflow → ArithmeticOverflow
+    let err = client
+        .try_remove_liquidity(&provider, &shares)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::ArithmeticOverflow);
+}
+
+#[test]
 fn get_shares_tracks_provider_balance() {
     let (_, client, _) = setup();
     let provider = Address::generate(&client.env);

--- a/contracts/mental-health/src/lib.rs
+++ b/contracts/mental-health/src/lib.rs
@@ -185,6 +185,12 @@ pub enum DataKey {
     Consent(Address, Symbol, Address),
     /// Address of the emergency-medical-info contract for crisis escalation
     EmergencyContractAddress,
+    /// Auto-incrementing counter for pseudonym IDs
+    PseudonymCounter,
+    /// Mapping from pseudonym address to real patient address
+    PseudonymMapping(Address),
+    /// Authorized address that can resolve pseudonyms (e.g. emergency-medical-info contract)
+    AuthorizedResolver(Address),
 }
 
 #[contract]
@@ -241,11 +247,32 @@ impl MentalHealthContract {
         }
 
         let patient_token = if privacy_flagged {
-            // Derive a de-identified patient token via SHA-256
-            let patient_bytes = patient_id.clone().to_xdr(env);
-            let hash: [u8; 32] = env.crypto().sha256(&patient_bytes).into();
-            let salt = BytesN::<32>::from_array(env, &hash);
-            env.deployer().with_current_contract(salt).deployed_address()
+            // Generate a unique pseudonym ID
+            let pseudonym_counter: u64 = env
+                .storage()
+                .instance()
+                .get(&DataKey::PseudonymCounter)
+                .unwrap_or(0);
+            let next_id = pseudonym_counter + 1;
+            env.storage()
+                .instance()
+                .set(&DataKey::PseudonymCounter, &next_id);
+
+            // Derive a deterministic pseudonym address from the counter
+            let pseudo_bytes = BytesN::from_array(env, &env.crypto().sha256(
+                &next_id.to_xdr(env),
+            ).into());
+            let salt = pseudo_bytes;
+            let pseudonym_address =
+                env.deployer().with_current_contract(salt).deployed_address();
+
+            // Register the mapping so authorized resolvers can reverse it
+            env.storage().persistent().set(
+                &DataKey::PseudonymMapping(pseudonym_address.clone()),
+                patient_id,
+            );
+
+            pseudonym_address
         } else {
             patient_id.clone()
         };
@@ -777,6 +804,62 @@ impl MentalHealthContract {
             &requires_explicit_consent,
         );
         Ok(())
+    }
+
+    /// Authorize an address (e.g. the emergency-medical-info contract) to resolve
+    /// de-identified pseudonyms back to real patient addresses.
+    pub fn authorize_resolver(env: Env, admin: Address, resolver: Address) -> Result<(), Error> {
+        admin.require_auth();
+        let emergency_addr: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::EmergencyContractAddress)
+            .ok_or(Error::NotAuthorized)?;
+        // Only the contract deployer/emergency-contract admin can authorize resolvers;
+        // for simplicity, require that the caller matches the emergency contract address.
+        if admin != emergency_addr {
+            return Err(Error::NotAuthorized);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::AuthorizedResolver(resolver.clone()), &true);
+        Ok(())
+    }
+
+    /// Revoke a resolver's authorization.
+    pub fn revoke_resolver(env: Env, admin: Address, resolver: Address) -> Result<(), Error> {
+        admin.require_auth();
+        let emergency_addr: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::EmergencyContractAddress)
+            .ok_or(Error::NotAuthorized)?;
+        if admin != emergency_addr {
+            return Err(Error::NotAuthorized);
+        }
+        env.storage()
+            .persistent()
+            .remove(&DataKey::AuthorizedResolver(resolver));
+        Ok(())
+    }
+
+    /// Resolve a de-identified pseudonym address back to the real patient address.
+    /// Only authorized resolvers may call this.
+    pub fn resolve_pseudonym(env: Env, caller: Address, pseudonym: Address) -> Result<Address, Error> {
+        caller.require_auth();
+        // Verify caller is authorized
+        let is_authorized: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AuthorizedResolver(caller.clone()))
+            .unwrap_or(false);
+        if !is_authorized {
+            return Err(Error::NotAuthorized);
+        }
+        env.storage()
+            .persistent()
+            .get(&DataKey::PseudonymMapping(pseudonym))
+            .ok_or(Error::NotFound)
     }
 }
 

--- a/contracts/patient-registry/src/lib.rs
+++ b/contracts/patient-registry/src/lib.rs
@@ -81,17 +81,6 @@ pub struct PatientStatusChanged {
 }
 
 /// --------------------
-/// Retention Class
-/// --------------------
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum RetentionClass {
-    Clinical,
-    Financial,
-    Administrative,
-}
-
-/// --------------------
 /// Patient Structures
 /// --------------------
 #[contracttype]

--- a/contracts/provider-registry/src/lib.rs
+++ b/contracts/provider-registry/src/lib.rs
@@ -279,6 +279,7 @@ impl ProviderRegistry {
         provider: Address,
         record_id: String,
         data: String,
+        nonce: u64,
     ) -> Result<(), Error> {
         Self::assert_initialized(&env)?;
         validate_nonzero_address(&provider).map_err(|_| Error::InvalidAddress)?;
@@ -286,6 +287,8 @@ impl ProviderRegistry {
         if !Self::is_provider(env.clone(), provider.clone()) {
             return Err(Error::NotAProvider);
         }
+        // Replay protection: verify the nonce is strictly greater than the last used nonce
+        Self::verify_and_increment_nonce(&env, &provider, nonce)?;
         env.storage()
             .persistent()
             .set(&DataKey::Record(record_id.clone()), &data);

--- a/contracts/provider-registry/src/test.rs
+++ b/contracts/provider-registry/src/test.rs
@@ -153,10 +153,12 @@ fn test_add_record_by_whitelisted_provider() {
     let (env, admin, client) = setup();
     let provider = Address::generate(&env);
     register_provider_with_anchor(&env, &client, &admin, &provider);
+    let nonce = client.get_caller_nonce(&provider);
     client.add_record(
         &provider,
         &String::from_str(&env, "REC001"),
         &String::from_str(&env, "Patient data"),
+        &(nonce + 1),
     );
     assert_eq!(
         client.get_record(&String::from_str(&env, "REC001")),
@@ -173,6 +175,7 @@ fn test_add_record_non_provider_returns_error() {
             &stranger,
             &String::from_str(&env, "REC002"),
             &String::from_str(&env, "bad data"),
+            &1u64,
         )
         .unwrap_err()
         .unwrap();
@@ -190,10 +193,59 @@ fn test_add_record_after_revocation_returns_error() {
             &provider,
             &String::from_str(&env, "REC003"),
             &String::from_str(&env, "stale"),
+            &1u64,
         )
         .unwrap_err()
         .unwrap();
     assert_eq!(err, Error::NotAProvider);
+}
+
+#[test]
+fn test_add_record_stale_nonce_rejected() {
+    let (env, admin, client) = setup();
+    env.mock_all_auths();
+    let provider = Address::generate(&env);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
+
+    let nonce = client.get_caller_nonce(&provider);
+    // First call with valid nonce succeeds
+    client.add_record(
+        &provider,
+        &String::from_str(&env, "REC001"),
+        &String::from_str(&env, "data"),
+        &(nonce + 1),
+    );
+    // Second call with the same nonce must be rejected (stale)
+    let err = client
+        .try_add_record(
+            &provider,
+            &String::from_str(&env, "REC002"),
+            &String::from_str(&env, "replay"),
+            &(nonce + 1),
+        )
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::StaleNonce);
+}
+
+#[test]
+fn test_add_record_zero_nonce_accepted_as_initial() {
+    let (env, admin, client) = setup();
+    env.mock_all_auths();
+    let provider = Address::generate(&env);
+    register_provider_with_anchor(&env, &client, &admin, &provider);
+
+    // Initial nonce is 0; passing 0 should fail (must be > 0), so pass 1
+    let nonce = client.get_caller_nonce(&provider);
+    assert_eq!(nonce, 0);
+    client.add_record(
+        &provider,
+        &String::from_str(&env, "REC001"),
+        &String::from_str(&env, "initial data"),
+        &(nonce + 1),
+    );
+    // Verify the nonce was incremented
+    assert_eq!(client.get_caller_nonce(&provider), 1);
 }
 
 // ── get_record ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Closes #591 
##Closes #620 
##Closes #621 
##Closes #622

### What does this PR do?

- **#591 — patient-registry compile error:** Removes duplicate  enum that was defined twice in , causing E0428/E0119 compilation errors. Retains the canonical definition.

- **#620 — mental-health unresolvable crisis-escalation pseudonym:** Replaces the synthetic  hash with a registered pseudonym mapping (). When  privacy flag is set, a unique pseudonym ID is generated, its SHA-256 hash is used as the deployed-address salt, and the mapping  is persisted in storage. Adds  (authorized-resolver gated), , and  public functions so emergency responders can reverse the de-identification during high-severity events.

- **#621 — liquidity-pool  unchecked multiplication:** Replaces plain  multiplication in  with , matching the same overflow-safe pattern already used in  and . Adds a white-box overflow test that directly manipulates storage reserves to verify  is returned (not a panic).

- **#622 — provider-registry nonce replay-protection never invoked:** Adds a  parameter to  and wires  into the function, so the existing but unused replay-protection helper is now activated. Adds regression tests for stale-nonce rejection and nonce progression.

### Key Modifications

- : Removed duplicate RetentionClass enum
- : Added PseudonymCounter/PseudonymMapping/AuthorizedResolver DataKeys; reworked escalate_crisis to register a resolvable pseudonym; added resolve_pseudonym/authorize_resolver/revoke_resolver public functions
- : Changed remove_liquidity multiplications to checked_mul
- : Added overflow regression test
- : Added nonce param to add_record, wired verify_and_increment_nonce
- : Updated existing tests for nonce param; added stale-nonce and nonce-progression regression tests

