### PR TITLE
fix(referral): resolve provider verification compilation errors and hoist registry check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,6 +1089,7 @@ dependencies = [
 name = "lab-management"
 version = "0.1.0"
 dependencies = [
+ "shared",
  "soroban-sdk",
 ]
 

--- a/contracts/lab-management/Cargo.toml
+++ b/contracts/lab-management/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
+shared = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/lab-management/src/lib.rs
+++ b/contracts/lab-management/src/lib.rs
@@ -101,13 +101,12 @@ impl LabManagementContract {
     }
 
     fn is_provider_registered(env: &Env, provider: &Address) -> bool {
-        if let Ok(provider_registry) = env
+        if let Some(provider_registry) = env
             .storage()
             .instance()
             .get::<_, Address>(&DataKey::ProviderRegistry)
         {
-            let args = vec![env, provider.clone().into_val(env)];
-            env.invoke_contract(&provider_registry, &Symbol::new(env, "is_provider"), args)
+            shared::actor_verification::is_provider_registered(env, &provider_registry, provider)
         } else {
             false
         }

--- a/contracts/referral/src/contract.rs
+++ b/contracts/referral/src/contract.rs
@@ -1,7 +1,7 @@
 use crate::types::{DataKey, Error, Referral, ReferralStatus};
 use shared::privacy::validate_nonzero_address;
 use shared_contracts::safe_increment;
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Symbol, Vec, vec};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, IntoVal, String, Symbol, Vec, vec};
 
 #[contract]
 pub struct ReferralContract;
@@ -17,13 +17,12 @@ impl ReferralContract {
     }
 
     fn is_provider_registered(env: &Env, provider: &Address) -> bool {
-        if let Ok(provider_registry) = env
+        if let Some(provider_registry) = env
             .storage()
             .instance()
             .get::<_, Address>(&DataKey::ProviderRegistry)
         {
-            let args = vec![env, provider.clone().into_val(env)];
-            env.invoke_contract(&provider_registry, &Symbol::new(env, "is_provider"), args)
+            shared::actor_verification::is_provider_registered(env, &provider_registry, provider)
         } else {
             false
         }

--- a/contracts/shared/src/actor_verification.rs
+++ b/contracts/shared/src/actor_verification.rs
@@ -121,3 +121,36 @@ fn verify_insurer(env: &Env, address: &Address) -> bool {
     let args = vec![env, address.clone().into_val(env)];
     env.invoke_contract(&registry, &Symbol::new(env, "is_insurer_active"), args)
 }
+
+/// Helper to check if a provider is registered with a provider registry.
+pub fn is_provider_registered(env: &Env, provider_registry: &Address, provider: &Address) -> bool {
+    let args = vec![env, provider.clone().into_val(env)];
+    env.invoke_contract(provider_registry, &Symbol::new(env, "is_provider"), args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{contract, contractimpl, Address, Env};
+    use soroban_sdk::testutils::Address as _;
+
+    #[contract]
+    pub struct MockProviderRegistry;
+
+    #[contractimpl]
+    impl MockProviderRegistry {
+        pub fn is_provider(_env: Env, _provider: Address) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn test_is_provider_registered() {
+        let env = Env::default();
+        let registry_id = env.register(MockProviderRegistry, ());
+        let provider = Address::generate(&env);
+
+        let is_reg = is_provider_registered(&env, &registry_id, &provider);
+        assert!(is_reg);
+    }
+}


### PR DESCRIPTION
Closes #586

# PR Description

I resolved the compilation failures in the referral and lab-management contracts. The issues were caused by type mismatches when querying instance storage and a missing import in the referral contract.

Previously, both contracts attempted to query the provider registry address from instance storage using a pattern that expected a Result:
if let Ok(provider_registry) = env.storage().instance().get(...)

However, the Soroban SDK's get method returns an Option, which caused a compilation type mismatch. Additionally, the referral contract attempted to convert the provider address using provider.clone().into_val(env), but failed to compile because IntoVal was not imported from the SDK.

To solve this cleanly, I performed the following steps:
1. I implemented a generic helper function `is_provider_registered` in the shared actor_verification module inside `contracts/shared/src/actor_verification.rs`. This helper accepts the registry address and checks if the provider is registered via a cross-contract invocation.
2. I added unit tests for this helper in the shared crate using a mock provider registry contract to verify the invocation works.
3. I updated the referral contract inside `contracts/referral/src/contract.rs` by importing `IntoVal` from the `soroban_sdk` and modifying its `is_provider_registered` method to retrieve the registry address with `if let Some` and then delegate to the new shared helper.
4. I updated the lab-management contract inside `contracts/lab-management/src/lib.rs` to depend on the shared crate and updated its internal `is_provider_registered` method to similarly use `if let Some` and delegate to the shared helper.

This implementation centralizes the cross-contract invocation logic in the shared crate, resolving code duplication while ensuring both contracts compile cleanly and operate as expected.

# Changes Made
* Modified contracts/shared/src/actor_verification.rs to implement the `is_provider_registered` helper and its corresponding unit tests using a mock registry.
* Modified contracts/referral/src/contract.rs to import `IntoVal`, change `if let Ok` to `if let Some`, and call the shared verification helper.
* Modified contracts/lab-management/Cargo.toml to include the shared crate dependency.
* Modified contracts/lab-management/src/lib.rs to change `if let Ok` to `if let Some` and call the shared verification helper.
* Modified Cargo.lock as a result of the new workspace dependency addition.

# Testing
* Run `cargo check -p referral`
Result: Compilation passed cleanly with no errors.
* Run `cargo check -p lab-management`
Result: Compilation passed cleanly with no errors.