### PR TITLE
fix(workflow): fix TTL extension CLI commands and manifest parsing

### DIFF
--- a/.github/workflows/extend-ttls.yml
+++ b/.github/workflows/extend-ttls.yml
@@ -101,12 +101,12 @@ jobs:
         env:
           NETWORK: ${{ needs.ttl-monitoring.outputs.network }}
         run: |
-          MANIFEST="deployments/${NETWORK}.json"
+          export MANIFEST="deployments/${NETWORK}.json"
 
-          # Extract contract IDs — skip metadata keys that start with "_".
+          # Extract contract IDs - skip metadata keys that start with "_".
           CONTRACT_IDS=$(python3 - <<'EOF'
-          import json, sys
-          with open("${MANIFEST}") as f:
+          import json, sys, os
+          with open(os.environ["MANIFEST"]) as f:
               d = json.load(f)
           ids = [v for k, v in d.items() if not k.startswith("_") and v]
           print("\n".join(ids))
@@ -121,11 +121,11 @@ jobs:
           FAILED=0
           while IFS= read -r contract_id; do
             echo "Extending TTL for contract: ${contract_id}"
-            stellar contract extend-ttl \
+            stellar contract extend \
               --id "$contract_id" \
               --source extender \
               --network "$NETWORK" \
-              --ledgers-to-expire 2000000 || {
+              --ledgers-to-extend 2000000 || {
               echo "::warning::Failed to extend TTL for ${contract_id}"
               FAILED=$((FAILED + 1))
             }


### PR DESCRIPTION
Closes #578

## PR Description

I fixed the weekly scheduled GitHub Actions workflow for contract TTL extension in `.github/workflows/extend-ttls.yml` because it was failing during execution.

The workflow had three errors. First, it invoked `stellar contract extend-ttl` which is not a valid Stellar CLI command. Second, it used the incorrect flag `--ledgers-to-expire` which does not exist in the CLI. Third, it attempted to read the manifest file path using `"${MANIFEST}"` inside a single quoted Python here-document. Since Bash does not interpolate variables in single quoted here-documents, Python tried to open a file literally named `"${MANIFEST}"` and crashed.

To resolve these errors, I exported the `MANIFEST` environment variable in the Bash step and updated the Python script to read it via `os.environ["MANIFEST"]`. I also updated the CLI command to `stellar contract extend` and changed the argument flag to `--ledgers-to-extend`.

These updates allow the workflow to successfully identify the contracts and execute the TTL extensions once deployment manifests are complete, safeguarding the contracts against expiration and data loss.

## Changes Made
- Modified `.github/workflows/extend-ttls.yml` to export the manifest variable and read it using environment variables in Python.
- Updated the CLI command in `.github/workflows/extend-ttls.yml` to use the correct command and flag names.

## Testing
- Checked the command options and flags against the official Stellar CLI documentation.
- Executed a dry-run check of the local script using `./scripts/extend-ttls.sh --network testnet --dry-run` to confirm manifest path handling.