### PR TITLE
fix(hospital-discharge-management): call set_hospital_registry in initialize()

### DIFF
--- a/contracts/hospital-discharge-management/src/lib.rs
+++ b/contracts/hospital-discharge-management/src/lib.rs
@@ -45,7 +45,7 @@ impl HospitalDischargeContract {
     /// Initialize the contract with a hospital registry address
     pub fn initialize(env: Env, hospital_registry: Address) -> Result<(), Error> {
         hospital_registry.require_auth();
-        save_hospital_registry(&env, &hospital_registry);
+        set_hospital_registry(&env, &hospital_registry);
         Ok(())
     }
 

--- a/contracts/hospital-discharge-management/src/test.rs
+++ b/contracts/hospital-discharge-management/src/test.rs
@@ -445,6 +445,29 @@ fn test_full_discharge_workflow() {
 }
 
 #[test]
+fn test_initialize_then_discharge_planning() {
+    let (env, admin, _patient, patient_id, hospital_id) = create_test_env();
+    let contract_id = env.register(HospitalDischargeContract, ());
+    let client = HospitalDischargeContractClient::new(&env, &contract_id);
+
+    // Initialize the contract with the hospital registry
+    client.initialize(&admin);
+
+    // Verify initialize succeeded by running a state-mutating call
+    let plan_id = client.initiate_discharge_planning(
+        &admin,
+        &patient_id,
+        &hospital_id,
+        &1000u64,
+        &2000u64,
+    );
+
+    assert_eq!(plan_id, 1);
+    let plan = client.get_discharge_plan(&plan_id);
+    assert_eq!(plan.patient_id, patient_id);
+}
+
+#[test]
 fn test_complete_discharge_unauthorized() {
     let (env, admin, _patient, patient_id, hospital_id) = create_test_env();
     let contract_id = env.register(HospitalDischargeContract, ());


### PR DESCRIPTION
## Overview

This PR fixes a compilation error in `hospital-discharge-management` where `initialize()` called a non-existent function `save_hospital_registry` instead of the actual setter `set_hospital_registry`.

## Related Issue

Closes #715

## Changes

- **[MODIFY]** `contracts/hospital-discharge-management/src/lib.rs:48`
  - Changed `save_hospital_registry(&env, &hospital_registry)` to `set_hospital_registry(&env, &hospital_registry)` to match the actual function defined in `storage.rs:109`.

- **[ADD]** `contracts/hospital-discharge-management/src/test.rs`
  - Added `test_initialize_then_discharge_planning` regression test that calls `initialize()` followed by `initiate_discharge_planning()` to verify the full flow works.

## Verification Results

```
cargo check -p hospital-discharge-management  ✅ passes (E0425 error resolved)
cargo test -p hospital-discharge-management   ✅ all tests pass including new regression test
```

## Acceptance Criteria

| Criteria | Status |
| --- | --- |
| Change the call in `initialize` to `set_hospital_registry` | ✅ Done |
| `cargo check -p hospital-discharge-management` passes | ✅ Verified |
| `cargo test -p hospital-discharge-management` passes | ✅ Verified |
| Add regression test asserting `initialize` followed by state-mutating call succeeds | ✅ Added `test_initialize_then_discharge_planning` |