### PR TITLE
Require admin auth for NFT badge initialization

### DIFF
--- a/contracts/nft-badges/src/lib.rs
+++ b/contracts/nft-badges/src/lib.rs
@@ -74,6 +74,7 @@ impl NftBadgesContract {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(Error::AlreadyInitialized);
         }
+        admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::NextId, &1u64);
         Ok(())

--- a/contracts/nft-badges/src/test.rs
+++ b/contracts/nft-badges/src/test.rs
@@ -16,6 +16,17 @@ fn setup() -> (Env, NftBadgesContractClient<'static>, Address) {
 fn s(env: &Env, v: &str) -> String { String::from_str(env, v) }
 
 #[test]
+#[should_panic]
+fn initialize_requires_admin_auth() {
+    let env = Env::default();
+    let contract_id = env.register(NftBadgesContract, ());
+    let client = NftBadgesContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+}
+
+#[test]
 fn mint_creates_badge_with_correct_metadata() {
     let (env, client, admin) = setup();
     let student = Address::generate(&env);


### PR DESCRIPTION
## Overview

Adds required admin authorization to `nft-badges` initialization so an unsigned caller cannot front-run deployment and set themselves as contract admin.

Closes #749

## Related Issue

- #749

## Changes

- Call `admin.require_auth()` before storing `DataKey::Admin` in `initialize`.
- Add a regression test proving `initialize` panics when called without the admin signature.

## Verification Results

- `cargo test -p nft-badges` - passed, 9 tests passed.
- Note: `contracts/nft-badges` is not currently listed in root `workspace.members`, so the focused test was run after temporarily adding the crate to the workspace locally and removing that temporary manifest/lockfile change afterward.
- `rustfmt --check contracts\nft-badges\src\lib.rs contracts\nft-badges\src\test.rs` - fails on pre-existing formatting style in these files; final diff preserves the existing style and avoids broad formatting churn.

## Acceptance Criteria

| Criteria | Status |
| --- | --- |
| Add `admin.require_auth()` before storing `DataKey::Admin` | Done |
| Add a test confirming `initialize` fails without the admin's signature | Done |
