### PR TITLE
fix: resolve compile-breaking bugs in hai-tracking, hospital-registry, nutrition-care-management

### DIFF
--- a/contracts/hai-tracking/src/lib.rs
+++ b/contracts/hai-tracking/src/lib.rs
@@ -897,4 +897,5 @@ impl HAITrackingContract {
     }
 }
 
+#[cfg(test)]
 mod test;

--- a/contracts/hai-tracking/src/test.rs
+++ b/contracts/hai-tracking/src/test.rs
@@ -320,7 +320,7 @@ fn test_calculate_infection_rate() {
 
     for _ in 0..2 {
         let patient = Address::generate(&env);
-        report_case(
+        let infection_id = report_case(
             &env,
             &client,
             &patient,
@@ -330,6 +330,7 @@ fn test_calculate_infection_rate() {
             "ICU",
             &reporter,
         );
+        client.record_patient_days(&infection_id, &500, &reporter);
     }
 
     let rate = client.calculate_infection_rate(
@@ -619,8 +620,6 @@ fn test_calculate_infection_rate_with_device_days() {
         &None,
     );
 
-    assert!(rate.is_ok());
-    let rate = rate.unwrap();
     assert_eq!(rate.numerator, 1);
     assert_eq!(rate.denominator, 10);
 }
@@ -657,8 +656,6 @@ fn test_calculate_infection_rate_with_patient_days() {
         &None,
     );
 
-    assert!(rate.is_ok());
-    let rate = rate.unwrap();
     assert_eq!(rate.numerator, 1);
     assert_eq!(rate.denominator, 50);
 }
@@ -690,5 +687,4 @@ fn test_calculate_infection_rate_no_denominator_fails() {
     );
 
     assert!(rate.is_err());
-}
 }

--- a/contracts/hospital-registry/src/lib.rs
+++ b/contracts/hospital-registry/src/lib.rs
@@ -312,30 +312,6 @@ impl HospitalRegistry {
             .publish((symbol_short!("audit"), caller.clone()), event);
     }
 
-    /// Check if caller is authorized to modify the hospital's config.
-    /// Authorized if: caller is the hospital OR caller is the admin.
-    fn assert_config_auth(
-        env: &Env,
-        caller: &Address,
-        hospital_address: &Address,
-    ) -> Result<(), ContractError> {
-        caller.require_auth();
-
-        // Hospital representative can update their own config
-        if caller == hospital_address {
-            return Ok(());
-        }
-
-        // Admin can update any hospital config
-        if let Some(admin) = env.storage().persistent().get::<_, Address>(&DataKey::Admin) {
-            if caller == &admin {
-                return Ok(());
-            }
-        }
-
-        Err(ContractError::NotAuthorized)
-    }
-
     /// Set the admin address. Only callable by the current admin (if set) or initially.
     pub fn set_admin(env: Env, caller: Address, admin: Address) -> Result<(), ContractError> {
         validate_nonzero_address(&admin).map_err(|_| ContractError::InvalidAddress)?;

--- a/contracts/nutrition-care-management/src/lib.rs
+++ b/contracts/nutrition-care-management/src/lib.rs
@@ -342,7 +342,7 @@ impl NutritionCareContract {
     /// One-time initialization of the contraindication admin.
     /// Fails if an admin has already been set; use `set_contraindication_admin`
     /// (called by the current admin) to rotate the admin afterwards.
-    pub fn initialize_contraindication_admin(env: Env, admin: Address) -> Result<(), Error> {
+    pub fn init_contraindication_admin(env: Env, admin: Address) -> Result<(), Error> {
         admin.require_auth();
         if env
             .storage()

--- a/contracts/nutrition-care-management/src/test.rs
+++ b/contracts/nutrition-care-management/src/test.rs
@@ -1732,14 +1732,14 @@ fn test_hijacked_admin_rejected_by_downstream_functions() {
 }
 
 #[test]
-fn test_initialize_contraindication_admin_once() {
+fn test_init_contraindication_admin_once() {
     let (env, _, _, _) = setup();
     let client = register(&env);
     let admin = Address::generate(&env);
     let attacker = Address::generate(&env);
 
-    client.initialize_contraindication_admin(&admin);
+    client.init_contraindication_admin(&admin);
 
-    let result = client.try_initialize_contraindication_admin(&attacker);
+    let result = client.try_init_contraindication_admin(&attacker);
     assert!(result.is_err());
 }


### PR DESCRIPTION
## Summary

Closes #714
Closes #716
Closes #717

Three independent contracts in the workspace failed to compile. This PR fixes each, minimally and in isolation.

### #714 — `hai-tracking` fails to compile
- Removed the stray extra closing `}` at the end of `test.rs` causing `error: unexpected closing delimiter`.
- Added `#[cfg(test)]` above `mod test;` in `lib.rs`, matching every other contract in the workspace, so the test module (and `soroban_sdk::testutils` usage) is excluded from release/WASM builds.
- Verified the release `wasm32-unknown-unknown` build no longer references `soroban_sdk::testutils` (checked with `strings` on the built `.wasm`).
- Fixing the parse error surfaced two latent, never-before-run test bugs in the same file (the crate's tests had never compiled, so these were undetected):
  - Two tests called the non-`try_` client method for `calculate_infection_rate` (which auto-unwraps the underlying `Result`) but then called `.is_ok()`/`.unwrap()` on the already-unwrapped value — fixed to match the working sibling test's pattern.
  - `test_calculate_infection_rate` never recorded patient-days for its cases, so the rate denominator was `0` and the call panicked with `Error::DivisionByZero` — added `record_patient_days` calls so the existing assertions (`denominator == 1000`, `rate_per_1000_days_x100 == 200`) are actually exercised.

### #716 — `hospital-registry` fails to compile
- Removed the stale, weaker duplicate `assert_config_auth` definition (`error[E0592]: duplicate definitions`). Kept the newer implementation added for #637, which verifies the hospital/admin registration actually exists before authorizing a config change. The admin-override branch remains reachable through the public API — every config-mutation call site (`set_hospital_config`, `update_departments`, etc.) already passes a distinct `caller` argument alongside `wallet`.

### #717 — `nutrition-care-management` fails to compile
- Renamed `initialize_contraindication_admin` (33 chars) to `init_contraindication_admin` (28 chars) to satisfy Soroban's 32-character exported function name limit, and updated the corresponding test call sites and test name.
- Grepped the rest of the file for other exported function names near the 32-char limit; the next closest is `document_nutrition_intervention` at 31 chars, which is under the limit.

No unrelated files were changed.

## Testing / validation

- `cargo check -p hai-tracking` / `-p hospital-registry` / `-p nutrition-care-management` — all pass.
- `cargo test -p hai-tracking` — 23/23 passing.
- `cargo test -p nutrition-care-management` — 76/76 passing.
- `cargo build -p hai-tracking --release --target wasm32-unknown-unknown` — succeeds; confirmed no `testutils` strings in the resulting `.wasm`.
- `cargo test -p hospital-registry` still fails to compile, but for reasons that pre-date and are unrelated to the duplicate-function bug fixed here: an unresolved `shared::test_utils` import (already tracked separately as #721 — `shared::test_utils` itself doesn't compile against the pinned SDK) and a stale test call-site missing an argument from an earlier `assert_config_auth`-adjacent change. Per the instruction to leave pre-existing, unrelated bugs untouched, neither was touched in this PR. `cargo check -p hospital-registry` (the lib target, matching the exact command in the issue body) passes cleanly.

## Issues

- https://github.com/Healthy-Stellar/contracts/issues/714
- https://github.com/Healthy-Stellar/contracts/issues/716
- https://github.com/Healthy-Stellar/contracts/issues/717