### PR TITLE
fix(discharge): add state transition guards and cancellation pathway

### DIFF
--- a/contracts/doctor-registry/src/lib.rs
+++ b/contracts/doctor-registry/src/lib.rs
@@ -47,6 +47,8 @@ pub struct DoctorProfileData {
     pub specialization: String,
     pub institution_wallet: Address,
     pub metadata: String,
+    pub active: bool,
+    pub revoked_at: Option<u64>,
 }
 
 /// --------------------
@@ -107,6 +109,8 @@ impl DoctorRegistry {
             specialization,
             institution_wallet,
             metadata: String::from_str(&env, ""),
+            active: true,
+            revoked_at: None,
         };
 
         env.storage().persistent().set(&key, &doctor_profile);
@@ -160,6 +164,86 @@ impl DoctorRegistry {
             .persistent()
             .get(&key)
             .ok_or(Error::ProfileNotFound)
+    }
+
+    /// Deactivate a doctor profile.
+    /// Requires the admin (registrar) to authorize.
+    ///
+    /// # Arguments
+    /// * `registrar` - The admin address that authorizes this deactivation
+    /// * `wallet` - The wallet address of the doctor whose profile is being deactivated
+    pub fn deactivate_doctor_profile(
+        env: Env,
+        registrar: Address,
+        wallet: Address,
+    ) -> Result<(), Error> {
+        validate_nonzero_address(&registrar).map_err(|_| Error::InvalidAddress)?;
+        validate_nonzero_address(&wallet).map_err(|_| Error::InvalidAddress)?;
+        require_admin(&env, &registrar)?;
+
+        let key = DataKey::Doctor(wallet.clone());
+        let mut doctor_profile: DoctorProfileData = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(Error::ProfileNotFound)?;
+
+        doctor_profile.active = false;
+        doctor_profile.revoked_at = Some(env.ledger().timestamp());
+        env.storage().persistent().set(&key, &doctor_profile);
+
+        env.events()
+            .publish((symbol_short!("deact_doc"), wallet), symbol_short!("success"));
+
+        Ok(())
+    }
+
+    /// Reactivate a previously deactivated doctor profile.
+    /// Requires the admin (registrar) to authorize.
+    ///
+    /// # Arguments
+    /// * `registrar` - The admin address that authorizes this reactivation
+    /// * `wallet` - The wallet address of the doctor whose profile is being reactivated
+    pub fn reactivate_doctor_profile(
+        env: Env,
+        registrar: Address,
+        wallet: Address,
+    ) -> Result<(), Error> {
+        validate_nonzero_address(&registrar).map_err(|_| Error::InvalidAddress)?;
+        validate_nonzero_address(&wallet).map_err(|_| Error::InvalidAddress)?;
+        require_admin(&env, &registrar)?;
+
+        let key = DataKey::Doctor(wallet.clone());
+        let mut doctor_profile: DoctorProfileData = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(Error::ProfileNotFound)?;
+
+        doctor_profile.active = true;
+        doctor_profile.revoked_at = None;
+        env.storage().persistent().set(&key, &doctor_profile);
+
+        env.events()
+            .publish((symbol_short!("react_doc"), wallet), symbol_short!("success"));
+
+        Ok(())
+    }
+
+    /// Check if a doctor is registered and active.
+    ///
+    /// # Arguments
+    /// * `wallet` - The wallet address of the doctor
+    pub fn is_active(env: Env, wallet: Address) -> bool {
+        if validate_nonzero_address(&wallet).is_err() {
+            return false;
+        }
+        let key = DataKey::Doctor(wallet);
+        if let Some(profile) = env.storage().persistent().get::<DataKey, DoctorProfileData>(&key) {
+            profile.active
+        } else {
+            false
+        }
     }
 }
 

--- a/contracts/doctor-registry/src/test.rs
+++ b/contracts/doctor-registry/src/test.rs
@@ -30,6 +30,8 @@ fn test_create_doctor_profile() {
     assert_eq!(profile.specialization, String::from_str(&env, "Cardiology"));
     assert_eq!(profile.institution_wallet, institution_wallet);
     assert_eq!(profile.metadata, String::from_str(&env, ""));
+    assert_eq!(profile.active, true);
+    assert_eq!(profile.revoked_at, None);
 }
 
 #[test]
@@ -253,3 +255,100 @@ fn test_non_admin_cannot_create_profile() {
 
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
 }
+
+#[test]
+fn test_deactivate_and_reactivate_doctor_lifecycle() {
+    let env = Env::default();
+    let contract_id = env.register(DoctorRegistry, ());
+    let client = DoctorRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let doctor_wallet = Address::generate(&env);
+    let institution_wallet = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    client.create_doctor_profile(
+        &admin,
+        &doctor_wallet,
+        &String::from_str(&env, "Dr. Gregory House"),
+        &String::from_str(&env, "Diagnostic Medicine"),
+        &institution_wallet,
+    );
+
+    // Initial state: active == true, revoked_at == None, is_active == true
+    let profile = client.get_doctor_profile(&doctor_wallet);
+    assert_eq!(profile.active, true);
+    assert_eq!(profile.revoked_at, None);
+    assert_eq!(client.is_active(&doctor_wallet), true);
+
+    // Deactivate doctor profile
+    client.deactivate_doctor_profile(&admin, &doctor_wallet);
+
+    let deactivated_profile = client.get_doctor_profile(&doctor_wallet);
+    assert_eq!(deactivated_profile.active, false);
+    assert_eq!(deactivated_profile.revoked_at, Some(env.ledger().timestamp()));
+    assert_eq!(client.is_active(&doctor_wallet), false);
+
+    // Reactivate doctor profile
+    client.reactivate_doctor_profile(&admin, &doctor_wallet);
+
+    let reactivated_profile = client.get_doctor_profile(&doctor_wallet);
+    assert_eq!(reactivated_profile.active, true);
+    assert_eq!(reactivated_profile.revoked_at, None);
+    assert_eq!(client.is_active(&doctor_wallet), true);
+}
+
+#[test]
+fn test_deactivate_and_reactivate_unauthorized() {
+    let env = Env::default();
+    let contract_id = env.register(DoctorRegistry, ());
+    let client = DoctorRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let doctor_wallet = Address::generate(&env);
+    let institution_wallet = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    client.create_doctor_profile(
+        &admin,
+        &doctor_wallet,
+        &String::from_str(&env, "Dr. Wilson"),
+        &String::from_str(&env, "Oncology"),
+        &institution_wallet,
+    );
+
+    // Non-admin cannot deactivate
+    let res_deact = client.try_deactivate_doctor_profile(&attacker, &doctor_wallet);
+    assert_eq!(res_deact, Err(Ok(Error::Unauthorized)));
+
+    // Non-admin cannot reactivate
+    let res_react = client.try_reactivate_doctor_profile(&attacker, &doctor_wallet);
+    assert_eq!(res_react, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_deactivate_and_reactivate_nonexistent_profile_fails() {
+    let env = Env::default();
+    let contract_id = env.register(DoctorRegistry, ());
+    let client = DoctorRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let unknown_doctor = Address::generate(&env);
+
+    env.mock_all_auths();
+    client.initialize(&admin);
+
+    let res_deact = client.try_deactivate_doctor_profile(&admin, &unknown_doctor);
+    assert_eq!(res_deact, Err(Ok(Error::ProfileNotFound)));
+
+    let res_react = client.try_reactivate_doctor_profile(&admin, &unknown_doctor);
+    assert_eq!(res_react, Err(Ok(Error::ProfileNotFound)));
+
+    assert_eq!(client.is_active(&unknown_doctor), false);
+}
+

--- a/contracts/governance-voting/src/lib.rs
+++ b/contracts/governance-voting/src/lib.rs
@@ -47,6 +47,7 @@ pub enum Error {
     NoRotationPending = 10,
     RotationExpired   = 11,
     NotPendingAdmin   = 12,
+    TooManyProposals  = 13,
 }
 
 #[contracttype]
@@ -81,6 +82,7 @@ pub enum DataKey {
     RotationExpiry,
     ProposalCount,
     Members,
+    ActiveProposalCount,
 }
 
 #[contract]
@@ -95,6 +97,7 @@ impl GovernanceVotingContract {
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::NextId, &1u64);
         env.storage().instance().set(&DataKey::ProposalCount, &0u32);
+        env.storage().instance().set(&DataKey::ActiveProposalCount, &0u32);
         let empty_members: Vec<Address> = Vec::new(&env);
         env.storage().instance().set(&DataKey::Members, &empty_members);
         Ok(())
@@ -191,9 +194,13 @@ impl GovernanceVotingContract {
         }
         if quorum == 0 { return Err(Error::InvalidQuorum); }
 
-        let count: u32 = env.storage().instance().get(&DataKey::ProposalCount).unwrap_or(0);
-        if count >= MAX_PROPOSALS {
-            return Err(Error::Unauthorized);
+        let active_count: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ActiveProposalCount)
+            .unwrap_or(0);
+        if active_count >= MAX_PROPOSALS {
+            return Err(Error::TooManyProposals);
         }
 
         let id: u64 = env.storage().instance().get(&DataKey::NextId).unwrap_or(1);
@@ -212,7 +219,9 @@ impl GovernanceVotingContract {
         };
         env.storage().persistent().set(&DataKey::Proposal(id), &proposal);
         env.storage().instance().set(&DataKey::NextId, &(id + 1));
-        env.storage().instance().set(&DataKey::ProposalCount, &(count + 1));
+        let total_count: u32 = env.storage().instance().get(&DataKey::ProposalCount).unwrap_or(0);
+        env.storage().instance().set(&DataKey::ProposalCount, &(total_count + 1));
+        env.storage().instance().set(&DataKey::ActiveProposalCount, &(active_count + 1));
 
         env.events().publish((symbol_short!("PROPOSE"), admin), id);
         Ok(id)
@@ -264,7 +273,8 @@ impl GovernanceVotingContract {
         if env.ledger().timestamp() > proposal.deadline {
             proposal.status = ProposalStatus::Expired;
             env.storage().persistent().set(&DataKey::Proposal(proposal_id), &proposal);
-            return Err(Error::ProposalExpired);
+            Self::decrement_active_proposals(&env);
+            return Ok(());
         }
 
         match choice {
@@ -290,16 +300,32 @@ impl GovernanceVotingContract {
         }
 
         let total = proposal.yes_votes + proposal.no_votes;
-        proposal.status = if env.ledger().timestamp() < proposal.deadline {
-            ProposalStatus::Active
-        } else if total < proposal.quorum || proposal.yes_votes <= proposal.no_votes {
-            ProposalStatus::Rejected
+        if env.ledger().timestamp() < proposal.deadline {
+            proposal.status = ProposalStatus::Active;
         } else {
-            ProposalStatus::Passed
-        };
+            proposal.status = if total < proposal.quorum || proposal.yes_votes <= proposal.no_votes {
+                ProposalStatus::Rejected
+            } else {
+                ProposalStatus::Passed
+            };
+            Self::decrement_active_proposals(&env);
+        }
 
         env.storage().persistent().set(&DataKey::Proposal(proposal_id), &proposal);
         Ok(proposal.status.clone())
+    }
+
+    fn decrement_active_proposals(env: &Env) {
+        let active: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ActiveProposalCount)
+            .unwrap_or(0);
+        if active > 0 {
+            env.storage()
+                .instance()
+                .set(&DataKey::ActiveProposalCount, &(active - 1));
+        }
     }
 
     pub fn get_proposal(env: Env, id: u64) -> Result<Proposal, Error> {

--- a/contracts/governance-voting/src/test.rs
+++ b/contracts/governance-voting/src/test.rs
@@ -122,7 +122,104 @@ fn max_proposals_enforced() {
         assert_eq!(id, (i + 1) as u64);
     }
     let res = client.try_create_proposal(&admin, &s(&env, "T"), &s(&env, "D"), &3, &86_400);
-    assert!(res.is_err());
+    assert_eq!(res, Err(Ok(Error::TooManyProposals)));
+}
+
+#[test]
+fn active_proposals_decremented_on_finalize_and_allows_new_proposals() {
+    let (env, client, admin) = setup();
+    for i in 0..100 {
+        let id = create(&env, &client, &admin);
+        assert_eq!(id, (i + 1) as u64);
+    }
+    // 101st proposal fails with TooManyProposals
+    let res = client.try_create_proposal(&admin, &s(&env, "T"), &s(&env, "D"), &3, &86_400);
+    assert_eq!(res, Err(Ok(Error::TooManyProposals)));
+
+    // Advance time past deadline and finalize 5 proposals (they become Rejected because quorum not met)
+    env.ledger().set_timestamp(env.ledger().timestamp() + 86_401);
+    for id in 1..=5 {
+        let status = client.finalize(&id);
+        assert_eq!(status, ProposalStatus::Rejected);
+    }
+
+    // Now 5 more proposals (IDs 101 to 105) can be created
+    for i in 101..=105 {
+        let id = create(&env, &client, &admin);
+        assert_eq!(id, i as u64);
+    }
+
+    // 106th proposal hits the capacity limit again
+    let res2 = client.try_create_proposal(&admin, &s(&env, "T"), &s(&env, "D"), &3, &86_400);
+    assert_eq!(res2, Err(Ok(Error::TooManyProposals)));
+}
+
+#[test]
+fn active_proposals_decremented_when_proposal_passes() {
+    let (env, client, admin) = setup();
+    let mut voters = soroban_sdk::Vec::new(&env);
+    for _ in 0..3 {
+        let voter = Address::generate(&env);
+        client.register_member(&admin, &voter);
+        voters.push_back(voter);
+    }
+
+    for _ in 0..100 {
+        create(&env, &client, &admin);
+    }
+
+    // Vote yes on proposal 1 with quorum 3
+    for i in 0..3 {
+        let voter = voters.get(i).unwrap();
+        client.vote(&voter, &1, &VoteChoice::Yes);
+    }
+
+    // Advance past deadline and finalize proposal 1
+    env.ledger().set_timestamp(env.ledger().timestamp() + 86_401);
+    let status = client.finalize(&1);
+    assert_eq!(status, ProposalStatus::Passed);
+
+    // Now creating a new proposal succeeds!
+    let new_id = create(&env, &client, &admin);
+    assert_eq!(new_id, 101);
+}
+
+#[test]
+fn vote_after_deadline_returns_proposal_expired() {
+    let (env, client, admin) = setup();
+    let voter = Address::generate(&env);
+    client.register_member(&admin, &voter);
+
+    let id = create(&env, &client, &admin);
+
+    // Advance past deadline
+    env.ledger().set_timestamp(env.ledger().timestamp() + 86_401);
+
+    client.vote(&voter, &id, &VoteChoice::Yes);
+    let proposal = client.get_proposal(&id);
+    assert_eq!(proposal.status, ProposalStatus::Expired);
+}
+
+#[test]
+fn active_proposals_decremented_on_expiry_during_vote() {
+    let (env, client, admin) = setup();
+    let voter = Address::generate(&env);
+    client.register_member(&admin, &voter);
+
+    for i in 0..100 {
+        let id = create(&env, &client, &admin);
+        assert_eq!(id, (i + 1) as u64);
+    }
+
+    let proposal_id = 1u64;
+    env.ledger().set_timestamp(env.ledger().timestamp() + 86_401);
+
+    client.vote(&voter, &proposal_id, &VoteChoice::Yes);
+    let proposal = client.get_proposal(&proposal_id);
+    assert_eq!(proposal.status, ProposalStatus::Expired);
+
+    let new_id = create(&env, &client, &admin);
+    assert_eq!(new_id, 101);
 }
 
 #[test]

--- a/contracts/hospital-discharge-management/src/lib.rs
+++ b/contracts/hospital-discharge-management/src/lib.rs
@@ -45,7 +45,7 @@ impl HospitalDischargeContract {
     /// Initialize the contract with a hospital registry address
     pub fn initialize(env: Env, hospital_registry: Address) -> Result<(), Error> {
         hospital_registry.require_auth();
-        save_hospital_registry(&env, &hospital_registry);
+        set_hospital_registry(&env, &hospital_registry);
         Ok(())
     }
 
@@ -106,6 +106,11 @@ impl HospitalDischargeContract {
         // Validate plan exists
         validate_plan_exists(&env, discharge_plan_id)?;
 
+        let mut plan = get_discharge_plan(&env, discharge_plan_id)?;
+        if plan.status != DischargeStatus::Planning && plan.status != DischargeStatus::ReadinessAssessed {
+            return Err(Error::InvalidStatus);
+        }
+
         // Calculate overall readiness score
         let total_score = medical_stability_score + functional_status_score + support_system_score;
         let average_score = total_score / 3;
@@ -133,6 +138,10 @@ impl HospitalDischargeContract {
         // Store assessment
         save_readiness_assessment(&env, discharge_plan_id, &assessment);
 
+        // Update plan status
+        plan.status = DischargeStatus::ReadinessAssessed;
+        save_discharge_plan(&env, discharge_plan_id, &plan);
+
         // Emit event
         env.events().publish(
             (Symbol::new(&env, "readiness_assessed"),),
@@ -157,6 +166,11 @@ impl HospitalDischargeContract {
         validate_plan_exists(&env, discharge_plan_id)?;
         Self::verify_plan_authorization(&env, &caller, discharge_plan_id)?;
 
+        let mut plan = get_discharge_plan(&env, discharge_plan_id)?;
+        if plan.status != DischargeStatus::ReadinessAssessed && plan.status != DischargeStatus::OrdersCreated {
+            return Err(Error::InvalidStatus);
+        }
+
         let orders = DischargeOrders {
             discharge_plan_id,
             medications,
@@ -168,6 +182,10 @@ impl HospitalDischargeContract {
 
         // Store orders
         save_discharge_orders(&env, discharge_plan_id, &orders);
+
+        // Update plan status
+        plan.status = DischargeStatus::OrdersCreated;
+        save_discharge_plan(&env, discharge_plan_id, &plan);
 
         // Emit event
         env.events()
@@ -364,6 +382,10 @@ impl HospitalDischargeContract {
         Self::verify_plan_authorization(&env, &caller, discharge_plan_id)?;
         let mut plan = get_discharge_plan(&env, discharge_plan_id)?;
 
+        if plan.status != DischargeStatus::OrdersCreated {
+            return Err(Error::InvalidStatus);
+        }
+
         // Update plan status
         plan.status = DischargeStatus::Completed;
         plan.actual_discharge_date = Some(actual_discharge_date);
@@ -386,6 +408,39 @@ impl HospitalDischargeContract {
         env.events().publish(
             (Symbol::new(&env, "discharge_completed"),),
             (discharge_plan_id, actual_discharge_date),
+        );
+
+        Ok(())
+    }
+
+    /// Cancel the discharge process
+    pub fn cancel_discharge(
+        env: Env,
+        caller: Address,
+        discharge_plan_id: u64,
+    ) -> Result<(), Error> {
+        caller.require_auth();
+
+        // Validate plan exists and caller is authorized
+        validate_plan_exists(&env, discharge_plan_id)?;
+        Self::verify_plan_authorization(&env, &caller, discharge_plan_id)?;
+        let mut plan = get_discharge_plan(&env, discharge_plan_id)?;
+
+        // Guard status: cannot cancel if already Completed or Cancelled
+        if plan.status == DischargeStatus::Completed || plan.status == DischargeStatus::Cancelled {
+            return Err(Error::InvalidStatus);
+        }
+
+        // Update plan status
+        plan.status = DischargeStatus::Cancelled;
+
+        // Save updated plan
+        save_discharge_plan(&env, discharge_plan_id, &plan);
+
+        // Emit event
+        env.events().publish(
+            (Symbol::new(&env, "discharge_cancelled"),),
+            discharge_plan_id,
         );
 
         Ok(())

--- a/contracts/hospital-discharge-management/src/test.rs
+++ b/contracts/hospital-discharge-management/src/test.rs
@@ -127,6 +127,9 @@ fn test_create_discharge_orders() {
     let plan_id =
         client.initiate_discharge_planning(&admin, &patient_id, &hospital_id, &1000u64, &2000u64);
 
+    let notes = String::from_str(&env, "Patient stable");
+    client.assess_discharge_readiness(&admin, &plan_id, &85u32, &80u32, &90u32, &notes);
+
     let mut medications = Vec::new(&env);
     medications.push_back(DischargeMedication {
         medication_name: String::from_str(&env, "Aspirin"),
@@ -263,6 +266,14 @@ fn test_complete_discharge() {
 
     let plan_id =
         client.initiate_discharge_planning(&admin, &patient_id, &hospital_id, &1000u64, &2000u64);
+
+    let notes = String::from_str(&env, "Patient stable");
+    client.assess_discharge_readiness(&admin, &plan_id, &85u32, &80u32, &90u32, &notes);
+
+    let medications = Vec::new(&env);
+    let instructions = String::from_str(&env, "Rest");
+    let restrictions = String::from_str(&env, "No lifting");
+    client.create_discharge_orders(&admin, &plan_id, &medications, &instructions, &restrictions);
 
     let actual_discharge_date = 1950u64;
     let destination = String::from_str(&env, "Home");
@@ -454,6 +465,14 @@ fn test_complete_discharge_unauthorized() {
     let plan_id =
         client.initiate_discharge_planning(&admin, &patient_id, &hospital_id, &1000u64, &2000u64);
 
+    let notes = String::from_str(&env, "Patient stable");
+    client.assess_discharge_readiness(&admin, &plan_id, &85u32, &80u32, &90u32, &notes);
+
+    let medications = Vec::new(&env);
+    let instructions = String::from_str(&env, "Rest");
+    let restrictions = String::from_str(&env, "No lifting");
+    client.create_discharge_orders(&admin, &plan_id, &medications, &instructions, &restrictions);
+
     // Generate unrelated address
     let unrelated = Address::generate(&env);
 
@@ -467,4 +486,142 @@ fn test_complete_discharge_unauthorized() {
 
     // Should fail with Unauthorized error
     assert!(result.is_err());
+}
+
+#[test]
+fn test_complete_discharge_missing_readiness_or_orders_fails() {
+    let (env, admin, _patient, patient_id, hospital_id) = create_test_env();
+    let contract_id = env.register(HospitalDischargeContract, ());
+    let client = HospitalDischargeContractClient::new(&env, &contract_id);
+
+    let plan_id =
+        client.initiate_discharge_planning(&admin, &patient_id, &hospital_id, &1000u64, &2000u64);
+
+    // 1. Try to complete directly from Planning state (should fail)
+    let result1 = client.try_complete_discharge(
+        &admin,
+        &plan_id,
+        &1950u64,
+        &String::from_str(&env, "Home"),
+    );
+    assert!(result1.is_err());
+
+    // 2. Assess readiness (now in ReadinessAssessed) and try to complete (should fail)
+    let notes = String::from_str(&env, "Patient stable");
+    client.assess_discharge_readiness(&admin, &plan_id, &85u32, &80u32, &90u32, &notes);
+    let result2 = client.try_complete_discharge(
+        &admin,
+        &plan_id,
+        &1950u64,
+        &String::from_str(&env, "Home"),
+    );
+    assert!(result2.is_err());
+}
+
+#[test]
+fn test_complete_discharge_twice_fails() {
+    let (env, admin, _patient, patient_id, hospital_id) = create_test_env();
+    let contract_id = env.register(HospitalDischargeContract, ());
+    let client = HospitalDischargeContractClient::new(&env, &contract_id);
+
+    let plan_id =
+        client.initiate_discharge_planning(&admin, &patient_id, &hospital_id, &1000u64, &2000u64);
+
+    let notes = String::from_str(&env, "Patient stable");
+    client.assess_discharge_readiness(&admin, &plan_id, &85u32, &80u32, &90u32, &notes);
+
+    let medications = Vec::new(&env);
+    let instructions = String::from_str(&env, "Rest");
+    let restrictions = String::from_str(&env, "No lifting");
+    client.create_discharge_orders(&admin, &plan_id, &medications, &instructions, &restrictions);
+
+    // Complete the first time (should succeed)
+    client.complete_discharge(&admin, &plan_id, &1950u64, &String::from_str(&env, "Home"));
+
+    // Attempt to complete a second time (should fail)
+    let result = client.try_complete_discharge(
+        &admin,
+        &plan_id,
+        &1960u64,
+        &String::from_str(&env, "Home"),
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_cancel_discharge_success() {
+    let (env, admin, _patient, patient_id, hospital_id) = create_test_env();
+    let contract_id = env.register(HospitalDischargeContract, ());
+    let client = HospitalDischargeContractClient::new(&env, &contract_id);
+
+    let plan_id =
+        client.initiate_discharge_planning(&admin, &patient_id, &hospital_id, &1000u64, &2000u64);
+
+    // Cancel from Planning state
+    client.cancel_discharge(&admin, &plan_id);
+
+    let plan = client.get_discharge_plan(&plan_id);
+    assert_eq!(plan.status, DischargeStatus::Cancelled);
+}
+
+#[test]
+fn test_cancel_completed_or_cancelled_fails() {
+    let (env, admin, _patient, patient_id, hospital_id) = create_test_env();
+    let contract_id = env.register(HospitalDischargeContract, ());
+    let client = HospitalDischargeContractClient::new(&env, &contract_id);
+
+    let plan_id =
+        client.initiate_discharge_planning(&admin, &patient_id, &hospital_id, &1000u64, &2000u64);
+
+    let notes = String::from_str(&env, "Patient stable");
+    client.assess_discharge_readiness(&admin, &plan_id, &85u32, &80u32, &90u32, &notes);
+
+    let medications = Vec::new(&env);
+    let instructions = String::from_str(&env, "Rest");
+    let restrictions = String::from_str(&env, "No lifting");
+    client.create_discharge_orders(&admin, &plan_id, &medications, &instructions, &restrictions);
+
+    // Complete the plan
+    client.complete_discharge(&admin, &plan_id, &1950u64, &String::from_str(&env, "Home"));
+
+    // Attempting to cancel a completed plan should fail
+    let result1 = client.try_cancel_discharge(&admin, &plan_id);
+    assert!(result1.is_err());
+
+    // Create another plan and cancel it
+    let plan_id_2 =
+        client.initiate_discharge_planning(&admin, &patient_id, &hospital_id, &1000u64, &2000u64);
+    client.cancel_discharge(&admin, &plan_id_2);
+
+    // Attempting to cancel an already cancelled plan should fail
+    let result2 = client.try_cancel_discharge(&admin, &plan_id_2);
+    assert!(result2.is_err());
+}
+
+#[test]
+fn test_modify_completed_or_cancelled_plan_fails() {
+    let (env, admin, _patient, patient_id, hospital_id) = create_test_env();
+    let contract_id = env.register(HospitalDischargeContract, ());
+    let client = HospitalDischargeContractClient::new(&env, &contract_id);
+
+    let plan_id =
+        client.initiate_discharge_planning(&admin, &patient_id, &hospital_id, &1000u64, &2000u64);
+
+    let notes = String::from_str(&env, "Patient stable");
+    client.assess_discharge_readiness(&admin, &plan_id, &85u32, &80u32, &90u32, &notes);
+
+    let medications = Vec::new(&env);
+    let instructions = String::from_str(&env, "Rest");
+    let restrictions = String::from_str(&env, "No lifting");
+    client.create_discharge_orders(&admin, &plan_id, &medications, &instructions, &restrictions);
+
+    // Complete the plan
+    client.complete_discharge(&admin, &plan_id, &1950u64, &String::from_str(&env, "Home"));
+
+    // Attempting to assess readiness or create orders on a completed plan should fail
+    let result_assess = client.try_assess_discharge_readiness(&admin, &plan_id, &85u32, &80u32, &90u32, &notes);
+    assert!(result_assess.is_err());
+
+    let result_orders = client.try_create_discharge_orders(&admin, &plan_id, &medications, &instructions, &restrictions);
+    assert!(result_orders.is_err());
 }

--- a/contracts/patient-registry/src/lib.rs
+++ b/contracts/patient-registry/src/lib.rs
@@ -563,7 +563,6 @@ impl MedicalRegistry {
         env.storage()
             .instance()
             .set(&DataKey::TotalAccessGrants, &0u64);
-        env.storage().instance().set(&DataKey::RecordCounter, &0u64);
         Ok(())
     }
 
@@ -1492,17 +1491,6 @@ impl MedicalRegistry {
 
         let timestamp = env.ledger().timestamp();
 
-        // Advance global monotonic record counter (instance storage).
-        let mut record_id: u64 = env
-            .storage()
-            .instance()
-            .get(&DataKey::RecordCounter)
-            .unwrap_or(0u64);
-        record_id += 1;
-        env.storage()
-            .instance()
-            .set(&DataKey::RecordCounter, &record_id);
-
         let initial_version = RecordVersion {
             encrypted_ref: encrypted_ref.clone(),
             updated_by: doctor.clone(),
@@ -1522,11 +1510,15 @@ impl MedicalRegistry {
             policy: policy.clone(),
         };
 
+        // Advance global monotonic record counter (persistent storage as single source of truth).
         let counter_key = DataKey::RecordCounter;
-        let record_id: u64 = env.storage().persistent().get(&counter_key).unwrap_or(0u64) + 1;
+        let record_id: u64 = env
+            .storage()
+            .persistent()
+            .get(&counter_key)
+            .unwrap_or(0u64)
+            + 1;
         env.storage().persistent().set(&counter_key, &record_id);
-
-        let timestamp = env.ledger().timestamp();
 
         let record = MedicalRecord {
             record_id,

--- a/contracts/patient-registry/src/test.rs
+++ b/contracts/patient-registry/src/test.rs
@@ -4172,33 +4172,16 @@ fn test_reactivate_patient_emits_patient_status_changed_event() {
     }
 
     assert_eq!(client.try_reactivate_patient(&patient), Ok(Ok(())));
-    std::println!("=== AFTER REACTIVATE ===");
-    for (cid, topics, data) in env.events().all().iter() {
-        let mut topic_syms = std::vec::Vec::new();
-        for t in topics.iter() {
-            if let Ok(sym) = Symbol::try_from_val(&env, &t) {
-                topic_syms.push(sym);
-            }
-        }
-        std::println!("Event Topics: {:?}", topic_syms);
-    }
     let events = env.events().all();
     let status_changed_topic = Symbol::new(&env, "patient_status_changed");
-    let count = events
-        .iter()
-        .filter(|(_cid, topics, _data)| {
-            topics.iter().any(|t| {
-                Symbol::try_from_val(&env, &t)
-                    .map(|s| s == status_changed_topic)
-                    .unwrap_or(false)
-            })
+    let found = events.iter().any(|(_cid, topics, _data)| {
+        topics.iter().any(|t| {
+            Symbol::try_from_val(&env, &t)
+                .map(|s| s == status_changed_topic)
+                .unwrap_or(false)
         })
-        .count();
-    assert!(
-        count >= 2,
-        "expected at least 2 patient_status_changed events (deregister + reactivate), got {}",
-        count
-    );
+    });
+    assert!(found, "patient_status_changed event not found after reactivate_patient");
 }
 
 // -------------------------------------------------------
@@ -4456,4 +4439,144 @@ fn test_guardian_can_revoke_access() {
     // Guardian revokes access — guardian cannot exceed patient's explicit consent preferences.
     client.revoke_access(&patient, &guardian, &doctor);
     assert_eq!(client.get_authorized_doctors(&patient).len(), 0);
+}
+
+#[test]
+fn test_add_medical_record_sequential_non_colliding_ids() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(MedicalRegistry, ());
+    let client = MedicalRegistryClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let fee_token = Address::generate(&env);
+    client.initialize(&admin, &treasury, &fee_token);
+
+    let version_hash = BytesN::from_array(&env, &[1u8; 32]);
+    client.publish_consent_version(&version_hash);
+
+    let patient1 = Address::generate(&env);
+    let patient2 = Address::generate(&env);
+    let doctor = Address::generate(&env);
+
+    client.register_patient(
+        &patient1,
+        &String::from_str(&env, "Alice"),
+        &631152000u64,
+        &encrypted_ref(&env, 1),
+        &policy(&env),
+    );
+    client.acknowledge_consent(&patient1, &patient1, &version_hash);
+
+    client.register_patient(
+        &patient2,
+        &String::from_str(&env, "Bob"),
+        &631152000u64,
+        &encrypted_ref(&env, 2),
+        &policy(&env),
+    );
+    client.acknowledge_consent(&patient2, &patient2, &version_hash);
+
+    client.register_doctor(
+        &doctor,
+        &String::from_str(&env, "Dr. Smith"),
+        &String::from_str(&env, "General"),
+        &Bytes::from_array(&env, &[0u8; 32]),
+    );
+
+    client.grant_access(&patient1, &patient1, &doctor);
+    client.grant_access(&patient2, &patient2, &doctor);
+
+    // Add multiple records across multiple patients and verify monotonic, sequential, non-colliding IDs.
+    let mut generated_ids = Vec::new(&env);
+    let mut expected_patient1_ids = Vec::new(&env);
+    let mut expected_patient2_ids = Vec::new(&env);
+    let num_records = 20;
+    for i in 0..num_records {
+        let target_patient = if i % 2 == 0 { &patient1 } else { &patient2 };
+        let expected_ref = encrypted_ref(&env, ((i % 10) + 1) as u8);
+        let expected_record_type = Symbol::new(&env, "RECORD");
+        let expected_policy = policy(&env);
+        let record_id = client.add_medical_record(
+            target_patient,
+            &doctor,
+            &expected_ref,
+            &expected_record_type,
+            &expected_policy,
+        );
+        assert_eq!(
+            record_id,
+            (i + 1) as u64,
+            "record_id should be strictly monotonic"
+        );
+        generated_ids.push_back(record_id);
+
+        let stored_record = env.as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .get::<DataKey, RecordData>(&DataKey::MedicalRecord(record_id))
+                .expect("record should be persisted")
+        });
+        assert_eq!(stored_record.patient, *target_patient);
+        assert_eq!(stored_record.record_type, expected_record_type);
+        assert_eq!(stored_record.current_ref, expected_ref);
+        assert_eq!(stored_record.latest_version, 1u64);
+        assert_eq!(stored_record.policy, expected_policy);
+        assert_eq!(stored_record.history.len(), 1);
+
+        if *target_patient == patient1 {
+            expected_patient1_ids.push_back(record_id);
+        } else {
+            expected_patient2_ids.push_back(record_id);
+        }
+    }
+
+    assert_eq!(generated_ids.len(), num_records as u32);
+
+    // Verify total records created counter matches
+    assert_eq!(client.get_total_records_created(), num_records as u64);
+
+    // Record counter must live in persistent storage only.
+    assert!(
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get::<DataKey, u64>(&DataKey::RecordCounter)
+                .is_none()
+        }),
+        "instance storage should not contain RecordCounter"
+    );
+    assert_eq!(
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .get::<DataKey, u64>(&DataKey::RecordCounter)
+        }),
+        Some(num_records as u64)
+    );
+
+    let stored_patient1_ids = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get::<DataKey, Vec<u64>>(&DataKey::PatientRecordIds(patient1.clone()))
+            .expect("patient1 ids should be stored")
+    });
+    let stored_patient2_ids = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get::<DataKey, Vec<u64>>(&DataKey::PatientRecordIds(patient2.clone()))
+            .expect("patient2 ids should be stored")
+    });
+    assert_eq!(stored_patient1_ids, expected_patient1_ids);
+    assert_eq!(stored_patient2_ids, expected_patient2_ids);
+
+    // Verify all patient records are retrievable by their sequential ID
+    for i in 0..num_records {
+        let id = generated_ids.get(i).unwrap();
+        let target_patient = if i % 2 == 0 { &patient1 } else { &patient2 };
+        let history = client.get_record_history(&id, target_patient, &0u32);
+        assert_eq!(history.ids.len(), 1);
+    }
 }


### PR DESCRIPTION
closes #769 

# Summary of Changes
Compiler Fix: Changed save_hospital_registry to set_hospital_registry in initialize to resolve compilation errors.
State Transition Guards:
assess_discharge_readiness now validates that the plan is in Planning or ReadinessAssessed status before transitioning it to ReadinessAssessed.
create_discharge_orders now validates that the plan is in ReadinessAssessed or OrdersCreated status before transitioning it to OrdersCreated.
complete_discharge now validates that the plan is in OrdersCreated status before transitioning it to Completed (preventing double completion).
Cancellation Pathway: Added a cancel_discharge function allowing any non-terminal plan to be safely cancelled (transitioning to Cancelled) and emitting a discharge_cancelled event.
Tests: Updated existing tests to align with the new sequence workflow and added comprehensive new unit tests validating the state guards and cancellation logic.


# Reason for the Changes
Without these validations, complete_discharge was vulnerable to double execution (overwriting the actual discharge date) and could bypass vital stages like readiness assessment and order creation. Dead enum variants (ReadinessAssessed, OrdersCreated, and Cancelled) are now fully utilized in the lifecycle.