### PR TITLE
security/bug: fix authorization gaps in prior-authorization, lab-mana…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,6 +1089,7 @@ dependencies = [
 name = "lab-management"
 version = "0.1.0"
 dependencies = [
+ "provider-registry",
  "shared",
  "soroban-sdk",
 ]
@@ -1499,6 +1500,7 @@ name = "referral"
 version = "0.1.0"
 dependencies = [
  "Contracts",
+ "provider-registry",
  "shared",
  "soroban-sdk",
 ]

--- a/contracts/lab-management/Cargo.toml
+++ b/contracts/lab-management/Cargo.toml
@@ -13,4 +13,5 @@ soroban-sdk = { workspace = true }
 shared = { workspace = true }
 
 [dev-dependencies]
+provider-registry = { path = "../provider-registry" }
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/lab-management/src/lib.rs
+++ b/contracts/lab-management/src/lib.rs
@@ -236,10 +236,24 @@ impl LabManagementContract {
         lab_id: Address,
         test_code: String,
         val: String,
-    ) {
+    ) -> Result<(), Error> {
         lab_id.require_auth();
+
+        // 1. Verify order exists.
+        let order: LabOrder = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LabOrder(order_id))
+            .ok_or(Error::NotFound)?;
+
+        // 2. Verify the caller is the assigned lab.
+        if order.lab_id != Some(lab_id.clone()) {
+            return Err(Error::Unauthorized);
+        }
+
         env.events()
             .publish((Symbol::new(&env, "CRITICAL"), order_id), (test_code, val));
+        Ok(())
     }
 }
 mod test;

--- a/contracts/lab-management/src/test.rs
+++ b/contracts/lab-management/src/test.rs
@@ -27,6 +27,37 @@ fn make_result(env: &Env) -> TestResult {
     }
 }
 
+/// Wires up a ProviderRegistry, initializes `lab_client` against it, and
+/// registers a provider on it. Returns the registered provider's address.
+///
+/// `order_lab_test` requires the ordering provider to be registered on the
+/// configured ProviderRegistry (see `Error::ProviderNotRegistered`), so any
+/// test that needs to create a real order via `order_lab_test` must go
+/// through this setup first.
+fn setup_registered_provider(env: &Env, lab_client: &LabManagementContractClient) -> Address {
+    let provider_registry_id = env.register_contract(None, ProviderRegistry);
+    let pr_client = ProviderRegistryClient::new(env, &provider_registry_id);
+    let admin = Address::generate(env);
+    pr_client.initialize(&admin);
+
+    lab_client.initialize(&provider_registry_id);
+
+    let provider = Address::generate(env);
+    pr_client.register_provider(
+        &admin,
+        &provider,
+        &String::from_str(env, "Dr. Lab"),
+        &String::from_str(env, "Pathology"),
+        &String::from_str(env, "LAB123"),
+        &BytesN::from_array(env, &[1; 32]),
+        &admin,
+        &BytesN::from_array(env, &[2; 32]),
+        &(env.ledger().timestamp() + 86400),
+        &BytesN::from_array(env, &[3; 32]),
+    );
+    provider
+}
+
 // ── existing tests (unchanged behaviour) ─────────────────────────────────────
 
 #[test]
@@ -91,12 +122,102 @@ fn test_critical_value_alerting() {
     env.mock_all_auths();
     let contract_id = env.register(LabManagementContract, ());
     let client = LabManagementContractClient::new(&env, &contract_id);
+    let provider = setup_registered_provider(&env, &client);
+
+    let patient = Address::generate(&env);
+    let lab = Address::generate(&env);
+    let test_code = String::from_str(&env, "12345-1");
+    let value = String::from_str(&env, "9.0");
+
+    let order_id = client.order_lab_test(&provider, &patient, &make_req(&env));
+    client.assign_lab(&order_id, &lab, &3600);
+
+    client.flag_critical_value(&order_id, &lab, &test_code, &value);
+}
+
+/// A lab that has never been assigned to the order (order.lab_id is None)
+/// must not be able to flag a critical value for it.
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_flag_critical_value_unassigned_lab_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LabManagementContract, ());
+    let client = LabManagementContractClient::new(&env, &contract_id);
+    let provider = setup_registered_provider(&env, &client);
+
+    let patient = Address::generate(&env);
+    let lab = Address::generate(&env);
+    let test_code = String::from_str(&env, "12345-1");
+    let value = String::from_str(&env, "9.0");
+
+    // Order is created but never assigned to any lab.
+    let order_id = client.order_lab_test(&provider, &patient, &make_req(&env));
+
+    client.flag_critical_value(&order_id, &lab, &test_code, &value);
+}
+
+/// A lab other than the one actually assigned to the order must not be able
+/// to flag a critical value for it.
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_flag_critical_value_wrong_lab_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LabManagementContract, ());
+    let client = LabManagementContractClient::new(&env, &contract_id);
+    let provider = setup_registered_provider(&env, &client);
+
+    let patient = Address::generate(&env);
+    let lab_a = Address::generate(&env);
+    let lab_b = Address::generate(&env);
+    let test_code = String::from_str(&env, "12345-1");
+    let value = String::from_str(&env, "9.0");
+
+    let order_id = client.order_lab_test(&provider, &patient, &make_req(&env));
+    client.assign_lab(&order_id, &lab_a, &3600);
+
+    // lab_b is not the assigned lab.
+    client.flag_critical_value(&order_id, &lab_b, &test_code, &value);
+}
+
+/// Flagging a critical value against an order_id that was never created
+/// must fail rather than silently emitting an event.
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_flag_critical_value_nonexistent_order_returns_error() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LabManagementContract, ());
+    let client = LabManagementContractClient::new(&env, &contract_id);
 
     let lab = Address::generate(&env);
     let test_code = String::from_str(&env, "12345-1");
     let value = String::from_str(&env, "9.0");
 
-    client.flag_critical_value(&0, &lab, &test_code, &value);
+    client.flag_critical_value(&999, &lab, &test_code, &value);
+}
+
+/// The lab actually assigned to the order must be able to flag a critical
+/// value successfully.
+#[test]
+fn test_flag_critical_value_correct_lab_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(LabManagementContract, ());
+    let client = LabManagementContractClient::new(&env, &contract_id);
+    let provider = setup_registered_provider(&env, &client);
+
+    let patient = Address::generate(&env);
+    let lab = Address::generate(&env);
+    let test_code = String::from_str(&env, "12345-1");
+    let value = String::from_str(&env, "9.0");
+
+    let order_id = client.order_lab_test(&provider, &patient, &make_req(&env));
+    client.assign_lab(&order_id, &lab, &3600);
+
+    let result = client.try_flag_critical_value(&order_id, &lab, &test_code, &value);
+    assert!(result.is_ok());
 }
 
 #[test]
@@ -320,7 +441,7 @@ fn test_provider_registration_verification() {
     let result = client.try_order_lab_test(&registered_provider, &patient, &make_req(&env));
     assert!(result.is_ok());
     let order_id = result.unwrap();
-    assert_eq!(order_id, 0);
+    assert_eq!(order_id, Ok(0));
 }
 
 #[test]

--- a/contracts/prescription-management/src/lib.rs
+++ b/contracts/prescription-management/src/lib.rs
@@ -1149,11 +1149,18 @@ impl PrescriptionContract {
         Ok(warnings)
     }
 
+    /// #737: PHI read — reveals whether `patient_id` has an allergy to `medication`.
+    /// Requires `requester` to authenticate, and to be either the patient themself
+    /// or a caller registered in the provider-registry (see `require_phi_access`).
     pub fn check_allergy_interaction(
         env: Env,
+        requester: Address,
         patient_id: Address,
         medication: String,
     ) -> Result<Vec<InteractionWarning>, Error> {
+        requester.require_auth();
+        require_phi_access(&env, &requester, &patient_id)?;
+
         let med: Medication = env
             .storage()
             .persistent()
@@ -1191,12 +1198,20 @@ impl PrescriptionContract {
         Ok(warnings)
     }
 
+    /// #737: PHI read — reveals whether `patient_id` has a condition contraindicated
+    /// with `medication`. Requires `requester` to authenticate, and to be either the
+    /// patient themself or a caller registered in the provider-registry (see
+    /// `require_phi_access`).
     pub fn get_contraindications(
         env: Env,
+        requester: Address,
         patient_id: Address,
         medication: String,
         conditions: Vec<String>,
     ) -> Result<Vec<String>, Error> {
+        requester.require_auth();
+        require_phi_access(&env, &requester, &patient_id)?;
+
         if !env
             .storage()
             .persistent()
@@ -1774,6 +1789,39 @@ fn do_issue_prescription(
     );
 
     Ok(rx_id)
+}
+
+/// Authorization gate for PHI reads that expose patient allergy/condition data
+/// (`check_allergy_interaction`, `get_contraindications` — see #737). This
+/// contract has no separate consent-grant/access-control mechanism (unlike the
+/// sibling `allergy-tracking` contract's `AccessControl` map), so a caller is
+/// authorized only if they *are* the patient, or if they are registered in the
+/// configured provider-registry — the only gating primitive this contract has,
+/// mirroring the check `do_issue_prescription` already performs for
+/// `issue_prescription`.
+///
+/// Unlike `do_issue_prescription` (which treats an unconfigured registry as
+/// "skip the check"), this fails *closed*: if no provider-registry is
+/// configured, only the patient themself may read their own PHI. That's
+/// intentional — this gate exists specifically to close a PHI leak, so an
+/// unconfigured registry must not silently reopen it.
+fn require_phi_access(env: &Env, requester: &Address, patient_id: &Address) -> Result<(), Error> {
+    if requester == patient_id {
+        return Ok(());
+    }
+
+    if let Some(registry_addr) = env
+        .storage()
+        .persistent()
+        .get::<_, Address>(&DataKey::ProviderRegistry)
+    {
+        let client = ProviderRegistryClient::new(env, &registry_addr);
+        if client.is_provider(requester) {
+            return Ok(());
+        }
+    }
+
+    Err(Error::Unauthorized)
 }
 
 fn is_registry_governed(env: &Env) -> bool {

--- a/contracts/prescription-management/src/test.rs
+++ b/contracts/prescription-management/src/test.rs
@@ -326,7 +326,8 @@ fn test_drug_allergy_and_contraindications() {
 
     client.set_patient_allergies(&patient, &vec![&env, String::from_str(&env, "Penicillin")]);
 
-    let allergy = client.check_allergy_interaction(&patient, &med);
+    // The patient querying their own allergies is always authorized.
+    let allergy = client.check_allergy_interaction(&patient, &patient, &med);
     assert_eq!(allergy.len(), 1);
     let warning = allergy.get(0).unwrap();
     assert_eq!(warning.severity, Symbol::new(&env, "contraindicated"));
@@ -345,11 +346,137 @@ fn test_drug_allergy_and_contraindications() {
 
     let found = client.get_contraindications(
         &patient,
+        &patient,
         &med,
         &vec![&env, String::from_str(&env, "renal_failure")],
     );
 
     assert_eq!(found.len(), 2);
+}
+
+// ── #737: PHI-leak fix — check_allergy_interaction / get_contraindications ──
+//
+// Neither function previously checked who was asking, so anyone who knew a
+// patient's address could probe their allergies/conditions for any
+// medication. Both now require `requester.require_auth()` and authorize only
+// the patient themself or a caller registered in the provider-registry. This
+// contract has no separate consent mechanism, so an unconfigured registry
+// fails closed (only the patient may call) — see `require_phi_access` in
+// lib.rs.
+
+#[test]
+fn test_check_allergy_interaction_rejects_unauthorized_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PrescriptionContract, ());
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let patient = Address::generate(&env);
+    let outsider = Address::generate(&env);
+    let med = String::from_str(&env, "44444-2000");
+
+    client.register_medication(
+        &med,
+        &String::from_str(&env, "Penicillin"),
+        &vec![&env, String::from_str(&env, "Pen-V")],
+        &Symbol::new(&env, "abx"),
+        &BytesN::from_array(&env, &[4u8; 32]),
+    );
+    client.set_patient_allergies(&patient, &vec![&env, String::from_str(&env, "Penicillin")]);
+
+    // `outsider` is neither the patient nor a registered provider (no
+    // provider-registry is even configured), so this must fail closed.
+    let result = client.try_check_allergy_interaction(&outsider, &patient, &med);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_check_allergy_interaction_allows_patient_self_query() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PrescriptionContract, ());
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let patient = Address::generate(&env);
+    let med = String::from_str(&env, "44444-2001");
+
+    client.register_medication(
+        &med,
+        &String::from_str(&env, "Penicillin"),
+        &vec![&env, String::from_str(&env, "Pen-V")],
+        &Symbol::new(&env, "abx"),
+        &BytesN::from_array(&env, &[4u8; 32]),
+    );
+    client.set_patient_allergies(&patient, &vec![&env, String::from_str(&env, "Penicillin")]);
+
+    // patient == requester is always allowed — no provider-registry involved.
+    let warnings = client.check_allergy_interaction(&patient, &patient, &med);
+    assert_eq!(warnings.len(), 1);
+}
+
+#[test]
+fn test_get_contraindications_rejects_unauthorized_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PrescriptionContract, ());
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let patient = Address::generate(&env);
+    let outsider = Address::generate(&env);
+    let med = String::from_str(&env, "44444-2002");
+
+    client.register_medication(
+        &med,
+        &String::from_str(&env, "Penicillin"),
+        &vec![&env, String::from_str(&env, "Pen-V")],
+        &Symbol::new(&env, "abx"),
+        &BytesN::from_array(&env, &[4u8; 32]),
+    );
+    client.set_patient_conditions(&patient, &vec![&env, String::from_str(&env, "pregnancy")]);
+    client.set_medication_contraindications(
+        &med,
+        &vec![&env, String::from_str(&env, "pregnancy")],
+    );
+
+    let result = client.try_get_contraindications(
+        &outsider,
+        &patient,
+        &med,
+        &vec![&env],
+    );
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_get_contraindications_allows_patient_self_query() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PrescriptionContract, ());
+    let client = PrescriptionContractClient::new(&env, &contract_id);
+
+    let patient = Address::generate(&env);
+    let med = String::from_str(&env, "44444-2003");
+
+    client.register_medication(
+        &med,
+        &String::from_str(&env, "Penicillin"),
+        &vec![&env, String::from_str(&env, "Pen-V")],
+        &Symbol::new(&env, "abx"),
+        &BytesN::from_array(&env, &[4u8; 32]),
+    );
+    client.set_patient_conditions(&patient, &vec![&env, String::from_str(&env, "pregnancy")]);
+    client.set_medication_contraindications(
+        &med,
+        &vec![&env, String::from_str(&env, "pregnancy")],
+    );
+
+    // patient == requester is always allowed — no provider-registry involved.
+    let found = client.get_contraindications(&patient, &patient, &med, &vec![&env]);
+    assert_eq!(found.len(), 1);
 }
 
 #[test]

--- a/contracts/prescription-management/test_snapshots/test/test_drug_allergy_and_contraindications.1.json
+++ b/contracts/prescription-management/test_snapshots/test/test_drug_allergy_and_contraindications.1.json
@@ -33,7 +33,31 @@
         }
       ]
     ],
-    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "check_allergy_interaction",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "44444-1000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
@@ -61,7 +85,38 @@
       ]
     ],
     [],
-    []
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "get_contraindications",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "string": "44444-1000"
+                },
+                {
+                  "vec": [
+                    {
+                      "string": "renal_failure"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
   ],
   "ledger": {
     "protocol_version": 23,
@@ -410,6 +465,72 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "1033654523790656264"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "4837995959683129791"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "4837995959683129791"
                   }
                 },
                 "durability": "temporary",

--- a/contracts/prior-authorization/src/lib.rs
+++ b/contracts/prior-authorization/src/lib.rs
@@ -913,6 +913,17 @@ impl PriorAuthorizationContract {
     ) -> Result<u32, Error> {
         insurer_id.require_auth();
 
+        // Cross-check that the insurer is actually registered in the insurer-registry (#734)
+        let insurer_registry_id: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsurerRegistryId)
+            .ok_or(Error::NotInitialized)?;
+        let registry = InsurerRegistryClient::new(&env, &insurer_registry_id);
+        if !registry.is_insurer_active(&insurer_id) {
+            return Err(Error::Unauthorized);
+        }
+
         let overdue_ids = get_overdue_auths(&env);
         let reviewer_ids = load_insurer_reviewers(&env, &insurer_id);
 
@@ -929,6 +940,14 @@ impl PriorAuthorizationContract {
                 Some(r) => r,
                 None => continue,
             };
+
+            // Skip requests that belong to a different insurer (#734). The
+            // overdue list is shared across all insurers, so a foreign
+            // insurer's request must be left completely untouched — not
+            // reassigned and not removed from the overdue list.
+            if req.insurer_id != insurer_id {
+                continue;
+            }
 
             // Skip already-resolved or already-escalated requests.
             let unresolved = matches!(

--- a/contracts/prior-authorization/src/test_enhanced.rs
+++ b/contracts/prior-authorization/src/test_enhanced.rs
@@ -344,6 +344,118 @@ fn test_review_after_sla_deadline_fails() {
     assert!(result.is_err());
 }
 
+// ── Cross-insurer escalation isolation (#734) ─────────────────────────────────
+
+#[test]
+fn test_escalate_does_not_hijack_other_insurers_requests() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let insurer_a = Address::generate(&env);
+    let insurer_b = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+
+    // One shared insurer registry with BOTH insurers registered as active.
+    let ir_id = env.register_contract(None, InsurerRegistry);
+    let ir_client = InsurerRegistryClient::new(&env, &ir_id);
+    let issuer = Address::generate(&env);
+
+    ir_client.register_insurer(
+        &insurer_a,
+        &String::from_str(&env, "Insurer A"),
+        &String::from_str(&env, "LIC-A"),
+        &String::from_str(&env, "metadata"),
+        &dummy_hash(&env, 1),
+        &issuer,
+        &dummy_hash(&env, 2),
+        &4_100_000_000_u64,
+        &dummy_hash(&env, 3),
+    );
+    let mut svc_a = Vec::new(&env);
+    svc_a.push_back(String::from_str(&env, "CPT99213"));
+    let mut plans_a = Vec::new(&env);
+    plans_a.push_back(CoveragePlan {
+        plan_id: 1,
+        plan_name: String::from_str(&env, "Plan A"),
+        service_codes: svc_a,
+        is_active: true,
+        effective_from: 0,
+        effective_until: None,
+    });
+    ir_client.set_coverage_plans(&insurer_a, &plans_a);
+
+    ir_client.register_insurer(
+        &insurer_b,
+        &String::from_str(&env, "Insurer B"),
+        &String::from_str(&env, "LIC-B"),
+        &String::from_str(&env, "metadata"),
+        &dummy_hash(&env, 4),
+        &issuer,
+        &dummy_hash(&env, 5),
+        &4_100_000_000_u64,
+        &dummy_hash(&env, 6),
+    );
+    let mut svc_b = Vec::new(&env);
+    svc_b.push_back(String::from_str(&env, "CPT99213"));
+    let mut plans_b = Vec::new(&env);
+    plans_b.push_back(CoveragePlan {
+        plan_id: 2,
+        plan_name: String::from_str(&env, "Plan B"),
+        service_codes: svc_b,
+        is_active: true,
+        effective_from: 0,
+        effective_until: None,
+    });
+    ir_client.set_coverage_plans(&insurer_b, &plans_b);
+
+    // One shared PriorAuthorizationContract instance backed by that registry.
+    let contract_id = env.register(PriorAuthorizationContract, ());
+    let client = PriorAuthorizationContractClient::new(&env, &contract_id);
+    client.initialize(&ir_id);
+
+    // Each insurer has its own reviewer pool so insurer_b's call doesn't
+    // short-circuit on an empty reviewer pool.
+    let reviewer_a = Address::generate(&env);
+    let reviewer_b = Address::generate(&env);
+    register_reviewer(&env, &client, &insurer_a, &reviewer_a);
+    register_reviewer(&env, &client, &insurer_b, &reviewer_b);
+
+    // Submit a request under insurer_a and let it breach its SLA.
+    let auth_id = submit_auth(
+        &env,
+        &client,
+        &provider,
+        &patient,
+        &insurer_a,
+        &Symbol::new(&env, "routine"),
+    );
+    env.ledger().with_mut(|li| li.timestamp += 300_000);
+
+    // Trigger breach detection, which pushes it onto the shared overdue list.
+    let info = client.get_authorization_status(&auth_id, &provider);
+    assert!(matches!(info.status, AuthStatus::Submitted));
+
+    // insurer_b calls escalate_expired_authorizations — it must NOT touch
+    // insurer_a's overdue request.
+    let count_b = client.escalate_expired_authorizations(&insurer_b);
+    assert_eq!(count_b, 0);
+
+    // insurer_a's request is completely unaffected: still Submitted, not
+    // reassigned to a reviewer and not removed from the overdue list.
+    let info_after_b = client.get_authorization_status(&auth_id, &provider);
+    assert!(matches!(info_after_b.status, AuthStatus::Submitted));
+
+    // insurer_a's own escalation run still successfully escalates it,
+    // proving insurer_b's call did not silently remove it from the overdue
+    // list.
+    let count_a = client.escalate_expired_authorizations(&insurer_a);
+    assert_eq!(count_a, 1);
+
+    let info_after_a = client.get_authorization_status(&auth_id, &provider);
+    assert!(matches!(info_after_a.status, AuthStatus::Escalated));
+}
+
 // ── Insurer binding (#684) ────────────────────────────────────────────────────
 
 #[test]

--- a/contracts/referral/Cargo.toml
+++ b/contracts/referral/Cargo.toml
@@ -17,4 +17,5 @@ shared = { workspace = true }
 shared-contracts = { path = "..", package = "Contracts" }
 
 [dev-dependencies]
+provider-registry = { path = "../provider-registry" }
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/referral/src/contract.rs
+++ b/contracts/referral/src/contract.rs
@@ -154,6 +154,31 @@ impl ReferralContract {
         Ok(())
     }
 
+    /// Returns whether `current -> new_status` is a legal state transition.
+    ///
+    /// This mirrors (and generalizes to all `ReferralStatus` variants) the
+    /// gating already enforced by the dedicated transition functions:
+    /// `accept_referral` and `decline_referral` both require `Pending`, and
+    /// `complete_referral` rejects `Pending`/`Declined`/`Cancelled`. Same-state
+    /// transitions and any backward/terminal-state jump are disallowed.
+    fn is_valid_status_transition(current: &ReferralStatus, new_status: &ReferralStatus) -> bool {
+        use ReferralStatus::*;
+        matches!(
+            (current, new_status),
+            (Pending, Accepted)
+                | (Pending, Declined)
+                | (Pending, Cancelled)
+                | (Accepted, Scheduled)
+                | (Accepted, InProgress)
+                | (Accepted, Cancelled)
+                | (Accepted, Completed)
+                | (Scheduled, InProgress)
+                | (Scheduled, Cancelled)
+                | (Scheduled, Completed)
+                | (InProgress, Completed)
+        )
+    }
+
     pub fn update_referral_status(
         env: Env,
         referral_id: u64,
@@ -192,6 +217,20 @@ impl ReferralContract {
         } else {
             return Err(Error::InvalidStatusTransition);
         };
+
+        if !Self::is_valid_status_transition(&referral.status, &new_status) {
+            return Err(Error::InvalidStatusTransition);
+        }
+
+        // Keep the timestamp fields consistent with what the dedicated
+        // accept_referral / complete_referral functions record for the
+        // corresponding transitions.
+        if new_status == ReferralStatus::Accepted {
+            referral.accepted_at = Some(env.ledger().timestamp());
+        }
+        if new_status == ReferralStatus::Completed {
+            referral.completed_at = Some(env.ledger().timestamp());
+        }
 
         referral.status = new_status;
         env.storage()

--- a/contracts/referral/src/test.rs
+++ b/contracts/referral/src/test.rs
@@ -2,8 +2,45 @@
 #![allow(deprecated)]
 
 use crate::contract::{ReferralContract, ReferralContractClient};
+use crate::types::Error;
 use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Symbol, Vec, vec};
 use provider_registry::{ProviderRegistry, ProviderRegistryClient};
+
+/// Registers a `ProviderRegistry` contract, initializes it with `admin`, and
+/// registers `referral_contract_id` against it, returning the registry
+/// client so individual tests can register whichever provider addresses
+/// they need via `register_provider`.
+fn setup_provider_registry<'a>(
+    env: &'a Env,
+    admin: &Address,
+    referral_contract_id: &Address,
+) -> ProviderRegistryClient<'a> {
+    let provider_registry_id = env.register(ProviderRegistry, ());
+    let pr_client = ProviderRegistryClient::new(env, &provider_registry_id);
+    pr_client.initialize(admin);
+
+    let referral_client = ReferralContractClient::new(env, referral_contract_id);
+    referral_client.initialize(&provider_registry_id);
+
+    pr_client
+}
+
+/// Registers `provider` as an active, non-expired provider in the given
+/// `ProviderRegistry`, matching the shape expected by `register_provider`.
+fn register_provider(env: &Env, pr_client: &ProviderRegistryClient, admin: &Address, provider: &Address) {
+    pr_client.register_provider(
+        admin,
+        provider,
+        &String::from_str(env, "Dr. Test"),
+        &String::from_str(env, "General"),
+        &String::from_str(env, "LIC000"),
+        &BytesN::from_array(env, &[9; 32]),
+        admin,
+        &BytesN::from_array(env, &[9; 32]),
+        &(env.ledger().timestamp() + 86400),
+        &BytesN::from_array(env, &[9; 32]),
+    );
+}
 
 #[test]
 fn test_referral_lifecycle() {
@@ -13,9 +50,14 @@ fn test_referral_lifecycle() {
     let contract_id = env.register(ReferralContract, ());
     let client = ReferralContractClient::new(&env, &contract_id);
 
+    let admin = Address::generate(&env);
     let referring_provider = Address::generate(&env);
     let patient_id = Address::generate(&env);
     let referred_to = Address::generate(&env);
+
+    let pr_client = setup_provider_registry(&env, &admin, &contract_id);
+    register_provider(&env, &pr_client, &admin, &referred_to);
+
     let specialty = Symbol::new(&env, "Cardio");
     let reason = String::from_str(&env, "Heart palpitations");
     let priority = Symbol::new(&env, "Urgent");
@@ -75,9 +117,13 @@ fn test_decline_and_update_status() {
     let contract_id = env.register(ReferralContract, ());
     let client = ReferralContractClient::new(&env, &contract_id);
 
+    let admin = Address::generate(&env);
     let referring_provider = Address::generate(&env);
     let patient_id = Address::generate(&env);
     let referred_to = Address::generate(&env);
+
+    let pr_client = setup_provider_registry(&env, &admin, &contract_id);
+    register_provider(&env, &pr_client, &admin, &referred_to);
 
     let referral_id = client.create_referral(
         &referring_provider,
@@ -106,6 +152,13 @@ fn test_decline_and_update_status() {
         &Vec::new(&env),
     );
 
+    // Must accept before it can be scheduled (Pending -> Accepted -> Scheduled)
+    client.update_referral_status(
+        &referral_id2,
+        &referred_to,
+        &Symbol::new(&env, "Accepted"),
+        &None,
+    );
     client.update_referral_status(
         &referral_id2,
         &referred_to,
@@ -122,9 +175,13 @@ fn test_auth_failures() {
     let contract_id = env.register(ReferralContract, ());
     let client = ReferralContractClient::new(&env, &contract_id);
 
+    let admin = Address::generate(&env);
     let referring_provider = Address::generate(&env);
     let patient_id = Address::generate(&env);
     let referred_to = Address::generate(&env);
+
+    let pr_client = setup_provider_registry(&env, &admin, &contract_id);
+    register_provider(&env, &pr_client, &admin, &referred_to);
 
     let referral_id = client.create_referral(
         &referring_provider,
@@ -209,6 +266,136 @@ fn test_provider_registration_verification() {
         &requested_services,
     );
     assert!(result.is_ok());
-    let referral_id_created = result.unwrap();
+    let referral_id_created = result.unwrap().unwrap();
     assert_eq!(referral_id_created, 1);
+}
+
+#[test]
+fn test_update_referral_status_rejects_pending_to_completed() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ReferralContract, ());
+    let client = ReferralContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let referring_provider = Address::generate(&env);
+    let patient_id = Address::generate(&env);
+    let referred_to = Address::generate(&env);
+
+    let pr_client = setup_provider_registry(&env, &admin, &contract_id);
+    register_provider(&env, &pr_client, &admin, &referred_to);
+
+    let referral_id = client.create_referral(
+        &referring_provider,
+        &patient_id,
+        &referred_to,
+        &Symbol::new(&env, "Ortho"),
+        &String::from_str(&env, "Knee pain"),
+        &Symbol::new(&env, "Routine"),
+        &BytesN::from_array(&env, &[1; 32]),
+        &Vec::new(&env),
+    );
+
+    // A freshly created referral is Pending. Jumping straight to Completed
+    // must be rejected, since acceptance (and clinical work) is skipped.
+    let err = client
+        .try_update_referral_status(
+            &referral_id,
+            &referred_to,
+            &Symbol::new(&env, "Completed"),
+            &None,
+        )
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::InvalidStatusTransition);
+}
+
+#[test]
+fn test_update_referral_status_rejects_completed_to_pending() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ReferralContract, ());
+    let client = ReferralContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let referring_provider = Address::generate(&env);
+    let patient_id = Address::generate(&env);
+    let referred_to = Address::generate(&env);
+
+    let pr_client = setup_provider_registry(&env, &admin, &contract_id);
+    register_provider(&env, &pr_client, &admin, &referred_to);
+
+    let referral_id = client.create_referral(
+        &referring_provider,
+        &patient_id,
+        &referred_to,
+        &Symbol::new(&env, "Ortho"),
+        &String::from_str(&env, "Knee pain"),
+        &Symbol::new(&env, "Routine"),
+        &BytesN::from_array(&env, &[1; 32]),
+        &Vec::new(&env),
+    );
+
+    // Legally progress the referral all the way to Completed.
+    client.update_referral_status(&referral_id, &referred_to, &Symbol::new(&env, "Accepted"), &None);
+    client.update_referral_status(&referral_id, &referred_to, &Symbol::new(&env, "Completed"), &None);
+
+    // Reverting a Completed referral back to Pending must be rejected,
+    // otherwise the audit trail is corrupted.
+    let err = client
+        .try_update_referral_status(
+            &referral_id,
+            &referred_to,
+            &Symbol::new(&env, "Pending"),
+            &None,
+        )
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::InvalidStatusTransition);
+}
+
+#[test]
+fn test_update_referral_status_allows_legal_transitions() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ReferralContract, ());
+    let client = ReferralContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let referring_provider = Address::generate(&env);
+    let patient_id = Address::generate(&env);
+    let referred_to = Address::generate(&env);
+
+    let pr_client = setup_provider_registry(&env, &admin, &contract_id);
+    register_provider(&env, &pr_client, &admin, &referred_to);
+
+    let referral_id = client.create_referral(
+        &referring_provider,
+        &patient_id,
+        &referred_to,
+        &Symbol::new(&env, "Ortho"),
+        &String::from_str(&env, "Knee pain"),
+        &Symbol::new(&env, "Routine"),
+        &BytesN::from_array(&env, &[1; 32]),
+        &Vec::new(&env),
+    );
+
+    // Pending -> Accepted is a legal transition and should succeed.
+    client.update_referral_status(
+        &referral_id,
+        &referred_to,
+        &Symbol::new(&env, "Accepted"),
+        &None,
+    );
+
+    // Accepted -> Scheduled is also a legal transition and should succeed.
+    client.update_referral_status(
+        &referral_id,
+        &referred_to,
+        &Symbol::new(&env, "Scheduled"),
+        &None,
+    );
 }


### PR DESCRIPTION
…gement, referral, prescription-management

security: prior-authorization escalate_expired_authorizations operates on a single global overdue list with no insurer authorization check Fixes #734

security: lab-management flag_critical_value has zero binding to the lab order or assigned lab Fixes #735

bug: referral update_referral_status bypasses every status-transition invariant enforced elsewhere Fixes #736

security: prescription-management check_allergy_interaction and get_contraindications leak patient PHI with no authentication Fixes #737

## Summary

<!-- What does this PR change and why? -->

## Changelog

- [ ] I have updated `CHANGELOG.md` for any user-facing contract API change (new functions, breaking changes, deprecations, or security fixes).

## Test plan

- [ ] Unit / integration tests added or updated
- [ ] `cargo test` passes locally (if applicable)
