### PR TITLE
Fix/test compile authz events

### DIFF
--- a/contracts/healthcare-analytics/src/test.rs
+++ b/contracts/healthcare-analytics/src/test.rs
@@ -798,7 +798,7 @@ fn test_cpu_quota_accumulates_across_jobs() {
         &DegradationPolicy::Fail,
     ).unwrap().unwrap().job_id;
     client.execute_next_report();
-    client.complete_report(&job1, &400, &50);
+    client.complete_report(&job1, &400, &50, &100);
 
     // Second job: another 400 CPU — still below threshold (total 800, not > 800)
     let job2 = client.try_request_report(
@@ -810,7 +810,7 @@ fn test_cpu_quota_accumulates_across_jobs() {
         &DegradationPolicy::Fail,
     ).unwrap().unwrap().job_id;
     client.execute_next_report();
-    client.complete_report(&job2, &400, &50);
+    client.complete_report(&job2, &400, &50, &100);
 
     // Now TotalCpuUsed = 800; 800*100/1000 = 80, which is NOT > 80, so one more is still ok.
     // Push it over: complete a tiny job that adds 1 more CPU unit.
@@ -823,7 +823,7 @@ fn test_cpu_quota_accumulates_across_jobs() {
         &DegradationPolicy::Fail,
     ).unwrap().unwrap().job_id;
     client.execute_next_report();
-    client.complete_report(&job3, &1, &1);
+    client.complete_report(&job3, &1, &1, &10);
 
     // TotalCpuUsed = 801; 801*100/1000 = 80 (integer), still not > 80.
     // Add one more to make it 901 total.
@@ -836,7 +836,7 @@ fn test_cpu_quota_accumulates_across_jobs() {
         &DegradationPolicy::Fail,
     ).unwrap().unwrap().job_id;
     client.execute_next_report();
-    client.complete_report(&job4, &100, &1);
+    client.complete_report(&job4, &100, &1, &50);
 
     // TotalCpuUsed = 901; 901*100/1000 = 90 > 80 → throttled
     let result = client.try_request_report(

--- a/contracts/imaging-radiology/src/lib.rs
+++ b/contracts/imaging-radiology/src/lib.rs
@@ -170,6 +170,8 @@ pub enum Error {
     CounterUnavailable = 11,
     /// An addendum was submitted for an order with no final report yet.
     FinalReportNotFound = 12,
+    /// Radiologist cannot request peer review from themselves
+    SelfReviewNotAllowed = 13,
 }
 
 /// --------------------
@@ -555,6 +557,10 @@ impl ImagingRadiology {
         peer_radiologist: Address,
     ) -> Result<(), Error> {
         requesting_radiologist.require_auth();
+
+        if requesting_radiologist == peer_radiologist {
+            return Err(Error::SelfReviewNotAllowed);
+        }
 
         let order_key = DataKey::ImagingOrder(order_id);
         env.storage()

--- a/contracts/imaging-radiology/src/test.rs
+++ b/contracts/imaging-radiology/src/test.rs
@@ -534,6 +534,32 @@ fn test_request_peer_review_already_exists() {
 }
 
 #[test]
+fn test_request_peer_review_rejects_self_review() {
+    let env = Env::default();
+    let contract_id = env.register(ImagingRadiology, ());
+    let client = ImagingRadiologyClient::new(&env, &contract_id);
+
+    let provider = Address::generate(&env);
+    let patient = Address::generate(&env);
+    let radiologist = Address::generate(&env);
+    env.mock_all_auths();
+
+    let order_id = client.order_imaging_study(
+        &provider,
+        &patient,
+        &Symbol::new(&env, "CT"),
+        &String::from_str(&env, "Chest"),
+        &true,
+        &String::from_str(&env, "Complex case"),
+        &Symbol::new(&env, "ROUTINE"),
+    );
+
+    // Self-review request should fail
+    let result = client.try_request_peer_review(&order_id, &radiologist, &radiologist);
+    assert!(result.is_err());
+}
+
+#[test]
 fn test_get_patient_orders() {
     let env = Env::default();
     let contract_id = env.register(ImagingRadiology, ());

--- a/contracts/medical-device-tracking/src/lib.rs
+++ b/contracts/medical-device-tracking/src/lib.rs
@@ -85,12 +85,12 @@ impl MedicalDeviceRegistry {
 
         let device = DeviceRecord {
             device_id: new_id,
-            device_udi,
-            device_type,
-            manufacturer_id,
-            manufacturer,
-            model_number,
-            lot_number,
+            device_udi: device_udi.clone(),
+            device_type: device_type.clone(),
+            manufacturer_id: manufacturer_id.clone(),
+            manufacturer: manufacturer.clone(),
+            model_number: model_number.clone(),
+            lot_number: lot_number.clone(),
             manufacturing_date,
             expiration_date,
             device_specs_hash,
@@ -101,6 +101,11 @@ impl MedicalDeviceRegistry {
         env.storage()
             .persistent()
             .set(&DataKey::DeviceRecord(new_id), &device);
+
+        env.events().publish(
+            (Symbol::new(&env, "device_registered"),),
+            (new_id, device_type, device_udi),
+        );
 
         Ok(new_id)
     }
@@ -172,6 +177,11 @@ impl MedicalDeviceRegistry {
         env.storage()
             .persistent()
             .set(&DataKey::DeviceImplants(device_id), &device_implants);
+
+        env.events().publish(
+            (Symbol::new(&env, "implant_recorded"),),
+            (new_id, device_id, patient_id, implant_date),
+        );
 
         Ok(new_id)
     }
@@ -258,6 +268,11 @@ impl MedicalDeviceRegistry {
             .persistent()
             .set(&DataKey::ImplantRecord(implant_record_id), &record);
 
+        env.events().publish(
+            (Symbol::new(&env, "maintenance_recorded"),),
+            (new_m_id, implant_record_id, maintenance_type, maintenance_date),
+        );
+
         Ok(())
     }
 
@@ -304,7 +319,7 @@ impl MedicalDeviceRegistry {
             .persistent()
             .set(&DataKey::RecallInfo(new_id), &recall);
 
-        for device_id in device_ids {
+        for device_id in device_ids.iter() {
             let mut device_recalls: Vec<u64> = env
                 .storage()
                 .persistent()
@@ -315,6 +330,11 @@ impl MedicalDeviceRegistry {
                 .persistent()
                 .set(&DataKey::DeviceRecalls(device_id), &device_recalls);
         }
+
+        env.events().publish(
+            (Symbol::new(&env, "device_recall_issued"),),
+            (new_id, device_ids, severity),
+        );
 
         Ok(new_id)
     }
@@ -379,7 +399,7 @@ impl MedicalDeviceRegistry {
             .persistent()
             .set(&DataKey::RecallInfo(new_id), &recall);
 
-        for device_id in device_ids {
+        for device_id in device_ids.iter() {
             let mut device_recalls: Vec<u64> = env
                 .storage()
                 .persistent()
@@ -390,6 +410,11 @@ impl MedicalDeviceRegistry {
                 .persistent()
                 .set(&DataKey::DeviceRecalls(device_id), &device_recalls);
         }
+
+        env.events().publish(
+            (Symbol::new(&env, "regulator_recall_issued"),),
+            (new_id, device_ids, severity),
+        );
 
         Ok(new_id)
     }
@@ -480,6 +505,11 @@ impl MedicalDeviceRegistry {
         env.storage()
             .persistent()
             .set(&DataKey::ImplantRecord(implant_record_id), &record);
+
+        env.events().publish(
+            (Symbol::new(&env, "implant_removed"),),
+            (implant_record_id, record.device_id, removal_date),
+        );
 
         Ok(())
     }
@@ -652,6 +682,11 @@ impl MedicalDeviceRegistry {
         env.storage()
             .persistent()
             .set(&DataKey::DeviceWarranties(device_id), &warranties);
+
+        env.events().publish(
+            (Symbol::new(&env, "warranty_registered"),),
+            (warranty_id, device_id, warranty_expiration_date),
+        );
 
         Ok(warranty_id)
     }

--- a/contracts/medical-device-tracking/src/test.rs
+++ b/contracts/medical-device-tracking/src/test.rs
@@ -910,3 +910,150 @@ fn test_track_device_performance_patient_mismatch() {
     // Should fail with NotAuthorized error
     assert!(result.is_err());
 }
+
+// -----------------------------------------------------------------------
+// Event emission tests
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_device_registration_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = setup_client(&env);
+    let manufacturer = Address::generate(&env);
+
+    let device_id = client.register_device(
+        &manufacturer,
+        &String::from_str(&env, "UDI-12345-ABC"),
+        &Symbol::new(&env, "IMPLANT"),
+        &String::from_str(&env, "MedCorp"),
+        &String::from_str(&env, "MC-100"),
+        &String::from_str(&env, "LOT-001"),
+        &1690000000u64,
+        &None,
+        &dummy_hash(&env),
+        &DeviceExtras { warranty_expiration_date: None, maintenance_interval_days: None },
+    );
+    assert_eq!(device_id, 1);
+
+    let events = env.events().all();
+    assert!(!events.is_empty());
+}
+
+#[test]
+fn test_implant_device_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = setup_client(&env);
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+    let manufacturer = Address::generate(&env);
+
+    let device_id = register_device_helper(&env, &client, &manufacturer);
+    let implant_id = client.implant_device(
+        &patient_id,
+        &device_id,
+        &provider_id,
+        &1700000000u64,
+        &String::from_str(&env, "Left Hip"),
+        &dummy_hash(&env),
+    );
+    assert_eq!(implant_id, 1);
+
+    let events = env.events().all();
+    assert!(!events.is_empty());
+}
+
+#[test]
+fn test_device_recall_emits_event_with_device_ids_and_severity() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = setup_client(&env);
+    let manufacturer = Address::generate(&env);
+
+    let device_id = register_device_helper(&env, &client, &manufacturer);
+    let mut device_ids: Vec<u64> = Vec::new(&env);
+    device_ids.push_back(device_id);
+
+    env.events().all().clear();
+
+    let recall_id = client.issue_device_recall(
+        &manufacturer,
+        &device_ids,
+        &String::from_str(&env, "Battery failure risk"),
+        &Symbol::new(&env, "CRITICAL"),
+        &1750000000u64,
+        &String::from_str(&env, "Immediate explantation required"),
+    );
+    assert_eq!(recall_id, 1);
+
+    let events = env.events().all();
+    assert!(!events.is_empty());
+}
+
+#[test]
+fn test_regulator_recall_emits_event_with_device_ids_and_severity() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let regulator = Address::generate(&env);
+    let client = setup_client(&env);
+    let manufacturer = Address::generate(&env);
+
+    let device_id = register_device_helper(&env, &client, &manufacturer);
+    let mut device_ids: Vec<u64> = Vec::new(&env);
+    device_ids.push_back(device_id);
+
+    env.events().all().clear();
+
+    let recall_id = client.issue_regulator_recall(
+        &regulator,
+        &device_ids,
+        &String::from_str(&env, "Emergency safety recall"),
+        &Symbol::new(&env, "CRITICAL"),
+        &1750000000u64,
+        &String::from_str(&env, "Immediate action required"),
+        &String::from_str(&env, "Nationwide"),
+    );
+    assert_eq!(recall_id, 1);
+
+    let events = env.events().all();
+    assert!(!events.is_empty());
+}
+
+#[test]
+fn test_remove_implant_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = setup_client(&env);
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+    let manufacturer = Address::generate(&env);
+
+    let device_id = register_device_helper(&env, &client, &manufacturer);
+    let implant_id = client.implant_device(
+        &patient_id,
+        &device_id,
+        &provider_id,
+        &1700000000u64,
+        &String::from_str(&env, "Left Hip"),
+        &dummy_hash(&env),
+    );
+
+    env.events().all().clear();
+
+    client.remove_implant(
+        &implant_id,
+        &provider_id,
+        &1710000000u64,
+        &String::from_str(&env, "Device failure"),
+        &dummy_hash(&env),
+    );
+
+    let events = env.events().all();
+    assert!(!events.is_empty());
+}

--- a/contracts/nutrition-care-management/src/lib.rs
+++ b/contracts/nutrition-care-management/src/lib.rs
@@ -650,6 +650,10 @@ impl NutritionCareContract {
 
         load_care_plan(&env, care_plan_id).ok_or(Error::CarePlanNotFound)?;
 
+        if !is_provider_authorized(&env, care_plan_id, &dietitian_id) {
+            return Err(Error::ProviderNotAuthorized);
+        }
+
         let rec = SupplementRecommendation {
             care_plan_id,
             dietitian_id: dietitian_id.clone(),

--- a/contracts/nutrition-care-management/src/test.rs
+++ b/contracts/nutrition-care-management/src/test.rs
@@ -817,6 +817,23 @@ fn test_recommend_supplements_care_plan_not_found() {
     assert!(result.is_err());
 }
 
+#[test]
+fn test_recommend_supplements_rejects_unauthorized_dietitian() {
+    let (env, patient, dietitian, _) = setup();
+    let client = register(&env);
+    let (_, care_plan_id) = create_plan(&env, &client, &patient, &dietitian);
+    let stranger = Address::generate(&env);
+
+    let result = client.try_recommend_supplements(
+        &care_plan_id,
+        &stranger,
+        &symbol_short!("zinc"),
+        &String::from_str(&env, "15 mg/day"),
+        &String::from_str(&env, "Wound healing support"),
+    );
+    assert!(result.is_err());
+}
+
 // -----------------------------------------------------------------------
 // evaluate_nutrition_outcomes
 // -----------------------------------------------------------------------


### PR DESCRIPTION
 ## Summary                                                                                                                                                              
   Fixes a compile-breaking test regression in healthcare-analytics, closes two provider-authorization/integrity gaps (an unauthorized dietitian being able to attach      
   supplement recommendations, and a radiologist being able to peer-review their own imaging report), and adds the audit-event emissions that medical-device-tracking's    
   HIPAA-compliance docstring already claims exist but the code never actually produced.

   ## Changes

   ### #767 — healthcare-analytics test.rs fails to compile — complete_report gained a wall_time_ms parameter that 4 test call sites never got
   - All 4 stale call sites in `test.rs` updated to pass `wall_time_ms`, restoring compilation for the crate.

   ### #768 — nutrition-care-management recommend_supplements missing provider-authorization check
   - `recommend_supplements` now calls `is_provider_authorized` before proceeding, matching its sibling functions; test proves an unauthorized dietitian is rejected.

   ### #770 — imaging-radiology request_peer_review allows a radiologist to name themselves as peer_radiologist (self-review)
   - Self-review (`peer_radiologist == requesting_radiologist`) is now rejected with `SelfReviewNotAllowed` error variant; test proves the rejection.

   ### #771 — medical-device-tracking never emits any events despite HIPAA docstring claiming full audit logging
   - Events now emitted for device registration, implantation, removal, maintenance, and both recall paths (with `device_ids`/`severity` in recall payloads), closing
   the gap between the documented compliance claim and actual behavior.

   ## Implementation Notes
   - Code-only delivery: no install/build/test/scripts run during implementation.
   - Committer: favourawaku.
   - All 4 functions in #771 emit events: register_device, implant_device, remove_implant, record_device_maintenance, issue_device_recall, issue_regulator_recall,
   register_warranty.

   Closes #767, Closes #768, Closes #770, Closes #771