### PR TITLE
security: add missing responder/consent/registry checks across 4 cont…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,7 @@ name = "prenatal-pediatric"
 version = "0.1.0"
 dependencies = [
  "Contracts",
+ "provider-registry",
  "soroban-sdk",
 ]
 

--- a/contracts/dental-records/src/lib.rs
+++ b/contracts/dental-records/src/lib.rs
@@ -383,6 +383,7 @@ impl DentalRecordsContract {
         dosage_instructions: String,
     ) -> Result<u64, Error> {
         dentist_id.require_auth();
+        patient_id.require_auth();
 
         let count = safe_increment(&env, &DataKey::RxCount);
 

--- a/contracts/dental-records/src/test.rs
+++ b/contracts/dental-records/src/test.rs
@@ -3,7 +3,10 @@
 
 use crate::types::*;
 use crate::{DentalRecordsContract, DentalRecordsContractClient};
-use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Symbol, Vec};
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, BytesN, Env, IntoVal, String, Symbol, Vec,
+};
 
 fn create_env() -> (Env, DentalRecordsContractClient<'static>) {
     let env = Env::default();
@@ -194,6 +197,35 @@ fn test_procedure_documentation_flow() {
         &1672617500,
         &consent_hash,
     );
+}
+
+#[test]
+fn test_prescribe_dental_medication_requires_patient_auth() {
+    let env = Env::default();
+    let contract_id = env.register(DentalRecordsContract, ());
+    let client = DentalRecordsContractClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    // An unrelated dentist who signs the call themselves, but the patient
+    // never authorized this prescription.
+    let dentist_id = Address::generate(&env);
+    let medication = String::from_str(&env, "Amoxicillin 500mg");
+    let indication = String::from_str(&env, "Prophylaxis");
+    let dosage = String::from_str(&env, "Take 1 cap 1hr prior to appt");
+
+    let result = client
+        .mock_auths(&[MockAuth {
+            address: &dentist_id,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "prescribe_dental_medication",
+                args: (&patient_id, &dentist_id, &medication, &indication, &dosage).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .try_prescribe_dental_medication(&patient_id, &dentist_id, &medication, &indication, &dosage);
+
+    assert!(result.is_err());
 }
 
 #[test]

--- a/contracts/emergency-medical-info/src/lib.rs
+++ b/contracts/emergency-medical-info/src/lib.rs
@@ -238,8 +238,15 @@ impl EmergencyMedicalInfo {
         alert_type: Symbol,
         alert_text_hash: BytesN<32>,
         severity: Symbol,
-    ) {
+    ) -> Result<(), Error> {
         provider_id.require_auth();
+
+        // Proving control of an address is not proof of role -- only
+        // registered emergency responders (or trusted callers acting through
+        // one) may append critical alerts to a patient's record.
+        if !Self::is_registered_responder(env.clone(), provider_id.clone()) {
+            return Err(Error::NotAuthorized);
+        }
 
         let alert = CriticalAlert {
             provider_id,
@@ -258,6 +265,8 @@ impl EmergencyMedicalInfo {
 
         alerts.push_back(alert);
         env.storage().persistent().set(&key, &alerts);
+
+        Ok(())
     }
 
     /// Emergency access with break-glass protocol

--- a/contracts/emergency-medical-info/src/test.rs
+++ b/contracts/emergency-medical-info/src/test.rs
@@ -182,11 +182,15 @@ fn test_add_critical_alert() {
 
     let patient = Address::generate(&env);
     let provider = Address::generate(&env);
+    let admin = Address::generate(&env);
     env.mock_all_auths();
 
     let alert_type = Symbol::new(&env, "ALLERGY");
     let alert_text = hash(&env, 61);
     let severity = Symbol::new(&env, "CRITICAL");
+
+    client.initialize(&admin);
+    client.register_responder(&admin, &provider);
 
     client.add_critical_alert(&patient, &provider, &alert_type, &alert_text, &severity);
 
@@ -197,6 +201,34 @@ fn test_add_critical_alert() {
 }
 
 #[test]
+fn test_add_critical_alert_rejects_unregistered_responder() {
+    let env = Env::default();
+    let contract_id = env.register(EmergencyMedicalInfo, ());
+    let client = EmergencyMedicalInfoClient::new(&env, &contract_id);
+
+    let patient = Address::generate(&env);
+    let unregistered_caller = Address::generate(&env);
+    let admin = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.initialize(&admin);
+
+    // An address that merely signs the call but was never registered as an
+    // emergency responder must not be able to fabricate a critical alert.
+    let result = client.try_add_critical_alert(
+        &patient,
+        &unregistered_caller,
+        &Symbol::new(&env, "ALLERGY"),
+        &hash(&env, 61),
+        &Symbol::new(&env, "CRITICAL"),
+    );
+    assert_eq!(result, Err(Ok(Error::NotAuthorized)));
+
+    let alerts = client.get_critical_alerts(&patient, &patient);
+    assert_eq!(alerts.len(), 0);
+}
+
+#[test]
 fn test_multiple_critical_alerts() {
     let env = Env::default();
     let contract_id = env.register(EmergencyMedicalInfo, ());
@@ -204,7 +236,11 @@ fn test_multiple_critical_alerts() {
 
     let patient = Address::generate(&env);
     let provider = Address::generate(&env);
+    let admin = Address::generate(&env);
     env.mock_all_auths();
+
+    client.initialize(&admin);
+    client.register_responder(&admin, &provider);
 
     // Add multiple alerts
     client.add_critical_alert(
@@ -387,7 +423,11 @@ fn test_recovery_migrates_dnr_order_and_critical_alerts() {
     let guardian_2 = Address::generate(&env);
     let new_owner = Address::generate(&env);
     let provider = Address::generate(&env);
+    let admin = Address::generate(&env);
     env.mock_all_auths();
+
+    client.initialize(&admin);
+    client.register_responder(&admin, &provider);
 
     client.set_emergency_profile(
         &patient,

--- a/contracts/mental-health/src/lib.rs
+++ b/contracts/mental-health/src/lib.rs
@@ -42,7 +42,7 @@ pub trait EmergencyMedicalInfoInterface {
         alert_type: Symbol,
         alert_text_hash: BytesN<32>,
         severity: Symbol,
-    );
+    ) -> Result<(), soroban_sdk::Error>;
 }
 
 #[contracterror]
@@ -292,13 +292,17 @@ impl MentalHealthContract {
         let alert_type = Symbol::new(env, "crisis_escalation");
         let alert_text_hash = BytesN::from_array(env, &[0u8; 32]);
 
-        crisis_client.add_critical_alert(
+        let alert_result = crisis_client.try_add_critical_alert(
             &patient_token,
             provider_id,
             &alert_type,
             &alert_text_hash,
             &severity,
         );
+
+        if alert_result.is_err() {
+            return Err(Error::EscalationFailed);
+        }
 
         Ok(())
     }
@@ -426,6 +430,14 @@ impl MentalHealthContract {
             .get(&DataKey::Assessment(assessment_id))
             .ok_or(Error::NotFound)?;
 
+        // Validate explicit consent for recording the PHQ-9 score
+        Self::validate_explicit_consent(
+            &env,
+            &assessment.patient_id,
+            Symbol::new(&env, "phq9"),
+            &provider_id,
+        )?;
+
         assessment.phq9_score = Some(total_score);
         env.storage()
             .persistent()
@@ -453,6 +465,14 @@ impl MentalHealthContract {
             .persistent()
             .get(&DataKey::Assessment(assessment_id))
             .ok_or(Error::NotFound)?;
+
+        // Validate explicit consent for recording the GAD-7 score
+        Self::validate_explicit_consent(
+            &env,
+            &assessment.patient_id,
+            Symbol::new(&env, "gad7"),
+            &provider_id,
+        )?;
 
         assessment.gad7_score = Some(total_score);
         env.storage()

--- a/contracts/mental-health/src/test.rs
+++ b/contracts/mental-health/src/test.rs
@@ -33,7 +33,7 @@ impl MockEmergencyMedicalInfo {
         alert_type: Symbol,
         _alert_text_hash: BytesN<32>,
         severity: Symbol,
-    ) {
+    ) -> Result<(), soroban_sdk::Error> {
         let alert = CrisisAlertEvent {
             patient_id: patient_id.clone(),
             provider_id,
@@ -49,6 +49,7 @@ impl MockEmergencyMedicalInfo {
             .unwrap_or(Vec::new(&env));
         alerts.push_back(alert);
         env.storage().persistent().set(&key, &alerts);
+        Ok(())
     }
 
     pub fn get_alert_count(env: Env, patient_id: Address) -> u32 {
@@ -78,6 +79,8 @@ fn test_conduct_assessment_and_record_scores() {
 
     grant_consent(&env, &client, &patient_id, "assessment", &provider_id);
     grant_consent(&env, &client, &patient_id, "suicide_risk", &provider_id);
+    grant_consent(&env, &client, &patient_id, "phq9", &provider_id);
+    grant_consent(&env, &client, &patient_id, "gad7", &provider_id);
 
     let concerns = vec![&env, String::from_str(&env, "anxiety")];
     let tools = vec![&env, Symbol::new(&env, "PHQ9")];
@@ -123,6 +126,51 @@ fn test_conduct_assessment_and_record_scores() {
         &protective_factors,
         &true,
     );
+}
+
+#[test]
+fn test_record_scores_reject_uninvolved_provider_without_consent() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(MentalHealthContract, ());
+    let client = MentalHealthContractClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+    // Never granted consent for "phq9" or "gad7" -- merely signing the call
+    // must not be enough to overwrite a patient's screening scores.
+    let uninvolved_provider = Address::generate(&env);
+
+    grant_consent(&env, &client, &patient_id, "assessment", &provider_id);
+
+    let assessment_id = client.conduct_mental_health_assessment(
+        &patient_id,
+        &provider_id,
+        &1690000000,
+        &Symbol::new(&env, "initial"),
+        &vec![&env, String::from_str(&env, "anxiety")],
+        &vec![&env, Symbol::new(&env, "PHQ9")],
+        &BytesN::from_array(&env, &[0; 32]),
+    );
+
+    let phq9_result = client.try_record_phq9_score(
+        &assessment_id,
+        &uninvolved_provider,
+        &15,
+        &vec![&env, 3, 3, 3, 3, 3],
+        &1690000000,
+    );
+    assert_eq!(phq9_result, Err(Ok(Error::RequiresExplicitConsent)));
+
+    let gad7_result = client.try_record_gad7_score(
+        &assessment_id,
+        &uninvolved_provider,
+        &12,
+        &vec![&env, 2, 2, 2, 2, 2, 2],
+        &1690000000,
+    );
+    assert_eq!(gad7_result, Err(Ok(Error::RequiresExplicitConsent)));
 }
 
 #[test]
@@ -333,6 +381,7 @@ fn test_high_risk_assessment_triggers_crisis_escalation() {
     grant_consent(&env, &mental_health, &patient_id, "assessment", &provider_id);
     grant_consent(&env, &mental_health, &patient_id, "suicide_risk", &provider_id);
     grant_consent(&env, &mental_health, &patient_id, "crisis_escalation", &provider_id);
+    grant_consent(&env, &mental_health, &patient_id, "phq9", &provider_id);
 
     // Create an assessment
     let assessment_id = mental_health.conduct_mental_health_assessment(

--- a/contracts/prenatal-pediatric/Cargo.toml
+++ b/contracts/prenatal-pediatric/Cargo.toml
@@ -14,3 +14,4 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+provider-registry = { path = "../provider-registry" }

--- a/contracts/prenatal-pediatric/src/lib.rs
+++ b/contracts/prenatal-pediatric/src/lib.rs
@@ -27,8 +27,8 @@
 //! validated. Developmental milestones enumerated with age validation.
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
-    String, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, vec, Address, BytesN, Env,
+    IntoVal, String, Symbol, Vec,
 };
 
 #[contracterror]
@@ -39,6 +39,7 @@ pub enum Error {
     Unauthorized = 2,
     InvalidData = 3,
     AlreadyExists = 4,
+    NotInitialized = 5,
 }
 
 #[contracttype]
@@ -199,6 +200,8 @@ pub struct GrowthPercentiles {
 
 #[contracttype]
 pub enum DataKey {
+    Admin,
+    ProviderRegistry,
     Pregnancy(u64),
     PrenatalVisit(u64),
     PrenatalScreening(u64),
@@ -218,6 +221,34 @@ pub struct MaternalChildHealthContract;
 
 #[contractimpl]
 impl MaternalChildHealthContract {
+    /// Configure the admin and the provider-registry contract used to
+    /// validate that a provider is credentialed before it may write records.
+    pub fn initialize(env: Env, admin: Address, provider_registry: Address) -> Result<(), Error> {
+        admin.require_auth();
+
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyExists);
+        }
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::ProviderRegistry, &provider_registry);
+        Ok(())
+    }
+
+    /// Check whether `provider_id` is an active, credentialed provider in
+    /// the configured provider-registry contract.
+    fn is_registered_provider(env: &Env, provider_id: &Address) -> bool {
+        let provider_registry: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProviderRegistry)
+            .unwrap();
+        let args = vec![env, provider_id.clone().into_val(env)];
+        env.invoke_contract(&provider_registry, &Symbol::new(env, "is_provider"), args)
+    }
+
     pub fn create_pregnancy_record(
         env: Env,
         patient_id: Address,
@@ -229,6 +260,11 @@ impl MaternalChildHealthContract {
         prenatal_risk_factors: Vec<Symbol>,
     ) -> Result<u64, Error> {
         provider_id.require_auth();
+        patient_id.require_auth();
+
+        if !Self::is_registered_provider(&env, &provider_id) {
+            return Err(Error::Unauthorized);
+        }
 
         if lmp_date >= estimated_due_date || para > gravida {
             return Err(Error::InvalidData);
@@ -414,6 +450,14 @@ impl MaternalChildHealthContract {
             .get(&DataKey::Labor(labor_id))
             .ok_or(Error::NotFound)?;
 
+        // Proving control of an address is not proof of role -- the
+        // delivering provider must be the provider on record for this
+        // pregnancy.
+        let mut pregnancy = Self::get_pregnancy(&env, labor.pregnancy_id)?;
+        if delivering_provider != pregnancy.provider_id {
+            return Err(Error::Unauthorized);
+        }
+
         let delivery_id = Self::next_id(&env, symbol_short!("dlvry_ct"));
         let delivery = DeliveryRecord {
             delivery_id,
@@ -432,7 +476,6 @@ impl MaternalChildHealthContract {
             .persistent()
             .set(&DataKey::Delivery(delivery_id), &delivery);
 
-        let mut pregnancy = Self::get_pregnancy(&env, labor.pregnancy_id)?;
         pregnancy.outcome = Some(symbol_short!("delivrd"));
         env.storage()
             .persistent()
@@ -543,6 +586,11 @@ impl MaternalChildHealthContract {
         bmi_x100: i64,
     ) -> Result<(), Error> {
         provider_id.require_auth();
+        patient_id.require_auth();
+
+        if !Self::is_registered_provider(&env, &provider_id) {
+            return Err(Error::Unauthorized);
+        }
 
         if age_months > 228 || weight_kg_x100 <= 0 || height_cm_x100 <= 0 || bmi_x100 <= 0 {
             return Err(Error::InvalidData);
@@ -585,6 +633,11 @@ impl MaternalChildHealthContract {
         concerns: Vec<Symbol>,
     ) -> Result<(), Error> {
         provider_id.require_auth();
+        patient_id.require_auth();
+
+        if !Self::is_registered_provider(&env, &provider_id) {
+            return Err(Error::Unauthorized);
+        }
 
         if age_months > 228 {
             return Err(Error::InvalidData);
@@ -617,6 +670,11 @@ impl MaternalChildHealthContract {
         anticipatory_guidance_hash: BytesN<32>,
     ) -> Result<(), Error> {
         provider_id.require_auth();
+        patient_id.require_auth();
+
+        if !Self::is_registered_provider(&env, &provider_id) {
+            return Err(Error::Unauthorized);
+        }
 
         if age_months > 228 {
             return Err(Error::InvalidData);

--- a/contracts/prenatal-pediatric/src/test.rs
+++ b/contracts/prenatal-pediatric/src/test.rs
@@ -1,22 +1,63 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::Address as _, vec, Address, BytesN, Env, String, Symbol};
+use provider_registry::{ProviderRegistry, ProviderRegistryClient};
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    vec, Address, BytesN, Env, IntoVal, String, Symbol,
+};
 
-fn setup() -> (Env, MaternalChildHealthContractClient<'static>) {
+fn register_test_provider(
+    env: &Env,
+    registry: &ProviderRegistryClient<'static>,
+    admin: &Address,
+    provider: &Address,
+) {
+    let issuer = Address::generate(env);
+    registry.register_provider(
+        admin,
+        provider,
+        &String::from_str(env, "Dr. Provider"),
+        &String::from_str(env, "General"),
+        &String::from_str(env, "LIC-001"),
+        &BytesN::from_array(env, &[1u8; 32]),
+        &issuer,
+        &BytesN::from_array(env, &[2u8; 32]),
+        &u64::MAX,
+        &BytesN::from_array(env, &[3u8; 32]),
+    );
+}
+
+fn setup() -> (
+    Env,
+    MaternalChildHealthContractClient<'static>,
+    ProviderRegistryClient<'static>,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let registry_id = env.register(ProviderRegistry, ());
+    let registry = ProviderRegistryClient::new(&env, &registry_id);
+    registry.initialize(&admin);
+
     let contract_id = env.register(MaternalChildHealthContract, ());
     let client = MaternalChildHealthContractClient::new(&env, &contract_id);
-    (env, client)
+    client.initialize(&admin, &registry_id);
+
+    (env, client, registry, admin)
 }
 
 fn seed_pregnancy(
     env: &Env,
     client: &MaternalChildHealthContractClient<'static>,
+    registry: &ProviderRegistryClient<'static>,
+    admin: &Address,
 ) -> (Address, Address, u64) {
     let patient = Address::generate(env);
     let provider = Address::generate(env);
+    register_test_provider(env, registry, admin, &provider);
     let pregnancy_id = client.create_pregnancy_record(
         &patient,
         &provider,
@@ -31,8 +72,8 @@ fn seed_pregnancy(
 
 #[test]
 fn test_create_pregnancy_record() {
-    let (env, client) = setup();
-    let (patient, provider, id) = seed_pregnancy(&env, &client);
+    let (env, client, registry, admin) = setup();
+    let (patient, provider, id) = seed_pregnancy(&env, &client, &registry, &admin);
 
     assert_eq!(id, 1);
     let record = client.get_pregnancy_record(&id);
@@ -44,9 +85,10 @@ fn test_create_pregnancy_record() {
 
 #[test]
 fn test_create_pregnancy_invalid_dates_fails() {
-    let (env, client) = setup();
+    let (env, client, registry, admin) = setup();
     let patient = Address::generate(&env);
     let provider = Address::generate(&env);
+    register_test_provider(&env, &registry, &admin, &provider);
 
     let res = client.try_create_pregnancy_record(
         &patient,
@@ -61,9 +103,73 @@ fn test_create_pregnancy_invalid_dates_fails() {
 }
 
 #[test]
+fn test_create_pregnancy_record_rejects_unconsented_patient() {
+    let (env, client, registry, admin) = setup();
+    let patient = Address::generate(&env);
+    let provider = Address::generate(&env);
+    register_test_provider(&env, &registry, &admin, &provider);
+
+    let gravida = 2u32;
+    let para = 1u32;
+    let risk_factors = vec![&env, Symbol::new(&env, "diabetes")];
+
+    // Only the provider signs; the patient never authorized this record.
+    let result = client
+        .mock_auths(&[MockAuth {
+            address: &provider,
+            invoke: &MockAuthInvoke {
+                contract: &client.address,
+                fn_name: "create_pregnancy_record",
+                args: (
+                    &patient,
+                    &provider,
+                    1_700_000_000u64,
+                    1_725_000_000u64,
+                    gravida,
+                    para,
+                    &risk_factors,
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .try_create_pregnancy_record(
+            &patient,
+            &provider,
+            &1_700_000_000,
+            &1_725_000_000,
+            &gravida,
+            &para,
+            &risk_factors,
+        );
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_create_pregnancy_record_rejects_unregistered_provider() {
+    let (env, client, _registry, _admin) = setup();
+    let patient = Address::generate(&env);
+    // Never registered in the provider-registry.
+    let unregistered_provider = Address::generate(&env);
+
+    let result = client.try_create_pregnancy_record(
+        &patient,
+        &unregistered_provider,
+        &1_700_000_000,
+        &1_725_000_000,
+        &2,
+        &1,
+        &vec![&env, Symbol::new(&env, "diabetes")],
+    );
+
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
 fn test_prenatal_visit_screening_and_ultrasound() {
-    let (env, client) = setup();
-    let (_patient, _provider, pregnancy_id) = seed_pregnancy(&env, &client);
+    let (env, client, registry, admin) = setup();
+    let (_patient, _provider, pregnancy_id) = seed_pregnancy(&env, &client, &registry, &admin);
 
     client.record_prenatal_visit(
         &pregnancy_id,
@@ -107,8 +213,8 @@ fn test_prenatal_visit_screening_and_ultrasound() {
 
 #[test]
 fn test_labor_delivery_and_newborn_flow() {
-    let (env, client) = setup();
-    let (_patient, provider, pregnancy_id) = seed_pregnancy(&env, &client);
+    let (env, client, registry, admin) = setup();
+    let (_patient, provider, pregnancy_id) = seed_pregnancy(&env, &client, &registry, &admin);
 
     let labor_id = client.document_labor_admission(
         &pregnancy_id,
@@ -168,8 +274,40 @@ fn test_labor_delivery_and_newborn_flow() {
 }
 
 #[test]
+fn test_record_delivery_rejects_provider_not_on_pregnancy() {
+    let (env, client, registry, admin) = setup();
+    let (_patient, _provider, pregnancy_id) = seed_pregnancy(&env, &client, &registry, &admin);
+
+    // A different, otherwise-registered provider who was never assigned to
+    // this pregnancy tries to record the delivery.
+    let outsider_provider = Address::generate(&env);
+    register_test_provider(&env, &registry, &admin, &outsider_provider);
+
+    let labor_id = client.document_labor_admission(
+        &pregnancy_id,
+        &1_724_900_000,
+        &true,
+        &Symbol::new(&env, "intact"),
+        &6,
+        &90,
+    );
+
+    let res = client.try_record_delivery(
+        &labor_id,
+        &1_725_000_000,
+        &Symbol::new(&env, "vaginal"),
+        &Symbol::new(&env, "vertex"),
+        &vec![&env, Symbol::new(&env, "none")],
+        &350,
+        &outsider_provider,
+    );
+
+    assert_eq!(res, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
 fn test_newborn_screening_and_missing_newborn() {
-    let (env, client) = setup();
+    let (env, client, _registry, _admin) = setup();
     let provider = Address::generate(&env);
     let missing = Address::generate(&env);
     let res = client.try_record_newborn_screening(
@@ -185,8 +323,8 @@ fn test_newborn_screening_and_missing_newborn() {
 
 #[test]
 fn test_newborn_screening_success() {
-    let (env, client) = setup();
-    let (_patient, provider, pregnancy_id) = seed_pregnancy(&env, &client);
+    let (env, client, registry, admin) = setup();
+    let (_patient, provider, pregnancy_id) = seed_pregnancy(&env, &client, &registry, &admin);
 
     let labor_id = client.document_labor_admission(
         &pregnancy_id,
@@ -230,9 +368,10 @@ fn test_newborn_screening_success() {
 
 #[test]
 fn test_pediatric_growth_milestones_well_child() {
-    let (env, client) = setup();
+    let (env, client, registry, admin) = setup();
     let patient = Address::generate(&env);
     let provider = Address::generate(&env);
+    register_test_provider(&env, &registry, &admin, &provider);
 
     client.track_pediatric_growth(
         &provider,
@@ -271,8 +410,8 @@ fn test_pediatric_growth_milestones_well_child() {
 
 #[test]
 fn test_invalid_inputs_failures() {
-    let (env, client) = setup();
-    let (_patient, provider, pregnancy_id) = seed_pregnancy(&env, &client);
+    let (env, client, registry, admin) = setup();
+    let (_patient, provider, pregnancy_id) = seed_pregnancy(&env, &client, &registry, &admin);
 
     let bad_labor = client.try_document_labor_admission(
         &pregnancy_id,
@@ -331,7 +470,7 @@ fn test_invalid_inputs_failures() {
 
 #[test]
 fn test_calculate_growth_percentiles() {
-    let (env, client) = setup();
+    let (env, client, _registry, _admin) = setup();
     let patient = Address::generate(&env);
 
     let percentiles = client.calculate_growth_percentiles(
@@ -366,11 +505,8 @@ fn test_calculate_growth_percentiles() {
 #[test]
 #[should_panic]
 fn test_prenatal_visit_requires_provider_auth() {
-    let env = Env::default();
-    let contract_id = env.register(MaternalChildHealthContract, ());
-    let client = MaternalChildHealthContractClient::new(&env, &contract_id);
-    env.mock_all_auths();
-    let (_patient, _provider, pregnancy_id) = seed_pregnancy(&env, &client);
+    let (env, client, registry, admin) = setup();
+    let (_patient, _provider, pregnancy_id) = seed_pregnancy(&env, &client, &registry, &admin);
 
     env.set_auths(&[]);
     client.record_prenatal_visit(
@@ -388,11 +524,8 @@ fn test_prenatal_visit_requires_provider_auth() {
 #[test]
 #[should_panic]
 fn test_document_labor_admission_requires_provider_auth() {
-    let env = Env::default();
-    let contract_id = env.register(MaternalChildHealthContract, ());
-    let client = MaternalChildHealthContractClient::new(&env, &contract_id);
-    env.mock_all_auths();
-    let (_patient, _provider, pregnancy_id) = seed_pregnancy(&env, &client);
+    let (env, client, registry, admin) = setup();
+    let (_patient, _provider, pregnancy_id) = seed_pregnancy(&env, &client, &registry, &admin);
 
     env.set_auths(&[]);
     client.document_labor_admission(
@@ -407,8 +540,8 @@ fn test_document_labor_admission_requires_provider_auth() {
 
 #[test]
 fn test_record_newborn_rejects_mismatched_provider() {
-    let (env, client) = setup();
-    let (_patient, provider, pregnancy_id) = seed_pregnancy(&env, &client);
+    let (env, client, registry, admin) = setup();
+    let (_patient, provider, pregnancy_id) = seed_pregnancy(&env, &client, &registry, &admin);
     let impostor = Address::generate(&env);
 
     let labor_id = client.document_labor_admission(
@@ -467,7 +600,7 @@ fn test_track_pediatric_growth_requires_provider_auth() {
 
 #[test]
 fn test_nonexistent_getters_fail() {
-    let (env, client) = setup();
+    let (env, client, _registry, _admin) = setup();
     let res1 = client.try_get_pregnancy_record(&999);
     let res_labor = client.try_get_labor_record(&999);
     let res2 = client.try_get_delivery_record(&999);


### PR DESCRIPTION
…racts (#738, #739, #740, #741)

security: mental-health record_phq9_score and record_gad7_score skip consent validation unlike every sibling function Fixes #738

security: prenatal-pediatric record-creation functions have no patient consent or provider-registry checks despite docstring claims Fixes #739

bug: dental-records prescribe_dental_medication allows any self-declared dentist to write prescriptions for any patient Fixes #740

security: emergency-medical-info add_critical_alert has no responder verification Fixes #741

## Summary

<!-- What does this PR change and why? -->

## Changelog

- [ ] I have updated `CHANGELOG.md` for any user-facing contract API change (new functions, breaking changes, deprecations, or security fixes).

## Test plan

- [ ] Unit / integration tests added or updated
- [ ] `cargo test` passes locally (if applicable)
