### PR TITLE
Fix/device auth admin checks and id integrity

### DIFF
--- a/contracts/healthcare-analytics/src/lib.rs
+++ b/contracts/healthcare-analytics/src/lib.rs
@@ -368,16 +368,26 @@ impl HealthcareAnalytics {
 
     /// Execute next available report job (respects resource limits)
     /// Returns job_id if a job was started, or None if queue empty or resources exhausted
-    pub fn execute_next_report(env: Env) -> Option<u64> {
-        // Admin-only operation
+    /// Admin-only operation
+    pub fn execute_next_report(env: Env, admin: Address) -> Result<Option<u64>, Error> {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::Unauthorized)?;
+        if admin != stored_admin {
+            return Err(Error::Unauthorized);
+        }
+
         if let Some(job_id) = get_next_job_for_execution(&env) {
             // Start execution (in real implementation, this would spawn background job)
             let _ = shared::resource_management::start_job(&env, job_id);
             env.events()
                 .publish((symbol_short!("exec_job"), job_id), symbol_short!("started"));
-            Some(job_id)
+            Ok(Some(job_id))
         } else {
-            None
+            Ok(None)
         }
     }
 

--- a/contracts/healthcare-analytics/src/lib.rs
+++ b/contracts/healthcare-analytics/src/lib.rs
@@ -537,6 +537,10 @@ impl HealthcareAnalytics {
             return Err(Error::InvalidThreshold);
         }
 
+        if cpu_budget == 0 || memory_budget == 0 {
+            return Err(Error::InvalidValue);
+        }
+
         set_system_limits(
             &env,
             shared::resource_management::SystemResourceLimits {

--- a/contracts/healthcare-analytics/src/test.rs
+++ b/contracts/healthcare-analytics/src/test.rs
@@ -797,7 +797,7 @@ fn test_cpu_quota_accumulates_across_jobs() {
         &50,
         &DegradationPolicy::Fail,
     ).unwrap().unwrap().job_id;
-    client.execute_next_report();
+    client.execute_next_report(&admin).unwrap();
     client.complete_report(&job1, &400, &50);
 
     // Second job: another 400 CPU — still below threshold (total 800, not > 800)
@@ -809,7 +809,7 @@ fn test_cpu_quota_accumulates_across_jobs() {
         &50,
         &DegradationPolicy::Fail,
     ).unwrap().unwrap().job_id;
-    client.execute_next_report();
+    client.execute_next_report(&admin).unwrap();
     client.complete_report(&job2, &400, &50);
 
     // Now TotalCpuUsed = 800; 800*100/1000 = 80, which is NOT > 80, so one more is still ok.
@@ -822,7 +822,7 @@ fn test_cpu_quota_accumulates_across_jobs() {
         &1,
         &DegradationPolicy::Fail,
     ).unwrap().unwrap().job_id;
-    client.execute_next_report();
+    client.execute_next_report(&admin).unwrap();
     client.complete_report(&job3, &1, &1);
 
     // TotalCpuUsed = 801; 801*100/1000 = 80 (integer), still not > 80.
@@ -835,7 +835,7 @@ fn test_cpu_quota_accumulates_across_jobs() {
         &1,
         &DegradationPolicy::Fail,
     ).unwrap().unwrap().job_id;
-    client.execute_next_report();
+    client.execute_next_report(&admin).unwrap();
     client.complete_report(&job4, &100, &1);
 
     // TotalCpuUsed = 901; 901*100/1000 = 90 > 80 → throttled
@@ -852,7 +852,7 @@ fn test_cpu_quota_accumulates_across_jobs() {
 
 #[test]
 fn test_cancel_report_queued() {
-    let (env, client, _admin) = setup_with_admin();
+    let (env, client, admin) = setup_with_admin();
     let requester = Address::generate(&env);
 
     let accepted = client
@@ -880,13 +880,13 @@ fn test_cancel_report_queued() {
     assert_eq!(err_not_found, Err(Ok(Error::JobNotFound)));
 
     // Cancelled job ID cannot be re-executed
-    let next_job = client.execute_next_report();
-    assert_eq!(next_job, None);
+    let next_job = client.execute_next_report(&admin);
+    assert_eq!(next_job, Ok(None));
 }
 
 #[test]
 fn test_cancel_report_executing() {
-    let (env, client, _admin) = setup_with_admin();
+    let (env, client, admin) = setup_with_admin();
     let requester = Address::generate(&env);
 
     let accepted = client
@@ -902,12 +902,57 @@ fn test_cancel_report_executing() {
     let job_id = accepted.job_id;
 
     // Start executing the job
-    let executed_id = client.execute_next_report().unwrap();
+    let executed_id = client.execute_next_report(&admin).unwrap().unwrap();
     assert_eq!(executed_id, job_id);
 
     // Executing job cancellation returns Error::JobAlreadyExecuting
     let err_executing = client.try_cancel_report(&requester, &job_id);
     assert_eq!(err_executing, Err(Ok(Error::JobAlreadyExecuting)));
+}
+
+// ========================
+// execute_next_report auth tests
+// ========================
+
+#[test]
+fn test_execute_next_report_requires_admin_auth() {
+    let (env, client, admin) = setup_with_admin();
+    let requester = Address::generate(&env);
+
+    // Queue a report
+    client.request_report(
+        &requester,
+        &String::from_str(&env, "quality_metrics"),
+        &shared::resource_management::JobPriority::Normal,
+        &500_000,
+        &50_000,
+        &DegradationPolicy::Fail,
+    );
+
+    // Non-admin call should be rejected
+    let non_admin = Address::generate(&env);
+    let result = client.try_execute_next_report(&non_admin);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_execute_next_report_admin_succeeds() {
+    let (env, client, admin) = setup_with_admin();
+    let requester = Address::generate(&env);
+
+    // Queue a report
+    let accepted = client.request_report(
+        &requester,
+        &String::from_str(&env, "quality_metrics"),
+        &shared::resource_management::JobPriority::Normal,
+        &500_000,
+        &50_000,
+        &DegradationPolicy::Fail,
+    );
+
+    // Admin call should succeed and return the job_id
+    let result = client.execute_next_report(&admin);
+    assert_eq!(result, Ok(Some(accepted.job_id)));
 }
 
 // ========================

--- a/contracts/healthcare-analytics/src/test.rs
+++ b/contracts/healthcare-analytics/src/test.rs
@@ -956,6 +956,65 @@ fn test_execute_next_report_admin_succeeds() {
 }
 
 // ========================
+// set_resource_limits tests
+// ========================
+
+#[test]
+fn test_set_resource_limits_rejects_zero_cpu_budget() {
+    let (env, client, admin) = setup_with_admin();
+
+    let result = client.try_set_resource_limits(&admin, &0, &1_000_000, &5, &80);
+    assert_eq!(result, Err(Ok(Error::InvalidValue)));
+}
+
+#[test]
+fn test_set_resource_limits_rejects_zero_memory_budget() {
+    let (env, client, admin) = setup_with_admin();
+
+    let result = client.try_set_resource_limits(&admin, &1_000_000, &0, &5, &80);
+    assert_eq!(result, Err(Ok(Error::InvalidValue)));
+}
+
+#[test]
+fn test_set_resource_limits_rejects_both_zero() {
+    let (env, client, admin) = setup_with_admin();
+
+    let result = client.try_set_resource_limits(&admin, &0, &0, &5, &80);
+    assert_eq!(result, Err(Ok(Error::InvalidValue)));
+}
+
+#[test]
+fn test_set_resource_limits_accepts_nonzero_budgets() {
+    let (env, client, admin) = setup_with_admin();
+
+    let result = client.try_set_resource_limits(&admin, &1_000_000, &100_000, &5, &80);
+    assert_eq!(result, Ok(Ok(())));
+}
+
+#[test]
+fn test_request_report_throttle_check_no_panic_with_proper_budgets() {
+    let (env, client, admin) = setup_with_admin();
+    let requester = Address::generate(&env);
+
+    // Set valid non-zero budgets
+    client.set_resource_limits(&admin, &10_000, &10_000, &5, &50);
+
+    // should_throttle_job is called internally; it should not panic
+    // because the budgets are guaranteed to be non-zero
+    let result = client.try_request_report(
+        &requester,
+        &String::from_str(&env, "quality_metrics"),
+        &JobPriority::Normal,
+        &100,
+        &100,
+        &DegradationPolicy::Fail,
+    );
+
+    // Should succeed, proving should_throttle_job didn't panic
+    assert!(result.is_ok());
+}
+
+// ========================
 // Admin rotation tests
 // ========================
 

--- a/contracts/patient-vitals/src/contract.rs
+++ b/contracts/patient-vitals/src/contract.rs
@@ -163,16 +163,28 @@ impl PatientVitalsContract {
         env: Env,
         device_id: String,
         patient_id: Address,
+        device_address: Address,
         _reading_time: u64,
         readings: Vec<DeviceReading>,
     ) -> Result<(), Error> {
-        // Assume device or patient has permission to submit
-        patient_id.require_auth();
-
         // Verify device is registered
         let device_key = DataKey::DeviceReg(patient_id.clone(), device_id);
         if !env.storage().persistent().has(&device_key) {
             return Err(Error::NotFound); // Device not registered
+        }
+
+        // Authorization: require auth from either the device or the patient
+        // Primary path: registered device submits on its own authority
+        let is_device = env
+            .storage()
+            .persistent()
+            .has(&DataKey::DeviceAddress(patient_id.clone(), device_address.clone()));
+
+        if is_device {
+            device_address.require_auth();
+        } else {
+            // Fallback: patient can submit readings on device's behalf
+            patient_id.require_auth();
         }
 
         let key = DataKey::VitalsHistory(patient_id.clone());
@@ -186,7 +198,7 @@ impl PatientVitalsContract {
             history.push_back(VitalReading {
                 measurement_time: reading.reading_time,
                 vitals: reading.values.clone(),
-                recorder: patient_id.clone(), // or device address
+                recorder: device_address.clone(),
             });
             Self::evaluate_thresholds(&env, &patient_id, reading.reading_time, &reading.values);
         }

--- a/contracts/patient-vitals/src/test.rs
+++ b/contracts/patient-vitals/src/test.rs
@@ -128,13 +128,140 @@ fn test_device_registration_and_reading() {
         },
     });
 
-    client.submit_device_reading(&device_id, &patient_id, &1672531200, &readings);
+    client.submit_device_reading(&device_id, &patient_id, &device_address, &1672531200, &readings);
 
     // Verify trends to see the reading was added
     let trends =
         client.get_vital_trends(&patient_id, &patient_id, &Symbol::new(&env, "heart_rate"), &0, &u64::MAX);
     assert_eq!(trends.len(), 1);
     assert_eq!(trends.get(0).unwrap().vitals.heart_rate, Some(75));
+}
+
+#[test]
+fn test_submit_device_reading_device_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PatientVitalsContract, ());
+    let client = PatientVitalsContractClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    let device_id = String::from_str(&env, "DEVICE_123");
+    let device_address = Address::generate(&env);
+
+    // Register the device
+    client.register_monitoring_device(
+        &patient_id,
+        &device_id,
+        &device_address,
+        &Symbol::new(&env, "watch"),
+        &String::from_str(&env, "SN-456"),
+        &1670000000,
+    );
+
+    let mut readings = Vec::new(&env);
+    readings.push_back(DeviceReading {
+        reading_time: 1672531200,
+        values: VitalSigns {
+            blood_pressure_systolic: None,
+            blood_pressure_diastolic: None,
+            heart_rate: Some(75),
+            temperature: None,
+            respiratory_rate: None,
+            oxygen_saturation: None,
+            blood_glucose: None,
+            weight: None,
+        },
+    });
+
+    // Device submits via its own auth (not patient auth)
+    client.submit_device_reading(&device_id, &patient_id, &device_address, &1672531200, &readings);
+
+    // Verify the reading was added
+    let trends =
+        client.get_vital_trends(&patient_id, &patient_id, &Symbol::new(&env, "heart_rate"), &0, &u64::MAX);
+    assert_eq!(trends.len(), 1);
+    assert_eq!(trends.get(0).unwrap().vitals.heart_rate, Some(75));
+    // Recorder should be the device address
+    assert_eq!(trends.get(0).unwrap().recorder, device_address);
+}
+
+#[test]
+fn test_submit_device_reading_patient_fallback() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PatientVitalsContract, ());
+    let client = PatientVitalsContractClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    let device_id = String::from_str(&env, "DEVICE_123");
+    let device_address = Address::generate(&env);
+
+    // Register the device
+    client.register_monitoring_device(
+        &patient_id,
+        &device_id,
+        &device_address,
+        &Symbol::new(&env, "watch"),
+        &String::from_str(&env, "SN-456"),
+        &1670000000,
+    );
+
+    let mut readings = Vec::new(&env);
+    readings.push_back(DeviceReading {
+        reading_time: 1672531200,
+        values: VitalSigns {
+            blood_pressure_systolic: None,
+            blood_pressure_diastolic: None,
+            heart_rate: Some(75),
+            temperature: None,
+            respiratory_rate: None,
+            oxygen_saturation: None,
+            blood_glucose: None,
+            weight: None,
+        },
+    });
+
+    // Patient can submit on device's behalf via fallback auth
+    client.submit_device_reading(&device_id, &patient_id, &device_address, &1672531200, &readings);
+
+    // Verify the reading was added
+    let trends =
+        client.get_vital_trends(&patient_id, &patient_id, &Symbol::new(&env, "heart_rate"), &0, &u64::MAX);
+    assert_eq!(trends.len(), 1);
+}
+
+#[test]
+fn test_submit_device_reading_unregistered_device_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PatientVitalsContract, ());
+    let client = PatientVitalsContractClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    let device_id = String::from_str(&env, "DEVICE_123");
+    let unregistered_device = Address::generate(&env);
+
+    let mut readings = Vec::new(&env);
+    readings.push_back(DeviceReading {
+        reading_time: 1672531200,
+        values: VitalSigns {
+            blood_pressure_systolic: None,
+            blood_pressure_diastolic: None,
+            heart_rate: Some(75),
+            temperature: None,
+            respiratory_rate: None,
+            oxygen_saturation: None,
+            blood_glucose: None,
+            weight: None,
+        },
+    });
+
+    // Attempt to submit with an unregistered device should fail
+    let result = client.try_submit_device_reading(&device_id, &patient_id, &unregistered_device, &1672531200, &readings);
+    assert_eq!(result, Err(Ok(crate::types::Error::NotFound)));
 }
 
 #[test]

--- a/contracts/telemedicine/src/contract.rs
+++ b/contracts/telemedicine/src/contract.rs
@@ -591,7 +591,19 @@ impl TelemedicineContract {
             }
         }
 
-        let rx_id = env.ledger().timestamp() % 100000;
+        let rx_id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PrescriptionCount)
+            .unwrap_or(0)
+            + 1;
+        env.storage()
+            .persistent()
+            .set(&DataKey::PrescriptionCount, &rx_id);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Prescription(rx_id), &prescription_details);
 
         env.events().publish(
             (Symbol::new(&env, "prescription_issued"), visit_id),
@@ -616,6 +628,17 @@ impl TelemedicineContract {
             .persistent()
             .set(&DataKey::ControlledSubstancePolicy(jurisdiction), &requires_inperson);
         Ok(())
+    }
+
+    /// Retrieve a prescription by its rx_id.
+    pub fn get_prescription(
+        env: Env,
+        rx_id: u64,
+    ) -> Result<PrescriptionRequest, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Prescription(rx_id))
+            .ok_or(Error::VisitNotFound)
     }
 }
 

--- a/contracts/telemedicine/src/test.rs
+++ b/contracts/telemedicine/src/test.rs
@@ -105,7 +105,13 @@ fn test_telemedicine_lifecycle() {
         is_controlled_substance: false,
     };
     let rx_id = client.prescribe_during_visit(&visit_id, &provider_id, &patient_id, &rx_request);
-    assert_eq!(rx_id, 0);
+    assert_eq!(rx_id, 1);
+
+    // Verify prescription was persisted
+    let stored_rx = client.get_prescription(&rx_id);
+    assert_eq!(stored_rx.medication_name, rx_request.medication_name);
+    assert_eq!(stored_rx.dosage, rx_request.dosage);
+    assert_eq!(stored_rx.is_controlled_substance, rx_request.is_controlled_substance);
 
     // 6. Record documentation
     let note_hash = BytesN::from_array(&env, &[1; 32]);
@@ -450,4 +456,103 @@ fn test_prescribe_controlled_substance_blocked_by_policy() {
         result,
         Err(Ok(crate::types::Error::ControlledSubstanceRequiresInPerson))
     );
+}
+
+#[test]
+fn test_prescribe_rx_id_uniqueness_and_persistence() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(TelemedicineContract, ());
+    let client = TelemedicineContractClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+    let visit_time = 1700000000;
+
+    // Register provider license
+    client.register_provider_license(
+        &provider_id,
+        &String::from_str(&env, "NY"),
+        &String::from_str(&env, "LIC-NY-001"),
+        &0_u64,
+    );
+
+    // Schedule first visit
+    let visit_id_1 = client.schedule_virtual_visit(
+        &patient_id,
+        &provider_id,
+        &visit_time,
+        &Symbol::new(&env, "Consult"),
+        &30,
+        &Symbol::new(&env, "ZoomHD"),
+        &true,
+        &true,
+    );
+
+    // Start first session
+    let token_1 = client.start_virtual_session(
+        &visit_id_1,
+        &provider_id,
+        &visit_time,
+        &String::from_str(&env, "NY"),
+        &String::from_str(&env, "NY"),
+    );
+    client.validate_session_token(&visit_id_1, &provider_id, &token_1);
+
+    // Issue first prescription
+    let rx_request_1 = PrescriptionRequest {
+        medication_name: String::from_str(&env, "Amoxicillin"),
+        dosage: String::from_str(&env, "500mg"),
+        frequency: String::from_str(&env, "BID"),
+        duration_days: 10,
+        is_controlled_substance: false,
+    };
+    let rx_id_1 = client.prescribe_during_visit(&visit_id_1, &provider_id, &patient_id, &rx_request_1);
+
+    // Schedule second visit at same timestamp to test uniqueness
+    let visit_id_2 = client.schedule_virtual_visit(
+        &patient_id,
+        &provider_id,
+        &visit_time,
+        &Symbol::new(&env, "FollowUp"),
+        &15,
+        &Symbol::new(&env, "ZoomHD"),
+        &true,
+        &true,
+    );
+
+    // Start second session
+    let token_2 = client.start_virtual_session(
+        &visit_id_2,
+        &provider_id,
+        &visit_time,
+        &String::from_str(&env, "NY"),
+        &String::from_str(&env, "NY"),
+    );
+    client.validate_session_token(&visit_id_2, &provider_id, &token_2);
+
+    // Issue second prescription at same timestamp
+    let rx_request_2 = PrescriptionRequest {
+        medication_name: String::from_str(&env, "Ibuprofen"),
+        dosage: String::from_str(&env, "400mg"),
+        frequency: String::from_str(&env, "Q6H"),
+        duration_days: 5,
+        is_controlled_substance: false,
+    };
+    let rx_id_2 = client.prescribe_during_visit(&visit_id_2, &provider_id, &patient_id, &rx_request_2);
+
+    // rx_ids must be unique even though both prescriptions were issued at same timestamp
+    assert_ne!(rx_id_1, rx_id_2);
+    assert_eq!(rx_id_1, 1);
+    assert_eq!(rx_id_2, 2);
+
+    // Both prescriptions should be independently retrievable
+    let stored_rx_1 = client.get_prescription(&rx_id_1);
+    assert_eq!(stored_rx_1.medication_name, rx_request_1.medication_name);
+    assert_eq!(stored_rx_1.dosage, rx_request_1.dosage);
+
+    let stored_rx_2 = client.get_prescription(&rx_id_2);
+    assert_eq!(stored_rx_2.medication_name, rx_request_2.medication_name);
+    assert_eq!(stored_rx_2.dosage, rx_request_2.dosage);
 }

--- a/contracts/telemedicine/src/types.rs
+++ b/contracts/telemedicine/src/types.rs
@@ -148,4 +148,8 @@ pub enum DataKey {
     ProviderSessionWindow(Address),
     /// Address of the external provider registry contract
     ProviderRegistryAddress,
+    /// Persistent counter for prescription IDs
+    PrescriptionCount,
+    /// rx_id -> PrescriptionRequest
+    Prescription(u64),
 }


### PR DESCRIPTION
## Summary

   Fixes four defects across three contracts: `execute_next_report` now enforces the admin-only access its own code comment claims, `set_resource_limits` rejects zero
   CPU/memory budgets that could permanently brick the analytics pipeline, `submit_device_reading` allows registered monitoring devices to submit readings
   independently, and `prescribe_during_visit` generates genuinely unique, persistent rx_ids with full prescription records queryable on-chain.

   ## Changes

   ### #773 — healthcare-analytics: execute_next_report missing admin auth despite comment
   - Added `admin: Address` parameter + `.require_auth()` call + stored-admin comparison, matching `set_resource_limits` pattern
   - Tests verify non-admin calls rejected with `Unauthorized`, admin calls succeed

   ### #774 — healthcare-analytics: set_resource_limits allows zero budget causing division-by-zero panic
   - Rejects `cpu_budget == 0 || memory_budget == 0` with `InvalidValue` error
   - Prevents downstream panic in `should_throttle_job` division
   - Regression test confirms `request_report` works without panic when proper budgets set

   ### #772 — patient-vitals: submit_device_reading requires patient signature, blocks autonomous monitoring
   - Added `device_address: Address` parameter
   - Registered device can now submit via `.require_auth()` on device (validated against `DataKey::DeviceAddress` mapping)
   - Patient-submits-on-device's-behalf kept as optional fallback, not requirement
   - Tests verify device auth path, patient fallback, and unregistered device rejection

   ### #775 — telemedicine: prescribe_during_visit generates non-unique timestamp-modulo rx_id, never persists prescription
   - Replaced `timestamp % 100000` with persistent auto-increment counter (matching `VisitCount` pattern)
   - Full `PrescriptionRequest` now persisted under `DataKey::Prescription(rx_id)`
   - Added `get_prescription(rx_id)` getter for on-chain retrieval
   - Tests verify unique rx_ids across same-timestamp prescriptions, independent retrievability from storage

   ## Notes
   - Code-only delivery: no install/build/test/scripts run during implementation
   - All four issues fixed in single branch, one commit per issue
   - No co-author tags per requirements

   Closes #773, Closes #774, Closes #772, Closes #775