### PR TITLE
security: require authorization for allergy severity downgrade and resolution

### DIFF
--- a/contracts/allergy-tracking/src/lib.rs
+++ b/contracts/allergy-tracking/src/lib.rs
@@ -453,6 +453,14 @@ impl AllergyTrackingContract {
             .get(&allergy_key)
             .ok_or(Error::AllergyNotFound)?;
 
+        // Only the recording provider, a provider the patient has granted access
+        // to, or the patient themselves may update severity.
+        if provider_id != allergy.provider_id
+            && !Self::check_access(&env, &allergy.patient_id, &provider_id)
+        {
+            return Err(Error::Unauthorized);
+        }
+
         if allergy.status == AllergyStatus::Resolved {
             return Err(Error::AlreadyResolved);
         }
@@ -521,6 +529,14 @@ impl AllergyTrackingContract {
             .persistent()
             .get(&allergy_key)
             .ok_or(Error::AllergyNotFound)?;
+
+        // Only the recording provider, a provider the patient has granted access
+        // to, or the patient themselves may resolve the allergy.
+        if provider_id != allergy.provider_id
+            && !Self::check_access(&env, &allergy.patient_id, &provider_id)
+        {
+            return Err(Error::Unauthorized);
+        }
 
         if allergy.status == AllergyStatus::Resolved {
             return Err(Error::AlreadyResolved);

--- a/contracts/allergy-tracking/tests/security_audit.rs
+++ b/contracts/allergy-tracking/tests/security_audit.rs
@@ -88,17 +88,71 @@ fn attack_severity_downgrade_without_auth() {
         &true,
     );
 
-    // With valid auth in this harness, a different provider can downgrade severity.
-    // This is a permissive behavior check, not an auth failure check.
-    client.update_allergy_severity(
+    // An attacker who is neither the recording provider, a provider granted
+    // access by the patient, nor the patient themselves must be rejected.
+    let result = client.try_update_allergy_severity(
         &allergy_id,
         &attacker,
         &Symbol::new(&env, "mild"),
         &String::from_str(&env, "Malicious downgrade"),
     );
+    assert_eq!(
+        result,
+        Err(Ok(allergy_tracking::Error::Unauthorized)),
+        "uninvolved caller must not be able to downgrade severity"
+    );
 
-    let updated = client.get_allergy(&allergy_id);
-    assert_eq!(updated.severity, allergy_tracking::Severity::Mild);
+    // Severity must remain unchanged after the rejected attempt.
+    let updated = client.get_allergy(&allergy_id, &patient);
+    assert_eq!(updated.severity, allergy_tracking::Severity::LifeThreatening);
+}
+
+/// ATTACK 3b: Resolution Manipulation
+/// Attempt to resolve a life-threatening allergy as an uninvolved third party
+#[test]
+fn attack_resolve_without_auth() {
+    let env = Env::default();
+    env.mock_all_auths(); // Auth for setup only
+    env.ledger().set_timestamp(10_000);
+
+    let contract_id = env.register(AllergyTrackingContract, ());
+    let client = AllergyTrackingContractClient::new(&env, &contract_id);
+
+    let patient = Address::generate(&env);
+    let provider = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    let mut reactions = Vec::new(&env);
+    reactions.push_back(String::from_str(&env, "anaphylaxis"));
+
+    let allergy_id = client.record_allergy(
+        &patient,
+        &provider,
+        &String::from_str(&env, "Penicillin"),
+        &Symbol::new(&env, "medication"),
+        &reactions,
+        &Symbol::new(&env, "life_threatening"),
+        &None,
+        &true,
+    );
+
+    // An uninvolved attacker must not be able to mark the allergy resolved.
+    let result = client.try_resolve_allergy(
+        &allergy_id,
+        &attacker,
+        &9_000u64,
+        &String::from_str(&env, "Malicious resolution"),
+    );
+    assert_eq!(
+        result,
+        Err(Ok(allergy_tracking::Error::Unauthorized)),
+        "uninvolved caller must not be able to resolve an allergy"
+    );
+
+    // Record must remain active/unresolved after the rejected attempt.
+    let updated = client.get_allergy(&allergy_id, &patient);
+    assert_eq!(updated.status, allergy_tracking::AllergyStatus::Active);
+    assert!(updated.resolution_date.is_none());
 }
 
 /// ATTACK 4: Data Tampering via Duplicate
@@ -340,7 +394,7 @@ fn attack_nonexistent_allergy_access() {
     let provider = Address::generate(&env);
 
     // Attempt to get non-existent allergy
-    let result1 = client.try_get_allergy(&999999);
+    let result1 = client.try_get_allergy(&999999, &provider);
     assert!(result1.is_err());
 
     // Attempt to update non-existent allergy
@@ -556,7 +610,11 @@ fn attack_race_condition_severity_updates() {
         &true,
     );
 
-    // Two providers try to update severity simultaneously
+    // provider2 is not the recording provider, so the patient must explicitly
+    // grant access before provider2's update is authorized.
+    client.grant_access(&patient, &provider2);
+
+    // Two authorized providers try to update severity simultaneously
     client.update_allergy_severity(
         &allergy_id,
         &provider1,


### PR DESCRIPTION
## Summary
`update_allergy_severity` and `resolve_allergy` in `contracts/allergy-tracking/src/lib.rs` only called `provider_id.require_auth()` — they verified that *some* signature was provided for the address passed in as `provider_id`, but never checked that address had any relationship to the allergy record being mutated. Any signer, including an address with no connection to the patient or the original recording provider, could downgrade a life-threatening allergy to Mild or mark it resolved. This re-opens closed issue #317 ("Allergy severity can be downgraded without authorization") — the underlying gap was never actually closed.

Both functions now reject the call with `Error::Unauthorized` unless the caller is one of:
- the provider who originally recorded the allergy (`allergy.provider_id`), or
- a provider the patient has explicitly granted access to via `grant_access` (checked through the existing `check_access` helper, the same mechanism used by every read path in this contract), or
- the patient themselves (also covered by `check_access`).

## Context / Before-After
Before: `tests/security_audit.rs::attack_severity_downgrade_without_auth` demonstrated an uninvolved `attacker` address successfully downgrading a `LifeThreatening` allergy to `Mild`, with a comment noting "this is a permissive behavior check, not an auth failure check" — i.e. the test documented the exploit rather than rejecting it.

After: the same test now asserts the attacker's call is rejected with `Error::Unauthorized` and that the severity is left unchanged.

## Testing
- Updated `attack_severity_downgrade_without_auth` to assert the uninvolved attacker's `update_allergy_severity` call is rejected (`Err(Ok(Error::Unauthorized))`) and that severity remains `LifeThreatening`.
- Added `attack_resolve_without_auth`, equivalent coverage for `resolve_allergy`: an uninvolved attacker is rejected and the record remains `Active` with no resolution date set.
- Adjusted `attack_race_condition_severity_updates`, which previously had two *different, unrelated* providers both mutate the same record — now the patient grants the second provider access first, so the test continues to exercise two concurrent *authorized* updates rather than accidentally re-encoding the vulnerability this PR fixes.
- Ran `cargo test -p allergy-tracking --test security_audit`: all 16 tests pass.

Note: `contracts/allergy-tracking/src/test.rs` (the crate's `#[cfg(test)] mod test` unit tests) currently fails to compile on `upstream/main` independent of this change — several calls to `get_allergy`/`get_record` are missing the `requester` argument that a prior, unrelated change added to those signatures. That's a pre-existing break unrelated to this vulnerability and left out of scope here to keep this PR minimal; happy to file/fix it separately if useful.

Closes #726