### PR TITLE
security: require patient consent before provider self-appointment in patient-vitals

### DIFF
--- a/contracts/patient-vitals/src/contract.rs
+++ b/contracts/patient-vitals/src/contract.rs
@@ -119,6 +119,12 @@ impl PatientVitalsContract {
         monitoring_frequency: u32,
     ) -> Result<(), Error> {
         provider_id.require_auth();
+        // #728: a MonitoringParameters record grants `provider_id` PHI read access
+        // to the patient (see is_authorized_provider). Without the patient's own
+        // signature, any address could self-appoint as "provider" for any patient
+        // by simply calling this function and authorizing as themselves. Require
+        // the patient's consent for every such grant.
+        patient_id.require_auth();
 
         let key = DataKey::MonitoringParams(patient_id, vital_type);
         let params = MonitoringParameters {

--- a/contracts/patient-vitals/src/test.rs
+++ b/contracts/patient-vitals/src/test.rs
@@ -3,7 +3,10 @@
 
 use crate::contract::{PatientVitalsContract, PatientVitalsContractClient};
 use crate::types::{AlertThresholds, DeviceReading, Range, VitalSigns, ALERT_COOLDOWN_SECONDS};
-use soroban_sdk::{testutils::Address as _, Address, Env, String, Symbol, Vec};
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal, String, Symbol, Vec,
+};
 
 #[test]
 fn test_record_vital_signs() {
@@ -787,6 +790,118 @@ fn test_device_can_trigger_vital_alert() {
     let alerts = client.get_alerts(&patient_id, &patient_id, &vital_type);
     assert_eq!(alerts.len(), 1, "device-triggered alert must be recorded");
     assert_eq!(alerts.get(0).unwrap().severity, Symbol::new(&env, "critical_hi"));
+}
+
+// ── #728: provider self-appointment requires patient consent ─────────────────
+
+/// An attacker must not be able to self-appoint as a patient's provider by
+/// calling set_monitoring_parameters(patient_id=victim, provider_id=attacker)
+/// and only authorizing as themselves. Without the patient's own signature the
+/// call must fail, and the attacker must gain no MonitoringParameters entry
+/// (and therefore no PHI read access via get_vital_trends / get_alerts).
+#[test]
+fn test_attacker_cannot_self_appoint_as_provider() {
+    let env = Env::default();
+
+    let contract_id = env.register(PatientVitalsContract, ());
+    let client = PatientVitalsContractClient::new(&env, &contract_id);
+
+    let victim = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let vital_type = Symbol::new(&env, "heart_rate");
+    let target_range = Range { min: 60, max: 100 };
+    let alert_thresholds = AlertThresholds {
+        critical_low: Some(40),
+        low: Some(50),
+        high: Some(110),
+        critical_high: Some(130),
+    };
+
+    // Attacker signs only for themselves (as provider_id) — the victim never
+    // authorizes this call. Real Soroban auth would never satisfy
+    // victim.require_auth() here, so the call must be rejected.
+    let result = client
+        .mock_auths(&[MockAuth {
+            address: &attacker,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "set_monitoring_parameters",
+                args: (
+                    &victim,
+                    &attacker,
+                    &vital_type,
+                    &target_range,
+                    &alert_thresholds,
+                    &3600u32,
+                )
+                    .into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .try_set_monitoring_parameters(
+            &victim,
+            &attacker,
+            &vital_type,
+            &target_range,
+            &alert_thresholds,
+            &3600,
+        );
+    assert!(
+        result.is_err(),
+        "attacker must not be able to self-appoint as provider without the patient's auth"
+    );
+
+    // No MonitoringParameters entry was created, so the attacker gained no PHI
+    // read access — get_vital_trends and get_alerts must still reject them.
+    // (mock_all_auths is used only to satisfy the requester's own require_auth();
+    // the Unauthorized rejection below comes from the application-level
+    // is_authorized_provider check, which the failed call above never satisfied.)
+    env.mock_all_auths();
+    let trends_result = client.try_get_vital_trends(
+        &attacker,
+        &victim,
+        &vital_type,
+        &0u64,
+        &u64::MAX,
+    );
+    assert!(
+        trends_result.is_err(),
+        "attacker must remain unable to read the victim's vital trends"
+    );
+
+    let alerts_result = client.try_get_alerts(&attacker, &victim, &vital_type);
+    assert!(
+        alerts_result.is_err(),
+        "attacker must remain unable to read the victim's alerts"
+    );
+}
+
+/// A patient who consents (both patient and provider authorize) can grant a
+/// provider monitoring access — the legitimate counterpart to the attack above.
+#[test]
+fn test_patient_consent_allows_provider_appointment() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PatientVitalsContract, ());
+    let client = PatientVitalsContractClient::new(&env, &contract_id);
+
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+    let vital_type = Symbol::new(&env, "heart_rate");
+
+    client.set_monitoring_parameters(
+        &patient_id,
+        &provider_id,
+        &vital_type,
+        &Range { min: 60, max: 100 },
+        &AlertThresholds { critical_low: None, low: None, high: None, critical_high: None },
+        &3600,
+    );
+
+    // Provider is now authorized to read the patient's alerts/trends.
+    let alerts = client.get_alerts(&provider_id, &patient_id, &vital_type);
+    assert_eq!(alerts.len(), 0);
 }
 
 /// The patient can still trigger their own alert (backward-compatible).


### PR DESCRIPTION
## Summary
`set_monitoring_parameters` only checked `provider_id.require_auth()` before creating a `MonitoringParameters` record for a patient. Because `is_authorized_provider` (which gates `get_vital_trends`, `calculate_vital_statistics`, and `get_alerts`) treats *any* address holding a `MonitoringParameters` record for a patient as an authorized provider, this allowed an attacker to call `set_monitoring_parameters(patient_id=victim, provider_id=attacker, ...)`, sign only as the attacker, and immediately gain full PHI read access to the victim's vitals — bypassing the access-control fix from #614.

Fix: also require `patient_id.require_auth()` before a `MonitoringParameters` record can be created, so provider appointment now requires the patient's own consent.

## Context / Before-After
**Before:** `provider_id.require_auth()` was the only auth check in `set_monitoring_parameters`. Anyone could self-appoint as a patient's "provider" without the patient ever signing anything, then use that record to pass `is_authorized_provider` and read the patient's vital trends, statistics, and alerts.

**After:** Both `provider_id.require_auth()` and `patient_id.require_auth()` are required. A `MonitoringParameters` record — and therefore the PHI read access it grants — can only be created with the patient's own signature authorizing it.

## Testing
Added `test_attacker_cannot_self_appoint_as_provider` in `contracts/patient-vitals/src/test.rs`: uses `mock_auths` to sign the call *only* as the attacker (the victim never authorizes), asserts `try_set_monitoring_parameters` fails, and then confirms the attacker still cannot read the victim's data via `try_get_vital_trends` / `try_get_alerts`.

Also added `test_patient_consent_allows_provider_appointment` as the legitimate counterpart, confirming a patient-consented appointment still works end-to-end.

Ran the package's full test suite:
```
cargo test -p patient-vitals
```
Result: 24 passed; 0 failed.

Closes #728