### PR TITLE
security: require authenticated caller for schedule_next_maintenance

### DIFF
--- a/contracts/medical-device-tracking/src/lib.rs
+++ b/contracts/medical-device-tracking/src/lib.rs
@@ -711,16 +711,28 @@ impl MedicalDeviceRegistry {
     }
 
     /// Schedule next maintenance after current maintenance is completed.
+    ///
+    /// Restricted to the device's manufacturer or a technician who has an
+    /// existing entry in the device's maintenance history (i.e. previously
+    /// called `record_device_maintenance` for one of this device's implants),
+    /// mirroring the authorization already used for device-level actions
+    /// (`register_device`, `issue_device_recall`) and technician-authenticated
+    /// service records (`record_device_maintenance`).
     pub fn schedule_next_maintenance(
         env: Env,
         device_id: u64,
         maintenance_completed_date: u64,
+        performed_by: Address,
     ) -> Result<(), Error> {
+        performed_by.require_auth();
+
         let mut device: DeviceRecord = env
             .storage()
             .persistent()
             .get(&DataKey::DeviceRecord(device_id))
             .ok_or(Error::RecordNotFound)?;
+
+        Self::assert_authorized_for_device_maintenance(&env, &performed_by, &device)?;
 
         if let Some(interval) = device.maintenance_interval_days {
             device.next_scheduled_maintenance =
@@ -732,6 +744,50 @@ impl MedicalDeviceRegistry {
         } else {
             Err(Error::InvalidInput)
         }
+    }
+
+    /// Verify that `performed_by` is authorized to manage maintenance for `device`:
+    /// either the device's registered manufacturer, or a technician who already
+    /// appears in the device's maintenance history via a prior
+    /// `record_device_maintenance` call on one of the device's implants.
+    fn assert_authorized_for_device_maintenance(
+        env: &Env,
+        performed_by: &Address,
+        device: &DeviceRecord,
+    ) -> Result<(), Error> {
+        if *performed_by == device.manufacturer_id {
+            return Ok(());
+        }
+
+        let implant_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DeviceImplants(device.device_id))
+            .unwrap_or(Vec::new(env));
+
+        for implant_id in implant_ids.iter() {
+            if let Some(implant) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, ImplantRecord>(&DataKey::ImplantRecord(implant_id))
+            {
+                for maintenance_id in implant.maintenance_history.iter() {
+                    if let Some(maintenance) = env
+                        .storage()
+                        .persistent()
+                        .get::<DataKey, MaintenanceRecord>(&DataKey::MaintenanceRecord(
+                            maintenance_id,
+                        ))
+                    {
+                        if maintenance.performed_by == *performed_by {
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+        }
+
+        Err(Error::NotAuthorized)
     }
 
     /// Flag devices that are out of warranty (warranty expired and no active coverage).

--- a/contracts/medical-device-tracking/src/test.rs
+++ b/contracts/medical-device-tracking/src/test.rs
@@ -910,3 +910,134 @@ fn test_track_device_performance_patient_mismatch() {
     // Should fail with NotAuthorized error
     assert!(result.is_err());
 }
+
+#[test]
+#[should_panic(expected = "HostError: Error(Auth, InvalidAction)")]
+fn test_schedule_next_maintenance_requires_auth() {
+    let env = Env::default();
+    // env.mock_all_auths() is NOT called, so auth will fail
+    let contract_id = env.register(MedicalDeviceRegistry, ());
+    let client = MedicalDeviceRegistryClient::new(&env, &contract_id);
+
+    let manufacturer = Address::generate(&env);
+
+    client.schedule_next_maintenance(&1u64, &1710000000u64, &manufacturer);
+}
+
+#[test]
+fn test_schedule_next_maintenance_rejects_unauthorized_caller() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = setup_client(&env);
+
+    let manufacturer = Address::generate(&env);
+    let stranger = Address::generate(&env);
+
+    let device_id = client.register_device(
+        &manufacturer,
+        &String::from_str(&env, "UDI-55555-DME"),
+        &Symbol::new(&env, "DME"),
+        &String::from_str(&env, "MedCorp"),
+        &String::from_str(&env, "MC-200"),
+        &String::from_str(&env, "LOT-002"),
+        &1690000000u64,
+        &None,
+        &dummy_hash(&env),
+        &DeviceExtras {
+            warranty_expiration_date: None,
+            maintenance_interval_days: Some(90u64),
+        },
+    );
+
+    // A caller who is neither the manufacturer nor a technician with an
+    // existing maintenance-history entry for this device must not be able
+    // to rewrite the maintenance schedule.
+    let res = client.try_schedule_next_maintenance(&device_id, &1710000000u64, &stranger);
+    assert_eq!(res.unwrap_err().unwrap(), Error::NotAuthorized);
+}
+
+#[test]
+fn test_schedule_next_maintenance_allows_manufacturer() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = setup_client(&env);
+
+    let manufacturer = Address::generate(&env);
+
+    let device_id = client.register_device(
+        &manufacturer,
+        &String::from_str(&env, "UDI-66666-DME"),
+        &Symbol::new(&env, "DME"),
+        &String::from_str(&env, "MedCorp"),
+        &String::from_str(&env, "MC-300"),
+        &String::from_str(&env, "LOT-003"),
+        &1690000000u64,
+        &None,
+        &dummy_hash(&env),
+        &DeviceExtras {
+            warranty_expiration_date: None,
+            maintenance_interval_days: Some(90u64),
+        },
+    );
+
+    let completed_date = 1710000000u64;
+    client.schedule_next_maintenance(&device_id, &completed_date, &manufacturer);
+
+    assert!(client.check_maintenance_due(&device_id, &(completed_date + 90 * 86400)));
+    assert!(!client.check_maintenance_due(&device_id, &(completed_date + 86400)));
+}
+
+#[test]
+fn test_schedule_next_maintenance_allows_technician_with_history() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let client = setup_client(&env);
+
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+    let technician = Address::generate(&env);
+    let manufacturer = Address::generate(&env);
+
+    let device_id = client.register_device(
+        &manufacturer,
+        &String::from_str(&env, "UDI-77777-IMP"),
+        &Symbol::new(&env, "IMPLANT"),
+        &String::from_str(&env, "MedCorp"),
+        &String::from_str(&env, "MC-400"),
+        &String::from_str(&env, "LOT-004"),
+        &1690000000u64,
+        &None,
+        &dummy_hash(&env),
+        &DeviceExtras {
+            warranty_expiration_date: None,
+            maintenance_interval_days: Some(90u64),
+        },
+    );
+
+    let implant_id = client.implant_device(
+        &patient_id,
+        &device_id,
+        &provider_id,
+        &1700000000u64,
+        &String::from_str(&env, "Left Hip"),
+        &dummy_hash(&env),
+    );
+
+    // Technician records maintenance for this device's implant first,
+    // establishing their authorization via the device's maintenance history.
+    client.record_device_maintenance(
+        &implant_id,
+        &1710000000u64,
+        &Symbol::new(&env, "CALIBRATION"),
+        &technician,
+        &dummy_hash(&env),
+    );
+
+    let completed_date = 1710000000u64;
+    client.schedule_next_maintenance(&device_id, &completed_date, &technician);
+
+    assert!(client.check_maintenance_due(&device_id, &(completed_date + 90 * 86400)));
+}


### PR DESCRIPTION
## Summary
`schedule_next_maintenance` took no `Address` parameter and called no `require_auth()`, so any unauthenticated caller could rewrite `next_scheduled_maintenance` for any tracked device -- including implants and durable medical equipment. An attacker could push the next-maintenance date far into the future, causing `check_maintenance_due` to falsely report "not due" and suppress overdue-maintenance alerts.

## Context / Before-After
**Before:** `schedule_next_maintenance(env, device_id, maintenance_completed_date)` -- no caller identity, no auth check, no role check. Anyone could call it for any `device_id`.

**After:** `schedule_next_maintenance(env, device_id, maintenance_completed_date, performed_by: Address)`. `performed_by.require_auth()` is enforced, and `performed_by` must be either:
- the device's registered `manufacturer_id` (mirrors the manufacturer-authority check already used in `issue_device_recall` via `assert_manufacturer_controls_devices`), or
- a technician who already appears in the device's maintenance history, i.e. has a prior `MaintenanceRecord.performed_by` entry from `record_device_maintenance` on one of the device's implants (reuses the existing technician-authentication pattern from `record_device_maintenance` rather than inventing a new role mechanism).

Any other caller gets `Error::NotAuthorized`. No other call sites of `schedule_next_maintenance` exist elsewhere in the repo.

## Testing
Added to `contracts/medical-device-tracking/src/test.rs`:
- `test_schedule_next_maintenance_requires_auth` -- calling without `mock_all_auths()`/a valid signature panics with `HostError: Error(Auth, InvalidAction)`.
- `test_schedule_next_maintenance_rejects_unauthorized_caller` -- a signed-in stranger with no manufacturer/technician relationship to the device gets `Error::NotAuthorized`.
- `test_schedule_next_maintenance_allows_manufacturer` -- the device's manufacturer can successfully reschedule.
- `test_schedule_next_maintenance_allows_technician_with_history` -- a technician who previously called `record_device_maintenance` for the device's implant can successfully reschedule.

`cargo test -p medical-device-tracking` passes: 31 passed; 0 failed.

Closes #727