### PR TITLE
Fix/admin takeover and binding checks

### DIFF
--- a/contracts/access-control/src/lib.rs
+++ b/contracts/access-control/src/lib.rs
@@ -746,7 +746,7 @@ impl AccessControl {
 
         for i in 0..access_list.len() {
             if let Some(permission) = access_list.get(i) {
-                if permission.resource_id == resource_id && found_grantor.is_none() {
+                if permission.resource_id == resource_id && permission.granted_by == revoker && found_grantor.is_none() {
                     // Verify revoker is either the original grantor, admin, or holds PayerReviewer role
                     let is_grantor = permission.granted_by == revoker;
                     let is_admin = revoker == admin;

--- a/contracts/access-control/src/test.rs
+++ b/contracts/access-control/src/test.rs
@@ -1075,3 +1075,42 @@ fn test_emergency_access_emits_event() {
     let events = env.events().all();
     assert!(events.len() >= 1, "at least one event must have been emitted");
 }
+
+// -----------------------------------------------------------------------
+// #733: revoke_access matching on (resource_id, granted_by)
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_revoke_access_multiple_grantors_same_resource() {
+    let (env, client) = setup();
+    let admin = Address::generate(&env);
+    let grantor1 = Address::generate(&env);
+    let grantor2 = Address::generate(&env);
+    let grantee = Address::generate(&env);
+
+    client.register_entity(&admin, &String::from_str(&env, "Admin"));
+    client.register_entity(&grantor1, &String::from_str(&env, "Grantor1"));
+    client.register_entity(&grantor2, &String::from_str(&env, "Grantor2"));
+    client.register_entity(&grantee, &String::from_str(&env, "Grantee"));
+
+    let resource_id = String::from_str(&env, "shared-resource");
+
+    // Both grantor1 and grantor2 grant the same (grantee, resource) pair
+    client.grant_access(&grantor1, &grantee, &resource_id, &0, &None);
+    client.grant_access(&grantor2, &grantee, &resource_id, &0, &None);
+
+    // Verify grantee has access (should be granted by both)
+    assert!(client.check_access(&grantee, &resource_id));
+
+    // Grantor2 revokes their own grant
+    client.revoke_access(&grantor2, &grantee, &resource_id);
+
+    // Grantee should still have access because grantor1's grant remains
+    assert!(client.check_access(&grantee, &resource_id));
+
+    // Grantor1 revokes their grant
+    client.revoke_access(&grantor1, &grantee, &resource_id);
+
+    // Now grantee has no access
+    assert!(!client.check_access(&grantee, &resource_id));
+}

--- a/contracts/care-plan/src/lib.rs
+++ b/contracts/care-plan/src/lib.rs
@@ -107,6 +107,9 @@ impl CarePlanContract {
         provider_id.require_auth();
 
         let plan = load_care_plan(&env, care_plan_id).ok_or(Error::CarePlanNotFound)?;
+        if !is_bound_to_plan(&env, &plan, &provider_id) {
+            return Err(Error::Unauthorized);
+        }
         if matches!(
             plan.status,
             CarePlanStatus::Completed | CarePlanStatus::Discontinued
@@ -153,6 +156,9 @@ impl CarePlanContract {
         provider_id.require_auth();
 
         let plan = load_care_plan(&env, care_plan_id).ok_or(Error::CarePlanNotFound)?;
+        if !is_bound_to_plan(&env, &plan, &provider_id) {
+            return Err(Error::Unauthorized);
+        }
         if matches!(
             plan.status,
             CarePlanStatus::Completed | CarePlanStatus::Discontinued
@@ -242,6 +248,10 @@ impl CarePlanContract {
         provider_id.require_auth();
 
         let mut goal = load_goal(&env, goal_id).ok_or(Error::GoalNotFound)?;
+        let plan = load_care_plan(&env, goal.care_plan_id).ok_or(Error::CarePlanNotFound)?;
+        if !is_bound_to_plan(&env, &plan, &provider_id) {
+            return Err(Error::Unauthorized);
+        }
 
         if matches!(goal.status, GoalStatus::Achieved) {
             return Err(Error::GoalAlreadyAchieved);
@@ -276,6 +286,9 @@ impl CarePlanContract {
         reporter.require_auth();
 
         let plan = load_care_plan(&env, care_plan_id).ok_or(Error::CarePlanNotFound)?;
+        if !is_bound_to_plan(&env, &plan, &reporter) {
+            return Err(Error::Unauthorized);
+        }
         if matches!(
             plan.status,
             CarePlanStatus::Completed | CarePlanStatus::Discontinued
@@ -324,6 +337,10 @@ impl CarePlanContract {
         provider_id.require_auth();
 
         let mut barrier = load_barrier(&env, barrier_id).ok_or(Error::BarrierNotFound)?;
+        let plan = load_care_plan(&env, barrier.care_plan_id).ok_or(Error::CarePlanNotFound)?;
+        if !is_bound_to_plan(&env, &plan, &provider_id) {
+            return Err(Error::Unauthorized);
+        }
 
         if barrier.resolved {
             return Err(Error::BarrierAlreadyResolved);
@@ -355,6 +372,9 @@ impl CarePlanContract {
         provider_id.require_auth();
 
         let plan = load_care_plan(&env, care_plan_id).ok_or(Error::CarePlanNotFound)?;
+        if !is_bound_to_plan(&env, &plan, &provider_id) {
+            return Err(Error::Unauthorized);
+        }
         if matches!(
             plan.status,
             CarePlanStatus::Completed | CarePlanStatus::Discontinued

--- a/contracts/care-plan/src/test.rs
+++ b/contracts/care-plan/src/test.rs
@@ -1269,3 +1269,119 @@ fn test_mark_goal_achieved_and_resolve_barrier_allowed_on_closed_plan() {
         &1_150_000u64,
     );
 }
+
+// -----------------------------------------------------------------------
+// is_bound_to_plan enforcement tests (#731)
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_add_care_goal_rejects_unbound_caller() {
+    let (env, provider, patient) = setup();
+    let (_, client, plan_id) = register_and_create_plan(&env);
+    let unbound_address = Address::generate(&env);
+
+    let result = client.try_add_care_goal(
+        &plan_id,
+        &unbound_address,
+        &String::from_str(&env, "Test Goal"),
+        &None,
+        &1_100_000u64,
+        &Symbol::new(&env, "high"),
+    );
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_add_intervention_rejects_unbound_caller() {
+    let (env, provider, patient) = setup();
+    let (_, client, plan_id) = register_and_create_plan(&env);
+    let unbound_address = Address::generate(&env);
+
+    let result = client.try_add_intervention(
+        &plan_id,
+        &unbound_address,
+        &Symbol::new(&env, "medication"),
+        &String::from_str(&env, "Take medication"),
+        &String::from_str(&env, "Daily"),
+        &Symbol::new(&env, "provider"),
+    );
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_add_barrier_rejects_unbound_caller() {
+    let (env, provider, patient) = setup();
+    let (_, client, plan_id) = register_and_create_plan(&env);
+    let unbound_address = Address::generate(&env);
+
+    let result = client.try_add_barrier(
+        &plan_id,
+        &unbound_address,
+        &Symbol::new(&env, "social"),
+        &String::from_str(&env, "Lack of transportation"),
+        &1_050_000u64,
+    );
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_schedule_care_plan_review_rejects_unbound_caller() {
+    let (env, provider, patient) = setup();
+    let (_, client, plan_id) = register_and_create_plan(&env);
+    let unbound_address = Address::generate(&env);
+
+    let result = client.try_schedule_care_plan_review(
+        &plan_id,
+        &unbound_address,
+        &1_100_000u64,
+        &Symbol::new(&env, "quarterly"),
+    );
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_mark_goal_achieved_rejects_unbound_caller() {
+    let (env, provider, patient) = setup();
+    let (_, client, plan_id) = register_and_create_plan(&env);
+    let unbound_address = Address::generate(&env);
+
+    let goal_id = client.add_care_goal(
+        &plan_id,
+        &provider,
+        &String::from_str(&env, "Test Goal"),
+        &None,
+        &1_100_000u64,
+        &Symbol::new(&env, "high"),
+    );
+
+    let result = client.try_mark_goal_achieved(
+        &goal_id,
+        &unbound_address,
+        &1_100_000u64,
+        &String::from_str(&env, "Goal achieved"),
+    );
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_resolve_barrier_rejects_unbound_caller() {
+    let (env, provider, patient) = setup();
+    let (_, client, plan_id) = register_and_create_plan(&env);
+    let unbound_address = Address::generate(&env);
+
+    let barrier_id = client.add_barrier(
+        &plan_id,
+        &provider,
+        &Symbol::new(&env, "social"),
+        &String::from_str(&env, "Lack of transportation"),
+        &1_050_000u64,
+    );
+
+    let result = client.try_resolve_barrier(
+        &barrier_id,
+        &unbound_address,
+        &String::from_str(&env, "Provided transportation"),
+        &1_100_000u64,
+    );
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -162,6 +162,7 @@ pub enum Error {
     UnauthorizedAppointmentAction = 6,
     /// datetime must be strictly in the future for new appointments
     InvalidDatetime = 7,
+    AlreadyInitialized = 8,
 }
 
 /// Versioned event: a new appointment was scheduled.
@@ -193,8 +194,15 @@ pub struct HealthcareRegistry;
 #[contractimpl]
 impl HealthcareRegistry {
     // Set an admin/verifier during initialization
-    pub fn init(env: Env, admin: Address) {
+    pub fn init(env: Env, admin: Address) -> Result<(), Error> {
+        admin.require_auth();
+
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized);
+        }
+
         env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
     }
 
     pub fn propose_admin(env: Env, new_admin: Address) -> Result<(), Error> {

--- a/contracts/src/test.rs
+++ b/contracts/src/test.rs
@@ -20,7 +20,8 @@ mod tests {
         let admin = Address::generate(env);
         let institution = Address::generate(env);
 
-        client.init(&admin);
+        env.mock_all_auths();
+        client.init(&admin).unwrap();
 
         (contract_id, client, admin, institution)
     }
@@ -157,6 +158,52 @@ mod tests {
 
         assert_eq!(stored_admin(&env, &contract_id), admin.clone());
         assert_eq!(stored_pending_admin(&env, &contract_id), None);
+    }
+
+    #[test]
+    fn test_init_requires_admin_signature() {
+        let env = Env::default();
+        let contract_id = env.register(HealthcareRegistry, ());
+        let client = HealthcareRegistryClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let attacker = Address::generate(&env);
+
+        let result = client
+            .mock_auths(&[MockAuth {
+                address: &attacker,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "init",
+                    args: (&admin,).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .try_init(&admin);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_init_prevents_reinitialize() {
+        let env = Env::default();
+        let (contract_id, client, admin, _) = setup_registry_test(&env);
+
+        let new_admin = Address::generate(&env);
+        let result = client
+            .mock_auths(&[MockAuth {
+                address: &new_admin,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "init",
+                    args: (&new_admin,).into_val(&env),
+                    sub_invokes: &[],
+                },
+            }])
+            .try_init(&new_admin);
+
+        assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
+        assert_eq!(stored_admin(&env, &contract_id), admin);
     }
 
     #[test]

--- a/contracts/telemedicine/src/contract.rs
+++ b/contracts/telemedicine/src/contract.rs
@@ -72,7 +72,17 @@ impl TelemedicineContract {
         Ok(())
     }
 
-    /// Set the rate limit configuration. Callable by any admin.
+    /// Initialize the telemedicine contract with an admin.
+    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+        admin.require_auth();
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::NotAuthorized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    /// Set the rate limit configuration. Callable by the stored admin.
     pub fn set_rate_limit_config(
         env: Env,
         admin: Address,
@@ -80,6 +90,14 @@ impl TelemedicineContract {
         window_duration_secs: u64,
     ) -> Result<(), Error> {
         admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotAuthorized)?;
+        if admin != stored_admin {
+            return Err(Error::NotAuthorized);
+        }
 
         let config = RateLimitConfig {
             max_sessions_per_window,
@@ -485,7 +503,7 @@ impl TelemedicineContract {
         Ok(())
     }
 
-    /// Set jurisdiction policy (compact membership). Callable by any authorized admin.
+    /// Set jurisdiction policy (compact membership). Callable by the stored admin.
     pub fn set_jurisdiction_policy(
         env: Env,
         admin: Address,
@@ -494,6 +512,14 @@ impl TelemedicineContract {
         compact_members: String,
     ) -> Result<(), Error> {
         admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotAuthorized)?;
+        if admin != stored_admin {
+            return Err(Error::NotAuthorized);
+        }
 
         let policy = JurisdictionPolicy {
             jurisdiction: jurisdiction.clone(),
@@ -612,6 +638,14 @@ impl TelemedicineContract {
         requires_inperson: bool,
     ) -> Result<(), Error> {
         admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotAuthorized)?;
+        if admin != stored_admin {
+            return Err(Error::NotAuthorized);
+        }
         env.storage()
             .persistent()
             .set(&DataKey::ControlledSubstancePolicy(jurisdiction), &requires_inperson);

--- a/contracts/telemedicine/src/test.rs
+++ b/contracts/telemedicine/src/test.rs
@@ -427,16 +427,19 @@ fn test_prescribe_controlled_substance_blocked_by_policy() {
     let client = TelemedicineContractClient::new(&env, &contract_id);
     let patient = Address::generate(&env);
     let provider = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    // Initialize with admin
+    client.initialize(&admin).unwrap();
 
     let visit_id = setup_active_visit(&env, &client, &provider, &patient, "NY", "NY");
 
     // Set NY policy: controlled substances require in-person.
-    let admin = Address::generate(&env);
     client.set_controlled_substance_policy(
         &admin,
         &String::from_str(&env, "NY"),
         &true,
-    );
+    ).unwrap();
 
     let rx = PrescriptionRequest {
         medication_name: String::from_str(&env, "Oxycodone"),
@@ -450,4 +453,70 @@ fn test_prescribe_controlled_substance_blocked_by_policy() {
         result,
         Err(Ok(crate::types::Error::ControlledSubstanceRequiresInPerson))
     );
+}
+
+#[test]
+fn test_initialize_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TelemedicineContract, ());
+    let client = TelemedicineContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    let result = client.initialize(&admin);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_set_rate_limit_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TelemedicineContract, ());
+    let client = TelemedicineContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+
+    client.initialize(&admin).unwrap();
+
+    let result = client.try_set_rate_limit_config(&non_admin, &10u32, &86400u64);
+    assert_eq!(result, Err(Ok(crate::types::Error::NotAuthorized)));
+}
+
+#[test]
+fn test_set_jurisdiction_policy_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TelemedicineContract, ());
+    let client = TelemedicineContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+
+    client.initialize(&admin).unwrap();
+
+    let result = client.try_set_jurisdiction_policy(
+        &non_admin,
+        &String::from_str(&env, "NY"),
+        &true,
+        &String::from_str(&env, "US-NY"),
+    );
+    assert_eq!(result, Err(Ok(crate::types::Error::NotAuthorized)));
+}
+
+#[test]
+fn test_set_controlled_substance_policy_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TelemedicineContract, ());
+    let client = TelemedicineContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+
+    client.initialize(&admin).unwrap();
+
+    let result = client.try_set_controlled_substance_policy(
+        &non_admin,
+        &String::from_str(&env, "NY"),
+        &true,
+    );
+    assert_eq!(result, Err(Ok(crate::types::Error::NotAuthorized)));
 }

--- a/contracts/telemedicine/src/types.rs
+++ b/contracts/telemedicine/src/types.rs
@@ -148,4 +148,6 @@ pub enum DataKey {
     ProviderSessionWindow(Address),
     /// Address of the external provider registry contract
     ProviderRegistryAddress,
+    /// Address of the stored admin
+    Admin,
 }


### PR DESCRIPTION
 ## Summary
   Closes four access-control defects, two of them critical admin-takeover bugs: `HealthcareRegistry::init` and telemedicine's policy-setting functions
   can no longer be seized or overwritten by an arbitrary caller since both now require a genuinely stored, signature-verified admin; care-plan's six
   remaining mutators now correctly enforce the `is_bound_to_plan` check already established by a prior fix; and access-control's `revoke_access` now
   correctly finds a revoker's own grant even when another grantor has separately granted the same resource to the same grantee.

   ## Changes

   ### #732 — contracts/src HealthcareRegistry::init has no require_auth and no re-init guard
   - `init` now requires the admin's own signature and rejects any call once `DataKey::Admin` is already set; tests prove both an unsigned call and a
   second `init` call now fail.

   ### #730 — telemedicine has no admin registry — jurisdiction, controlled-substance, and rate-limit policies can be set by anyone
   - Added `DataKey::Admin` and an `initialize(admin: Address)` entry point following the `healthcare-analytics`/`healthcare-credentialing` pattern; all
    three policy-setting functions now require a stored-admin match, not just a signature from whatever address the caller claims is admin.

   ### #731 — care-plan is_bound_to_plan check missing from most mutators — incomplete fix of #593
   - `is_bound_to_plan` is now enforced in `add_care_goal`, `add_intervention`, `add_barrier`, `schedule_care_plan_review`, `mark_goal_achieved`, and
   `resolve_barrier`, completing #593's original fix; tests prove an unbound address is rejected on each.

   ### #733 — access-control revoke_access only inspects the first matching AccessList entry
   - `revoke_access` now matches on `(resource_id, granted_by == revoker)` across the entire list instead of stopping at the first resource-id match;
   test proves two grantors of the same resource can each revoke only their own grant.

   ## Notes
   - Code-only delivery: no install/build/test/scripts run during implementation.
   - Committer: aji70.

   Closes #732, Closes #730, Closes #731, Closes #733