### PR TITLE
fix(scholarship-fund): restore recipient eligibility and award-cap enforcement (#719)

### DIFF
--- a/contracts/scholarship-fund/src/lib.rs
+++ b/contracts/scholarship-fund/src/lib.rs
@@ -27,9 +27,9 @@ use soroban_sdk::{contract,contracterror,contractimpl,contracttype,symbol_short,
 #[contracterror]
 #[derive(Copy,Clone,Debug,Eq,PartialEq)]
 #[repr(u32)]
-pub enum Error{NotInitialized=1,AlreadyInitialized=2,Unauthorized=3,ZeroAmount=4,InsufficientFunds=5,FundsCommitted=6}
+pub enum Error{NotInitialized=1,AlreadyInitialized=2,Unauthorized=3,ZeroAmount=4,InsufficientFunds=5,FundsCommitted=6,RecipientNotEligible=7,RecipientCapExceeded=8}
 #[contracttype]
-pub enum DataKey{Admin,PoolBalance,CommittedFunds,Deposit(Address)}
+pub enum DataKey{Admin,PoolBalance,CommittedFunds,Deposit(Address),Eligible(Address),RecipientAwards(Address),RecipientCap(Address)}
 #[contracttype]
 #[derive(Clone,Debug,Eq,PartialEq)]
 pub struct FundStats{pub pool_balance:i128,pub committed_balance:i128}
@@ -99,7 +99,27 @@ impl ScholarshipFundContract{
             let released=if amount<committed{amount}else{committed};
             env.storage().instance().set(&DataKey::CommittedFunds,&(committed-released));
         }
+        env.storage().persistent().set(&DataKey::RecipientAwards(recipient.clone()),&(prior_awards+amount));
         env.events().publish((symbol_short!("DISBURSE"),recipient),(amount,reason));
+        Ok(())
+    }
+    /// Admin-only: mark a recipient eligible/ineligible to receive disbursements.
+    pub fn set_recipient_eligibility(env:Env,admin:Address,recipient:Address,eligible:bool)->Result<(),Error>{
+        admin.require_auth();
+        let stored:Address=env.storage().instance().get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
+        if admin!=stored{return Err(Error::Unauthorized);}
+        env.storage().persistent().set(&DataKey::Eligible(recipient.clone()),&eligible);
+        env.events().publish((symbol_short!("ELIGIBLE"),recipient),eligible);
+        Ok(())
+    }
+    /// Admin-only: set the maximum cumulative amount a recipient may receive across all disbursements.
+    /// A cap of `0` means no cap is enforced.
+    pub fn set_recipient_cap(env:Env,admin:Address,recipient:Address,cap:i128)->Result<(),Error>{
+        admin.require_auth();
+        let stored:Address=env.storage().instance().get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
+        if admin!=stored{return Err(Error::Unauthorized);}
+        if cap<0{return Err(Error::ZeroAmount);}
+        env.storage().persistent().set(&DataKey::RecipientCap(recipient),&cap);
         Ok(())
     }
     pub fn get_stats(env:Env)->FundStats{FundStats{pool_balance:env.storage().instance().get(&DataKey::PoolBalance).unwrap_or(0),committed_balance:env.storage().instance().get(&DataKey::CommittedFunds).unwrap_or(0)}}

--- a/contracts/scholarship-fund/src/test.rs
+++ b/contracts/scholarship-fund/src/test.rs
@@ -28,6 +28,7 @@ fn committed_funds_survive_a_pending_award() {
     assert_eq!(result, Err(Ok(Error::FundsCommitted)));
 
     // The planned disbursement still succeeds because the funds were protected.
+    c.set_recipient_eligibility(&admin, &student, &true);
     c.disburse(&admin, &student, &1_000_000, &String::from_str(&env, "award"));
     assert_eq!(c.get_stats().pool_balance, 0);
     assert_eq!(c.get_stats().committed_balance, 0);
@@ -43,4 +44,42 @@ fn uncommitted_funds_remain_withdrawable() {
     // Only the committed portion is protected; the rest can still be withdrawn.
     c.withdraw(&donor, &600_000);
     assert_eq!(c.get_stats().pool_balance, 400_000);
+}
+#[test]
+fn disburse_to_ineligible_recipient_is_rejected() {
+    let (env, c, admin) = setup();
+    let donor = Address::generate(&env);
+    let student = Address::generate(&env);
+    c.deposit(&donor, &1_000_000);
+    let result = c.try_disburse(&admin, &student, &500_000, &String::from_str(&env, "award"));
+    assert_eq!(result, Err(Ok(Error::RecipientNotEligible)));
+    assert_eq!(c.get_stats().pool_balance, 1_000_000);
+}
+#[test]
+fn recipient_cap_limits_cumulative_awards() {
+    let (env, c, admin) = setup();
+    let donor = Address::generate(&env);
+    let student = Address::generate(&env);
+    c.deposit(&donor, &3_000_000);
+    c.set_recipient_eligibility(&admin, &student, &true);
+    c.set_recipient_cap(&admin, &student, &1_500_000);
+
+    c.disburse(&admin, &student, &1_000_000, &String::from_str(&env, "award-1"));
+    assert_eq!(c.get_recipient_awards(&student), 1_000_000);
+
+    // Second award would push cumulative total past the cap.
+    let result = c.try_disburse(&admin, &student, &1_000_000, &String::from_str(&env, "award-2"));
+    assert_eq!(result, Err(Ok(Error::RecipientCapExceeded)));
+
+    // A smaller award that stays within the cap still succeeds.
+    c.disburse(&admin, &student, &500_000, &String::from_str(&env, "award-2"));
+    assert_eq!(c.get_recipient_awards(&student), 1_500_000);
+}
+#[test]
+#[should_panic]
+fn non_admin_set_eligibility_panics() {
+    let (env, c, _admin) = setup();
+    let attacker = Address::generate(&env);
+    let student = Address::generate(&env);
+    c.set_recipient_eligibility(&attacker, &student, &true);
 }


### PR DESCRIPTION
## Summary

closes #718 
closes #719 
closes #720 
closes #721 


`disburse()` referenced `DataKey::Eligible`, `DataKey::RecipientAwards`,
`DataKey::RecipientCap`, `Error::RecipientNotEligible` and
`Error::RecipientCapExceeded`, and `test.rs` called `set_recipient_eligibility()`
— none of which existed. These pieces were originally added for #645 but were
lost when commit `207008d` re-introduced an older revision of the crate while
keeping the new `disburse()` body. The broken crate also broke
`cargo check/test/clippy --workspace`.

Changes (`contracts/scholarship-fund/src/lib.rs`):
- Add `DataKey::Eligible(Address)`, `DataKey::RecipientAwards(Address)`,
  `DataKey::RecipientCap(Address)`.
- Add `Error::RecipientNotEligible = 7`, `Error::RecipientCapExceeded = 8`
  (6 is already taken by `FundsCommitted`).
- Implement admin-gated `set_recipient_eligibility` and `set_recipient_cap`.
- Persist `RecipientAwards` in `disburse()` so `get_recipient_awards` and the
  per-recipient cap check accumulate across disbursements.

Tests (`contracts/scholarship-fund/src/test.rs`):
- Add the missing `set_recipient_eligibility` setup to
  `committed_funds_survive_a_pending_award`.
- `disburse_to_ineligible_recipient_is_rejected`
- `recipient_cap_limits_cumulative_awards`
- `non_admin_set_eligibility_panics`
