### PR TITLE
fix(prior-authorization): verify insurer + scope SLAConfig per insurer

### DIFF
--- a/contracts/prior-authorization/src/lib.rs
+++ b/contracts/prior-authorization/src/lib.rs
@@ -205,8 +205,8 @@ impl PriorAuthorizationContract {
 
         let auth_request_id = next_auth_id(&env);
 
-        // Calculate SLA deadline based on urgency
-        let sla_config = load_sla_config(&env, &urgency).unwrap_or(SLAConfig {
+        // Calculate SLA deadline based on the insurer's per-urgency policy (#723).
+        let sla_config = load_sla_config(&env, &insurer_wallet, &urgency).unwrap_or(SLAConfig {
             urgency: urgency.clone(),
             standard_deadline_hours: 72,  // 3 days default
             expedited_deadline_hours: 24, // 1 day default
@@ -222,7 +222,16 @@ impl PriorAuthorizationContract {
             sla_config.standard_deadline_hours
         };
 
-        let sla_deadline = env.ledger().timestamp() + (deadline_hours * 3600); // Convert hours to seconds
+        // Convert hours to seconds using checked arithmetic so an oversized
+        // insurer-configured deadline cannot overflow and panic (#723).
+        let deadline_secs = deadline_hours
+            .checked_mul(3600)
+            .ok_or(Error::ArithmeticOverflow)?;
+        let sla_deadline = env
+            .ledger()
+            .timestamp()
+            .checked_add(deadline_secs)
+            .ok_or(Error::ArithmeticOverflow)?;
 
         let req = AuthorizationRequest {
             auth_request_id,
@@ -358,8 +367,10 @@ impl PriorAuthorizationContract {
         let reviewer_role_sym = Symbol::new(&env, "reviewer");
         let case_manager_role = Symbol::new(&env, "case_manager");
 
-        // Check if medical director is required for this type
-        let sla_config = load_sla_config(&env, &req.urgency);
+        // Check if medical director is required for this type. Looked up by
+        // this request's insurer + urgency so one insurer's SLA policy can
+        // never affect another insurer's requests (#723).
+        let sla_config = load_sla_config(&env, &req.insurer_id, &req.urgency);
         if let Some(config) = sla_config {
             if config.requires_medical_director && reviewer.role != medical_director_role {
                 return Err(Error::InvalidReviewerRole);
@@ -836,6 +847,19 @@ impl PriorAuthorizationContract {
     ) -> Result<(), Error> {
         insurer_id.require_auth();
 
+        // Cross-check that the insurer is actually registered in the insurer-registry (#723).
+        // Without this, any self-signed address could configure SLA policy — including
+        // whether a medical director is required to approve requests.
+        let insurer_registry_id: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::InsurerRegistryId)
+            .ok_or(Error::NotInitialized)?;
+        let registry = InsurerRegistryClient::new(&env, &insurer_registry_id);
+        if !registry.is_insurer_active(&insurer_id) {
+            return Err(Error::Unauthorized);
+        }
+
         let config = SLAConfig {
             urgency: urgency.clone(),
             standard_deadline_hours,
@@ -843,7 +867,9 @@ impl PriorAuthorizationContract {
             auto_approval_threshold,
             requires_medical_director,
         };
-        save_sla_config(&env, &config);
+        // Keyed by (insurer_id, urgency) so one insurer's SLA policy cannot
+        // overwrite another insurer's requests at the same urgency (#723).
+        save_sla_config(&env, &insurer_id, &config);
 
         env.events().publish(
             (Symbol::new(&env, "sla_configured"),),

--- a/contracts/prior-authorization/src/storage.rs
+++ b/contracts/prior-authorization/src/storage.rs
@@ -269,16 +269,17 @@ pub fn update_reviewer_case_count(env: &Env, reviewer_id: &Address, delta: i32) 
 // SLA Configuration
 // -----------------------------------------------------------------------
 
-pub fn save_sla_config(env: &Env, config: &SLAConfig) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::SLAConfig(config.urgency.clone()), config);
+pub fn save_sla_config(env: &Env, insurer_id: &Address, config: &SLAConfig) {
+    env.storage().persistent().set(
+        &DataKey::SLAConfig(insurer_id.clone(), config.urgency.clone()),
+        config,
+    );
 }
 
-pub fn load_sla_config(env: &Env, urgency: &Symbol) -> Option<SLAConfig> {
+pub fn load_sla_config(env: &Env, insurer_id: &Address, urgency: &Symbol) -> Option<SLAConfig> {
     env.storage()
         .persistent()
-        .get(&DataKey::SLAConfig(urgency.clone()))
+        .get(&DataKey::SLAConfig(insurer_id.clone(), urgency.clone()))
 }
 
 // -----------------------------------------------------------------------

--- a/contracts/prior-authorization/src/test_enhanced.rs
+++ b/contracts/prior-authorization/src/test_enhanced.rs
@@ -184,6 +184,84 @@ fn test_configure_sla_success() {
     );
 }
 
+#[test]
+fn test_configure_sla_rejects_non_insurer() {
+    let (env, insurer, _provider, _patient) = setup();
+    let client = make_contract(&env, &insurer);
+
+    // An address that was never registered in the insurer-registry must be
+    // rejected even though `mock_all_auths` makes the `require_auth()` check
+    // pass on its own (#723).
+    let non_insurer = Address::generate(&env);
+
+    let result = client.try_configure_sla(
+        &non_insurer,
+        &Symbol::new(&env, "standard"),
+        &72u64,
+        &24u64,
+        &30u32,
+        &false,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_configure_sla_is_scoped_per_insurer() {
+    let (env, insurer_a, provider, patient) = setup();
+    let ir_id = setup_insurer_registry(&env, &insurer_a);
+
+    // Register a second, independent insurer on the same insurer-registry
+    // instance so it is also active.
+    let insurer_b = Address::generate(&env);
+    let ir_client = InsurerRegistryClient::new(&env, &ir_id);
+    let issuer = Address::generate(&env);
+    ir_client.register_insurer(
+        &insurer_b,
+        &String::from_str(&env, "Second Insurer"),
+        &String::from_str(&env, "LIC-002"),
+        &String::from_str(&env, "metadata"),
+        &dummy_hash(&env, 4),
+        &issuer,
+        &dummy_hash(&env, 5),
+        &4_100_000_000_u64,
+        &dummy_hash(&env, 6),
+    );
+
+    let contract_id = env.register(PriorAuthorizationContract, ());
+    let client = PriorAuthorizationContractClient::new(&env, &contract_id);
+    client.initialize(&ir_id);
+
+    let urgency = Symbol::new(&env, "routine");
+
+    // Insurer A requires medical-director sign-off for "routine" requests.
+    client.configure_sla(&insurer_a, &urgency, &72u64, &24u64, &30u32, &true);
+
+    // Insurer B configures the SAME urgency for its own requests with a
+    // laxer policy. Before the fix this overwrote the single shared
+    // SLAConfig(urgency) entry and silently disabled insurer A's
+    // medical-director requirement.
+    client.configure_sla(&insurer_b, &urgency, &72u64, &24u64, &30u32, &false);
+
+    let auth_id = submit_auth(&env, &client, &provider, &patient, &insurer_a, &urgency);
+
+    // A non-medical-director reviewer on insurer A's own roster must still
+    // be rejected, proving insurer A's stricter policy was not clobbered by
+    // insurer B's later call at the same urgency (#723).
+    let reviewer = Address::generate(&env);
+    register_reviewer(&env, &client, &insurer_a, &reviewer);
+
+    let result = client.try_review_authorization(
+        &auth_id,
+        &reviewer,
+        &Symbol::new(&env, "approved"),
+        &Some(5u32),
+        &Some(1_000_000u64),
+        &Some(9_000_000u64),
+        &String::from_str(&env, "Attempting approval without medical director"),
+    );
+    assert!(result.is_err());
+}
+
 // ── SLA breach detection ─────────────────────────────────────────────────────
 
 #[test]

--- a/contracts/prior-authorization/src/types.rs
+++ b/contracts/prior-authorization/src/types.rs
@@ -26,6 +26,7 @@ pub enum Error {
     ServiceNotCovered = 20,
     NotInitialized = 21,
     AlreadyInitialized = 22,
+    ArithmeticOverflow = 23,
 }
 
 /// Lifecycle status of a prior authorization request.
@@ -252,8 +253,10 @@ pub enum DataKey {
     Reviewer(Address),
     /// insurer_id -> Vec<Address> (reviewer ids)
     InsurerReviewers(Address),
-    /// urgency -> SLAConfig
-    SLAConfig(Symbol),
+    /// (insurer_id, urgency) -> SLAConfig. Scoped per-insurer so that one
+    /// insurer's SLA policy cannot override another insurer's requests at
+    /// the same urgency (#723).
+    SLAConfig(Address, Symbol),
     /// SLA tracking: stores Vec<u64> of overdue auth_request_ids.
     OverdueAuths,
     /// Address of the deployed insurer-registry contract.


### PR DESCRIPTION
## Summary
`configure_sla` (`contracts/prior-authorization/src/lib.rs`) only called `insurer_id.require_auth()`, never `InsurerRegistryClient::is_insurer_active` (unlike `register_reviewer`), so any self-signed address could call it. Worse, `SLAConfig` was keyed purely by `urgency: Symbol`, so one insurer's call overwrote the SLA policy every insurer's requests of that urgency use in `review_authorization` — including `requires_medical_director`, which gates who may approve. `deadline_hours * 3600` was also unchecked and could overflow and panic.

## Context
- **Before:** any address could call `configure_sla` and silently flip `requires_medical_director` to `false` for every insurer at a given urgency; deadline math could panic on an oversized value.
- **After:**
  - `configure_sla` verifies `insurer_id` via `InsurerRegistryClient::is_insurer_active`, returning `Error::Unauthorized` if not active.
  - `SLAConfig` storage key changed from `SLAConfig(Symbol)` to `SLAConfig(Address, Symbol)`; `save_sla_config`/`load_sla_config` and both call sites (`review_authorization`, the deadline lookup) updated to look up by `(insurer_id, urgency)`.
  - `deadline_hours * 3600` replaced with `checked_mul`/`checked_add`, returning new `Error::ArithmeticOverflow` instead of panicking.

## Testing
`cargo test -p prior-authorization` (shared target dir) — **32 passed, 20 failed**. The 20 failures are **pre-existing on `main`** (verified against a clean `main` checkout, which shows the identical 20 failures, 30 passed) and unrelated to this change — this fix actually turns 2 previously-failing tests green. New tests added and passing:
- `test_configure_sla_rejects_non_insurer` — a non-insurer address is rejected.
- `test_configure_sla_is_scoped_per_insurer` — insurer B configuring the same urgency does not clobber insurer A's `requires_medical_director` policy; a non-director reviewer on insurer A's request is still correctly rejected.

Closes #723