### PR TITLE
fix: address validation, reporter auth, patient consent, and revoked badge re-mint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,6 +999,7 @@ dependencies = [
 name = "immunization-registry"
 version = "0.0.0"
 dependencies = [
+ "provider-registry",
  "soroban-sdk",
 ]
 
@@ -1173,6 +1174,13 @@ dependencies = [
 
 [[package]]
 name = "multisig-governance"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
+name = "nft-badges"
 version = "0.0.0"
 dependencies = [
  "soroban-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ members = [
   "contracts/scholarship-fund",
   "contracts/liquidity-pool",
   "contracts/ttl-config",
+  "contracts/nft-badges",
 ]
 exclude = ["contracts/patient-registry/benches"]
 

--- a/contracts/immunization-registry/Cargo.toml
+++ b/contracts/immunization-registry/Cargo.toml
@@ -14,3 +14,4 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+provider-registry = { path = "../provider-registry" }

--- a/contracts/immunization-registry/src/lib.rs
+++ b/contracts/immunization-registry/src/lib.rs
@@ -28,7 +28,7 @@
 mod test;
 mod types;
 
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, IntoVal, String, Symbol, Vec};
 use types::{AdverseEvent, DataKey, Error, VaccineRecord, VaccineSeries};
 
 #[contract]
@@ -36,19 +36,36 @@ pub struct ImmunizationRegistry;
 
 #[contractimpl]
 impl ImmunizationRegistry {
-    /// Configure the regulator/public-health authority address allowed to run recall queries.
-    pub fn initialize(env: Env, regulator: Address) -> Result<(), Error> {
+    /// Configure the regulator/public-health authority and provider-registry contract address.
+    pub fn initialize(env: Env, regulator: Address, provider_registry: Address) -> Result<(), Error> {
         if env.storage().instance().has(&DataKey::Regulator) {
             return Err(Error::AlreadyInitialized);
         }
 
         regulator.require_auth();
         env.storage().instance().set(&DataKey::Regulator, &regulator);
+        env.storage().instance().set(&DataKey::ProviderRegistry, &provider_registry);
         Ok(())
     }
 
     pub fn record_immunization(env: Env, record: VaccineRecord) -> Result<u64, Error> {
         record.provider_id.require_auth();
+        record.patient_id.require_auth();
+
+        // Verify caller is a registered provider.
+        let provider_registry: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProviderRegistry)
+            .ok_or(Error::NotInitialized)?;
+        let is_registered: bool = env.invoke_contract(
+            &provider_registry,
+            &Symbol::new(&env, "is_provider"),
+            soroban_sdk::vec![&env, record.provider_id.clone().into_val(&env)],
+        );
+        if !is_registered {
+            return Err(Error::NotAuthorized);
+        }
 
         // Validate dose_number is not zero
         if record.dose_number == 0 {
@@ -155,12 +172,18 @@ impl ImmunizationRegistry {
     ) -> Result<(), Error> {
         reporter.require_auth();
 
-        if !env
+        let record: VaccineRecord = env
             .storage()
             .persistent()
-            .has(&DataKey::ImmunizationRecord(immunization_id))
-        {
-            return Err(Error::RecordNotFound);
+            .get(&DataKey::ImmunizationRecord(immunization_id))
+            .ok_or(Error::RecordNotFound)?;
+
+        let regulator: Option<Address> = env.storage().instance().get(&DataKey::Regulator);
+        let authorized = reporter == record.provider_id
+            || reporter == record.patient_id
+            || regulator.map(|r| reporter == r).unwrap_or(false);
+        if !authorized {
+            return Err(Error::NotAuthorized);
         }
 
         let event = AdverseEvent {

--- a/contracts/immunization-registry/src/test.rs
+++ b/contracts/immunization-registry/src/test.rs
@@ -2,56 +2,61 @@
 #![allow(deprecated)]
 
 use super::*;
-use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Symbol};
+use provider_registry::{ProviderRegistry, ProviderRegistryClient};
+use soroban_sdk::{testutils::{Address as _, Ledger as _}, Address, BytesN, Env, String, Symbol};
 
-#[test]
-fn test_record_immunization() {
+fn setup() -> (
+    Env,
+    ImmunizationRegistryClient<'static>,
+    ProviderRegistryClient<'static>,
+    Address, // admin (provider-registry admin)
+    Address, // regulator
+) {
     let env = Env::default();
     env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_700_000_000);
+
+    let admin = Address::generate(&env);
+    let registry_id = env.register(ProviderRegistry, ());
+    let registry = ProviderRegistryClient::new(&env, &registry_id);
+    registry.initialize(&admin);
 
     let contract_id = env.register(ImmunizationRegistry, ());
     let client = ImmunizationRegistryClient::new(&env, &contract_id);
+    let regulator = Address::generate(&env);
+    client.initialize(&regulator, &registry_id);
 
-    let patient_id = Address::generate(&env);
-    let provider_id = Address::generate(&env);
+    (env, client, registry, admin, regulator)
+}
 
-    let id = client.record_immunization(&VaccineRecord {
-        patient_id: patient_id.clone(),
-        provider_id: provider_id.clone(),
-        vaccine_name: String::from_str(&env, "Hepatitis B"),
-        cvx_code: String::from_str(&env, "CVX_43"),
-        lot_number: String::from_str(&env, "LOT_12345"),
-        manufacturer: String::from_str(&env, "SANOFI"),
-        administration_date: 1690000000,
-        expiration_date: 1790000000,
-        dose_number: 1,
-        route: Symbol::new(&env, "IM"), // Intramuscular
-        site: Symbol::new(&env, "DELTOID"),
-    });
-
-    assert_eq!(id, 1);
-
-    let _requester = Address::generate(&env);
-    let history = client.get_immunization_history(&patient_id, &patient_id);
-
-    assert_eq!(history.len(), 1);
-    let record = history.get(0).unwrap();
-    assert_eq!(record.patient_id, patient_id);
-    assert_eq!(record.provider_id, provider_id);
-    assert_eq!(record.vaccine_name, String::from_str(&env, "Hepatitis B"));
-    assert_eq!(record.cvx_code, String::from_str(&env, "CVX_43"));
+fn register_provider(
+    env: &Env,
+    registry: &ProviderRegistryClient<'static>,
+    admin: &Address,
+    provider: &Address,
+) {
+    let issuer = Address::generate(env);
+    registry.register_provider(
+        admin,
+        provider,
+        &String::from_str(env, "Dr. Provider"),
+        &String::from_str(env, "General"),
+        &String::from_str(env, "LIC-001"),
+        &BytesN::from_array(env, &[1u8; 32]),
+        &issuer,
+        &BytesN::from_array(env, &[2u8; 32]),
+        &u64::MAX,
+        &BytesN::from_array(env, &[3u8; 32]),
+    );
 }
 
 #[test]
-fn test_record_adverse_event() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let contract_id = env.register(ImmunizationRegistry, ());
-    let client = ImmunizationRegistryClient::new(&env, &contract_id);
+fn test_record_immunization() {
+    let (env, client, registry, admin, _regulator) = setup();
 
     let patient_id = Address::generate(&env);
     let provider_id = Address::generate(&env);
+    register_provider(&env, &registry, &admin, &provider_id);
 
     let id = client.record_immunization(&VaccineRecord {
         patient_id: patient_id.clone(),
@@ -67,38 +72,118 @@ fn test_record_adverse_event() {
         site: Symbol::new(&env, "DELTOID"),
     });
 
-    let reporter = Address::generate(&env);
-    client.record_adverse_event(
-        &id,
-        &reporter,
-        &String::from_str(&env, "Slight fever and arm soreness"),
-        &Symbol::new(&env, "MILD"),
-        &1690086400,
-    );
+    assert_eq!(id, 1);
 
-    // To verify, we'd theoretically need a getter for adverse events, but that's not
-    // on the requested interface. However, the function succeeding means it's recorded.
-    // Let's test non-existent ID.
-    let res = client.try_record_adverse_event(
-        &999,
-        &reporter,
-        &String::from_str(&env, "NA"),
-        &Symbol::new(&env, "NONE"),
-        &1690086400,
-    );
+    let history = client.get_immunization_history(&patient_id, &patient_id);
+    assert_eq!(history.len(), 1);
+    let record = history.get(0).unwrap();
+    assert_eq!(record.patient_id, patient_id);
+    assert_eq!(record.provider_id, provider_id);
+    assert_eq!(record.vaccine_name, String::from_str(&env, "Hepatitis B"));
+    assert_eq!(record.cvx_code, String::from_str(&env, "CVX_43"));
+}
+
+#[test]
+fn test_record_immunization_rejects_unregistered_provider() {
+    let (env, client, _registry, _admin, _regulator) = setup();
+
+    let patient_id = Address::generate(&env);
+    let unregistered = Address::generate(&env);
+
+    let res = client.try_record_immunization(&VaccineRecord {
+        patient_id: patient_id.clone(),
+        provider_id: unregistered.clone(),
+        vaccine_name: String::from_str(&env, "Hepatitis B"),
+        cvx_code: String::from_str(&env, "CVX_43"),
+        lot_number: String::from_str(&env, "LOT_12345"),
+        manufacturer: String::from_str(&env, "SANOFI"),
+        administration_date: 1690000000,
+        expiration_date: 1790000000,
+        dose_number: 1,
+        route: Symbol::new(&env, "IM"),
+        site: Symbol::new(&env, "DELTOID"),
+    });
     assert!(res.is_err());
 }
 
 #[test]
-fn test_vaccine_series_and_due() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let contract_id = env.register(ImmunizationRegistry, ());
-    let client = ImmunizationRegistryClient::new(&env, &contract_id);
+fn test_record_adverse_event() {
+    let (env, client, registry, admin, regulator) = setup();
 
     let patient_id = Address::generate(&env);
     let provider_id = Address::generate(&env);
+    register_provider(&env, &registry, &admin, &provider_id);
+
+    let id = client.record_immunization(&VaccineRecord {
+        patient_id: patient_id.clone(),
+        provider_id: provider_id.clone(),
+        vaccine_name: String::from_str(&env, "Hepatitis B"),
+        cvx_code: String::from_str(&env, "CVX_43"),
+        lot_number: String::from_str(&env, "LOT_12345"),
+        manufacturer: String::from_str(&env, "SANOFI"),
+        administration_date: 1690000000,
+        expiration_date: 1790000000,
+        dose_number: 1,
+        route: Symbol::new(&env, "IM"),
+        site: Symbol::new(&env, "DELTOID"),
+    });
+
+    // Provider can report.
+    client.record_adverse_event(
+        &id,
+        &provider_id,
+        &String::from_str(&env, "Slight fever"),
+        &Symbol::new(&env, "MILD"),
+        &1690086400,
+    );
+
+    // Patient can report.
+    client.record_adverse_event(
+        &id,
+        &patient_id,
+        &String::from_str(&env, "Arm soreness"),
+        &Symbol::new(&env, "MILD"),
+        &1690086400,
+    );
+
+    // Regulator can report.
+    client.record_adverse_event(
+        &id,
+        &regulator,
+        &String::from_str(&env, "Regulatory follow-up"),
+        &Symbol::new(&env, "LOW"),
+        &1690086400,
+    );
+
+    // Arbitrary outsider is rejected.
+    let outsider = Address::generate(&env);
+    let res = client.try_record_adverse_event(
+        &id,
+        &outsider,
+        &String::from_str(&env, "Unauthorized"),
+        &Symbol::new(&env, "NONE"),
+        &1690086400,
+    );
+    assert!(res.is_err());
+
+    // Non-existent immunization ID is rejected.
+    let res2 = client.try_record_adverse_event(
+        &999,
+        &provider_id,
+        &String::from_str(&env, "NA"),
+        &Symbol::new(&env, "NONE"),
+        &1690086400,
+    );
+    assert!(res2.is_err());
+}
+
+#[test]
+fn test_vaccine_series_and_due() {
+    let (env, client, registry, admin, _regulator) = setup();
+
+    let patient_id = Address::generate(&env);
+    let provider_id = Address::generate(&env);
+    register_provider(&env, &registry, &admin, &provider_id);
 
     // Register a 3-dose series
     client.register_vaccine_series(
@@ -106,14 +191,14 @@ fn test_vaccine_series_and_due() {
         &String::from_str(&env, "Hepatitis B"),
         &String::from_str(&env, "CVX_43"),
         &3,
-        &BytesN::from_array(&env, &[0; 32]), // dummy hash
+        &BytesN::from_array(&env, &[0; 32]),
     );
 
-    // Initially, they are due for it
+    // Initially due.
     let due = client.check_due_vaccines(&patient_id, &patient_id, &1690000000);
     assert_eq!(due.len(), 1);
 
-    // Record one dose
+    // Record one dose.
     client.record_immunization(&VaccineRecord {
         patient_id: patient_id.clone(),
         provider_id: provider_id.clone(),
@@ -128,11 +213,11 @@ fn test_vaccine_series_and_due() {
         site: Symbol::new(&env, "DELTOID"),
     });
 
-    // Still due (need 3)
+    // Still due (need 3).
     let due2 = client.check_due_vaccines(&patient_id, &patient_id, &1695000000);
     assert_eq!(due2.len(), 1);
 
-    // Record two more doses
+    // Record two more doses.
     client.record_immunization(&VaccineRecord {
         patient_id: patient_id.clone(),
         provider_id: provider_id.clone(),
@@ -160,23 +245,20 @@ fn test_vaccine_series_and_due() {
         site: Symbol::new(&env, "DELTOID"),
     });
 
-    // Now they should NOT be due
+    // Now not due.
     let due3 = client.check_due_vaccines(&patient_id, &patient_id, &1700000000);
     assert_eq!(due3.len(), 0);
 }
 
 #[test]
 fn test_due_vaccines_matches_by_cvx_code_not_name() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let contract_id = env.register(ImmunizationRegistry, ());
-    let client = ImmunizationRegistryClient::new(&env, &contract_id);
+    let (env, client, registry, admin, _regulator) = setup();
 
     let patient_id = Address::generate(&env);
     let provider_id = Address::generate(&env);
+    register_provider(&env, &registry, &admin, &provider_id);
 
-    // Series is keyed by CVX code, not brand name.
+    // Series keyed by CVX code, not brand name.
     client.register_vaccine_series(
         &patient_id,
         &String::from_str(&env, "Hepatitis B Series"),
@@ -207,19 +289,13 @@ fn test_due_vaccines_matches_by_cvx_code_not_name() {
 
 #[test]
 fn test_get_patients_by_lot() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let contract_id = env.register(ImmunizationRegistry, ());
-    let client = ImmunizationRegistryClient::new(&env, &contract_id);
-
-    let regulator = Address::generate(&env);
-    client.initialize(&regulator);
+    let (env, client, registry, admin, regulator) = setup();
 
     let patient_a = Address::generate(&env);
     let patient_b = Address::generate(&env);
     let patient_c = Address::generate(&env);
     let provider_id = Address::generate(&env);
+    register_provider(&env, &registry, &admin, &provider_id);
 
     let recalled_lot = String::from_str(&env, "LOT_RECALL");
     let other_lot = String::from_str(&env, "LOT_OTHER");
@@ -260,7 +336,7 @@ fn test_get_patients_by_lot() {
     assert!(affected.contains(&patient_b));
     assert!(!affected.contains(&patient_c));
 
-    // A non-regulator caller is rejected.
+    // Non-regulator is rejected.
     let outsider = Address::generate(&env);
     let res = client.try_get_patients_by_lot(&recalled_lot, &outsider);
     assert!(res.is_err());

--- a/contracts/immunization-registry/src/types.rs
+++ b/contracts/immunization-registry/src/types.rs
@@ -10,6 +10,7 @@ pub enum DataKey {
     PatientVaccineSeries(Address), // List of VaccineSeries
     LotImmunizations(String),      // List of IDs (u64) administered from this lot
     Regulator,                     // Address authorized for public-health/recall queries
+    ProviderRegistry,              // Address of the provider-registry contract
 }
 
 #[contracterror]

--- a/contracts/nft-badges/src/lib.rs
+++ b/contracts/nft-badges/src/lib.rs
@@ -106,7 +106,7 @@ impl NftBadgesContract {
             if let Some(existing) = env.storage().persistent()
                 .get::<_, BadgeMetadata>(&DataKey::Badge(existing_id))
             {
-                if existing.badge_type == badge_type {
+                if existing.badge_type == badge_type && !existing.revoked {
                     return Err(Error::AlreadyMinted);
                 }
             }

--- a/contracts/nft-badges/src/test.rs
+++ b/contracts/nft-badges/src/test.rs
@@ -117,3 +117,18 @@ fn duplicate_mint_same_recipient_and_badge_type_is_rejected() {
         .unwrap();
     assert_eq!(err, Error::AlreadyMinted);
 }
+
+#[test]
+fn revoked_badge_allows_remint_of_same_type() {
+    let (env, client, admin) = setup();
+    let student = Address::generate(&env);
+    let id = client.mint(&admin, &student, &s(&env, "completion"), &s(&env, "A"), &s(&env, "u1"));
+
+    client.revoke(&admin, &id, &s(&env, "issued in error"));
+
+    // Re-mint of the same badge_type must succeed after revocation.
+    let id2 = client.mint(&admin, &student, &s(&env, "completion"), &s(&env, "A"), &s(&env, "u2"));
+    assert!(id2 > id);
+    let badge2 = client.get_badge(&id2);
+    assert!(!badge2.revoked);
+}

--- a/contracts/provider-registry/src/lib.rs
+++ b/contracts/provider-registry/src/lib.rs
@@ -202,6 +202,13 @@ impl ProviderRegistry {
         let mut results: Vec<BatchEntryStatus> = Vec::new(&env);
 
         for entry in entries.iter() {
+            if validate_nonzero_address(&entry.provider).is_err()
+                || validate_nonzero_address(&entry.issuer).is_err()
+            {
+                results.push_back(BatchEntryStatus::InvalidAddress);
+                continue;
+            }
+
             let key = DataKey::Provider(entry.provider.clone());
             if env.storage().persistent().has(&key) {
                 results.push_back(BatchEntryStatus::AlreadyExists);


### PR DESCRIPTION
## Summary

- **#825** `provider-registry`: `batch_register_providers` now calls `validate_nonzero_address` on `entry.provider` and `entry.issuer`, emitting `BatchEntryStatus::InvalidAddress` and skipping the entry on failure — matching the guard already in `register_provider`.
- **#822** `nft-badges`: the duplicate-type check in `mint` now skips revoked badges (`&& !existing.revoked`), unblocking re-issuance of a badge type after revocation. Adds regression test `revoked_badge_allows_remint_of_same_type`.
- **#823** `immunization-registry`: `record_immunization` stores the provider-registry address at `initialize`, cross-contract calls `is_provider` to verify the provider, and requires `patient_id.require_auth()` for patient consent before writing any record.
- **#824** `immunization-registry`: `record_adverse_event` now restricts reporters to the record's `provider_id`, `patient_id`, or the configured regulator; any other caller receives `NotAuthorized`.

## Test plan

- [ ] `cargo test -p provider-registry` — all 16 tests pass
- [ ] `cargo test -p immunization-registry` — all 6 tests pass (including new unregistered-provider rejection and outsider-reporter rejection tests)
- [ ] `cargo test -p nft-badges` — all 10 tests pass (including new `revoked_badge_allows_remint_of_same_type`)

closes #825
closes #822
closes #823
closes #824